### PR TITLE
Fix DB schema update on deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV HOSTNAME "0.0.0.0"
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
+COPY drizzle.config.ts ./
 
 EXPOSE 3000
 CMD ["bun", "run", "server.js"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ docker compose -f docker-compose.dev.yml logs
 Updating `schema.ts` followed by running `bun run db:push` inside the docker container will migrate the database directly without the need for migration `.sql` files (see https://orm.drizzle.team/docs/drizzle-kit-push).
 
 To trigger the update from outside the container run:
+
 ```sh
 sudo docker compose exec web bun run db:push
 ```
@@ -58,6 +59,7 @@ However, you might want to use the above command when devloping locally.
 ## Helpful Commands
 
 Note that sudo is needed when executing the commands on the VPS.
+
 - `sudo docker compose ps` – check status of Docker containers
 - `sudo docker compose logs web` – view Next.js output logs
 - `sudo systemctl restart nginx` - restart nginx

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ docker compose -f docker-compose.dev.yml logs
 Updating `schema.ts` followed by running `bun run db:push` inside the docker container will migrate the database directly without the need for migration `.sql` files (see https://orm.drizzle.team/docs/drizzle-kit-push).
 
 To trigger the update from outside the container run:
-
 ```sh
 sudo docker compose exec web bun run db:push
 ```
@@ -59,7 +58,6 @@ However, you might want to use the above command when devloping locally.
 ## Helpful Commands
 
 Note that sudo is needed when executing the commands on the VPS.
-
 - `sudo docker compose ps` – check status of Docker containers
 - `sudo docker compose logs web` – view Next.js output logs
 - `sudo systemctl restart nginx` - restart nginx

--- a/update.sh
+++ b/update.sh
@@ -49,7 +49,7 @@ fi
 
 # Wait for the database to be ready
 echo "Applying database schema changes..."
-sudo bun run db:push
+sudo docker compose exec web bun run db:push
 
 # Cleanup old Docker images and containers
 sudo docker system prune -af


### PR DESCRIPTION
- Changed from incorrect command to `sudo docker compose exec web bun run db:push` which will run inside the web container (Next.js app will communicate with the db container)
- `drizzle.config.ts` was not copied, and is needed for the `sudo docker compose exec web bun run db:push` command to work