### PR TITLE
Use prod GitHub auth for any environment

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -2,7 +2,15 @@ import NextAuth from "next-auth";
 import GitHub from "next-auth/providers/github";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
-    providers: [GitHub],
+    providers: [
+        GitHub({
+            // Use the production URL as the redirect proxy (works for staging and localhost as well)
+            redirectProxyUrl:
+                process.env.NODE_ENV === "production"
+                    ? undefined
+                    : "https://matkassen.org/api/auth/callback/github",
+        }),
+    ],
     callbacks: {
         authorized: async ({ auth }) => {
             // Logged in users are authenticated, otherwise redirect to login page


### PR DESCRIPTION
Following the instruction at https://authjs.dev/getting-started/deployment\#securing-a-preview-deployment we can use the same GitHub OAuth app for prod as well as for staging and localhost and whatever we want.

We need to make sure the prod auth works, and it will handle all redirects regardless of environment.