### PR TITLE
Copy .env to container and fix update script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
             - "3000:3000"
         environment:
             - NODE_ENV=production
+        env_file:
+            - .env
         depends_on:
             - db
         networks:

--- a/update.sh
+++ b/update.sh
@@ -14,6 +14,9 @@ APP_DIR=~/$PROJECT_NAME
 if [ -d "$APP_DIR" ]; then
   echo "Pulling latest changes from the repository..."
   cd $APP_DIR
+  echo "Discarding any local changes..."
+  git reset --hard HEAD
+  git clean -fd
   git pull origin main
 else
   echo "App directory not found. Please run deploy.sh first."


### PR DESCRIPTION
The environment variables were missing in the docker container, so this is an attempt to copy them inside the docker container. Also, the update script would fail because of git mismatch in files - override with whats on origin.