### PR TITLE
Change deploy script to run manually and augment README

### DIFF
--- a/.github/workflows/init_deploy.yml
+++ b/.github/workflows/init_deploy.yml
@@ -1,9 +1,8 @@
-name: Deploy to Elastx
+name: Initial deploy to Elastx
 
 on:
-    push:
-        branches:
-            - main
+    workflow_dispatch:
+    - main
 
 jobs:
     deploy:

--- a/.github/workflows/init_deploy.yml
+++ b/.github/workflows/init_deploy.yml
@@ -2,7 +2,7 @@ name: Initial deploy to Elastx
 
 on:
     workflow_dispatch:
-    - main
+        - main
 
 jobs:
     deploy:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,43 @@ CREATE TABLE IF NOT EXISTS "todos" (
 
 For pushing subsequent updates, I also provided an `update.sh` script as an example.
 
+## nginx config on VPS
+
+This is the nginx configuration needed on the VPS
+Make sure that the certs are are the below location. They should have been created by deploy.sh
+
+```sh
+# /etc/nginx/sites-available/matkassen
+
+# Redirect HTTP traffic to HTTPS
+server {
+    listen 80;
+    server_name matkassen.org www.matkassen.org;
+    return 301 https://$host$request_uri;
+}
+
+# Serve HTTPS traffic
+server {
+    listen 443 ssl;
+    server_name matkassen.org www.matkassen.org;
+
+    ssl_certificate /etc/letsencrypt/live/matkassen.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/matkassen.org/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+```
+
 ## Developing Locally
 
 Make sure the database is up and running in the docker container (`docker-compose up -d db`), then run `bun dev`.


### PR DESCRIPTION
We don't want to perform the full deploy on each merge to main.

In the future we will try to use the update.sh script instead on merge to main