### PR TITLE
Make sure node_modules exists so that db migration can be performed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,9 @@ ENV HOSTNAME "0.0.0.0"
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
+# The below are needed for drizzle to work (db migrations inside the container)
 COPY drizzle.config.ts ./
+COPY --from=deps /app/node_modules ./node_modules
 
 EXPOSE 3000
 CMD ["bun", "run", "server.js"]


### PR DESCRIPTION
Resolves this error:
Reading config file '/app/drizzle.config.ts'
Error please install required packages: 'drizzle-orm' error: script db:push exited with code 1
Database schema changes failed. Check logs with 'docker compose logs'.