### PR TITLE
Add two modes of local dev env and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+AUTH_GITHUB_ID="from auth.js setup"
+AUTH_GITHUB_SECRET="from auth.js setup"
+AUTH_SECRET="from auth.js setup"
+AUTH_TRUST_HOST=true
+AUTH_URL="http://localhost:3000/api/auth"
+
+GITHUB_ORG="vasteras-stadsmission"
+
+# Database configuration
+POSTGRES_USER="your_db_user"
+POSTGRES_PASSWORD="your_db_password"
+POSTGRES_DB="your_db_name"
+
+# !! CHOOSE ONE OF THE BELOW !!
+# Used when running in containers (dev:containers-only) and in production
+DATABASE_URL="postgres://your_db_user:your_db_password@db:5432/your_db_name"
+# Used when running locally (dev)
+DATABASE_URL="postgres://your_db_user:your_db_password@localhost:5432/your_db_name"

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -22,25 +22,20 @@ This repo contains GitHub actions which will automatically deploy your app to th
 
 Note, first-time deployment to a VPS is handled using GitHub action `./.github/workflows/init_deploy.yml`, which is triggered manually in GitHub.
 
-## Developing Locally with hot reloads
+## Developing locally
 
-When devloping locally you can use a similar setup as in the production environment. However, instead of using `./docker-compose.yml` which makes use of `./Dockerfile`, you will instead use the combo `./docker-compose.dev.yml` and `.Dockerfile.dev`.
+First you need to setup your environment:
+1. Copy the `.env.example` file to create your own `.env` file:
+   ```bash
+   cp .env.example .env
+   ```
+2. Update the values in the .env file accordingly.
 
-Here are some useful commands
+Now, you choose between our two primary development modes:
+1. `bun run dev`: Next.js is running locally and db in a container (faster dev experience)
+2. `bun run dev:containers-only`: A similar setup as in the production environment where both Next.js and db is running in (separate) containers.
 
-```sh
-# Start containers
-docker compose -f docker-compose.dev.yml up
-
-# Rebuild and start (delegate builds to bake for better performance)
-COMPOSE_BAKE=true docker compose -f docker-compose.dev.yml up --build
-
-# Stop containers
-docker compose -f docker-compose.dev.yml down
-
-# View logs
-docker compose -f docker-compose.dev.yml logs
-```
+Note that in neither of these two modes will you have nginx running, as in production.
 
 ## Handling Postgres DB
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repo contains GitHub actions which will automatically deploy your app to th
 
 Note, first-time deployment to a VPS is handled using GitHub action `./.github/workflows/init_deploy.yml`, which is triggered manually in GitHub.
 
-## Developing locally
+## Local Development Modes
 
 First you need to setup your environment:
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,15 @@ Note, first-time deployment to a VPS is handled using GitHub action `./.github/w
 ## Developing locally
 
 First you need to setup your environment:
+
 1. Copy the `.env.example` file to create your own `.env` file:
-   ```bash
-   cp .env.example .env
-   ```
+    ```bash
+    cp .env.example .env
+    ```
 2. Update the values in the .env file accordingly.
 
 Now, you choose between our two primary development modes:
+
 1. `bun run dev`: Next.js is running locally and db in a container (faster dev experience)
 2. `bun run dev:containers-only`: A similar setup as in the production environment where both Next.js and db is running in (separate) containers.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "dev": "next dev --turbopack",
+        "dev": "docker compose -f docker-compose.dev.yml up db && next dev --turbopack",
+        "dev:containers-only": "COMPOSE_BAKE=true docker compose -f docker-compose.dev.yml up --build",
         "build": "next build",
         "start": "next start",
         "lint": "next lint",


### PR DESCRIPTION
Explanation of these modes are in the README, but one is for having Next.js inside a container, and the other is to keep it as a local server.