### PR TITLE
Fix database access and make sure DB schemas are pushed on deploy

### DIFF
--- a/app/db/drizzle.ts
+++ b/app/db/drizzle.ts
@@ -4,11 +4,9 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-// Niklas: To access the DB when running locally (outside of the container), you
-// need to set the DATABASE_URL_EXTERNAL environment variable instead of DATABASE_URL.
-if (!process.env.DATABASE_URL_EXTERNAL) {
-    throw new Error("DATABASE_URL_EXTERNAL environment variable is not set");
+if (!process.env.DATABASE_URL) {
+    throw new Error("DATABASE_URL environment variable is not set");
 }
 
-export const client = postgres(process.env.DATABASE_URL_EXTERNAL);
+export const client = postgres(process.env.DATABASE_URL);
 export const db = drizzle(client);

--- a/deploy.sh
+++ b/deploy.sh
@@ -249,6 +249,10 @@ if ! sudo docker compose ps | grep "Up"; then
   exit 1
 fi
 
+# Wait for the database to be ready
+echo "Applying database schema changes..."
+sudo docker compose exec web bun run db:push
+
 # Cleanup old Docker images and containers
 sudo docker system prune -af
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -2,9 +2,8 @@ import type { Config } from "drizzle-kit";
 
 export default {
     schema: "./app/db/schema.ts",
-    out: "./app/db/migrations",
     dialect: "postgresql",
     dbCredentials: {
-        url: process.env.DATABASE_URL_EXTERNAL!,
+        url: process.env.DATABASE_URL!,
     },
 } satisfies Config;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "start": "next start",
         "lint": "next lint",
         "format-check": "prettier --check .",
-        "format": "prettier --write ."
+        "format": "prettier --write .",
+        "db:push": "npx drizzle-kit push"
     },
     "dependencies": {
         "@types/pg": "^8.11.11",

--- a/update.sh
+++ b/update.sh
@@ -47,5 +47,12 @@ if ! sudo docker compose ps | grep "Up"; then
   exit 1
 fi
 
+# Wait for the database to be ready
+echo "Applying database schema changes..."
+sudo bun run db:push
+
+# Cleanup old Docker images and containers
+sudo docker system prune -af
+
 # Output final message
 echo "Update complete. Your Next.js app has been updated with the latest changes."


### PR DESCRIPTION
- Use DATABASE_URL to access the db container from the web container
- Perform DB schema update on deploy (both initial deployment, and incremental continuous deployment)
- Update the README accordingly (and clean up)