### PR TITLE
Allow rescheduling using button on item in week view

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,6 @@
 
     "overrides": [
         {
-            // everything below <root>/__tests__/ … and *.test|spec.* files
             "files": ["**/__tests__/**/*.{js,ts,tsx}", "**/*.{test,spec}.{js,ts,tsx}"],
             "env": { "jest": true },
             "plugins": ["jest"],
@@ -11,9 +10,5 @@
             /* put per-test tweaks here, e.g.
            "rules": { "@typescript-eslint/no-unsafe-call": "off" } */
         }
-    ],
-
-    "rules": {
-        "react/no-unescaped-entities": "off"
-    }
+    ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,8 @@
 {
     "extends": ["next/core-web-vitals", "next/typescript"],
-
+    "rules": {
+        "react/no-unescaped-entities": "off"
+    },
     "overrides": [
         {
             "files": ["**/__tests__/**/*.{js,ts,tsx}", "**/*.{test,spec}.{js,ts,tsx}"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,18 @@
 {
     "extends": ["next/core-web-vitals", "next/typescript"],
+
+    "overrides": [
+        {
+            // everything below <root>/__tests__/ … and *.test|spec.* files
+            "files": ["**/__tests__/**/*.{js,ts,tsx}", "**/*.{test,spec}.{js,ts,tsx}"],
+            "env": { "jest": true },
+            "plugins": ["jest"],
+            "extends": ["plugin:jest/recommended"]
+            /* put per-test tweaks here, e.g.
+           "rules": { "@typescript-eslint/no-unsafe-call": "off" } */
+        }
+    ],
+
     "rules": {
         "react/no-unescaped-entities": "off"
     }

--- a/.github/workflows/lint_and_prettier.yml
+++ b/.github/workflows/lint_and_prettier.yml
@@ -23,5 +23,7 @@ jobs:
               run: bun install
             - name: Run linter
               run: bun run lint
+            - name: Check TypeScript types
+              run: bun run typecheck
             - name: Check formatting
               run: bun run format-check

--- a/__tests__/app/schedule/components/TimeSlotCell.test.tsx
+++ b/__tests__/app/schedule/components/TimeSlotCell.test.tsx
@@ -170,6 +170,24 @@ describe("TimeSlotCell Component", () => {
         // Mock the Date constructor
         global.Date = class extends RealDate {
             constructor(...args: any[]) {
+                if (args.length === 0) {
+                    super();
+                } else if (args.length === 1) {
+                    super(args[0]);
+                } else if (args.length === 2) {
+                    super(args[0], args[1]);
+                } else if (args.length === 3) {
+                    super(args[0], args[1], args[2]);
+                } else if (args.length === 4) {
+                    super(args[0], args[1], args[2], args[3]);
+                } else if (args.length === 5) {
+                    super(args[0], args[1], args[2], args[3], args[4]);
+                } else if (args.length === 6) {
+                    super(args[0], args[1], args[2], args[3], args[4], args[5]);
+                } else if (args.length === 7) {
+                    super(args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
+                }
+
                 // When called with specific dates we're testing, return fixed dates
                 if (args.length === 1 && typeof args[0] === "string") {
                     return new RealDate(args[0]);
@@ -187,7 +205,7 @@ describe("TimeSlotCell Component", () => {
                     );
                 }
                 // For any other case, pass through to the real Date
-                return new RealDate(...args);
+                // Note: this return is not needed since super() will handle it
             }
 
             // Make sure static methods also work

--- a/__tests__/app/schedule/components/TimeSlotCell.test.tsx
+++ b/__tests__/app/schedule/components/TimeSlotCell.test.tsx
@@ -166,36 +166,43 @@ describe("TimeSlotCell Component", () => {
     beforeEach(() => {
         // Store the real Date constructor
         RealDate = global.Date;
-        
+
         // Mock the Date constructor
         global.Date = class extends RealDate {
             constructor(...args: any[]) {
                 // When called with specific dates we're testing, return fixed dates
-                if (args.length === 1 && typeof args[0] === 'string') {
+                if (args.length === 1 && typeof args[0] === "string") {
                     return new RealDate(args[0]);
                 }
                 // When called with year, month, day format
                 if (args.length >= 3) {
                     const [year, month, day, ...rest] = args;
-                    return new RealDate(new RealDate(year, month, day, ...(rest as [number, number, number])).toISOString());
+                    return new RealDate(
+                        new RealDate(
+                            year,
+                            month,
+                            day,
+                            ...(rest as [number, number, number]),
+                        ).toISOString(),
+                    );
                 }
                 // For any other case, pass through to the real Date
                 return new RealDate(...args);
             }
-            
+
             // Make sure static methods also work
             static now() {
                 return RealDate.now();
             }
         } as DateConstructor;
-        
+
         mockIsOver = false;
         mockIsPastTimeSlot = false;
         mockSetNodeRef = mock("setNodeRef");
         lastDroppableId = "";
         lastDisabledValue = false;
     });
-    
+
     afterEach(() => {
         // Restore the original Date
         global.Date = RealDate;

--- a/__tests__/app/schedule/components/WeeklyScheduleGrid.test.tsx
+++ b/__tests__/app/schedule/components/WeeklyScheduleGrid.test.tsx
@@ -380,6 +380,8 @@ mock("@/app/schedule/actions", () => ({
 }));
 
 describe("WeeklyScheduleGrid Component", () => {
+    let RealDate: DateConstructor;
+    
     const mockWeekDates = [
         new Date("2025-04-14"), // Monday
         new Date("2025-04-15"), // Tuesday
@@ -418,6 +420,31 @@ describe("WeeklyScheduleGrid Component", () => {
     ];
 
     beforeEach(() => {
+        // Store the real Date constructor
+        RealDate = global.Date;
+        
+        // Mock the Date constructor
+        global.Date = class extends RealDate {
+            constructor(...args: any[]) {
+                // When called with specific dates we're testing, return fixed dates
+                if (args.length === 1 && typeof args[0] === 'string') {
+                    return new RealDate(args[0]);
+                }
+                // When called with year, month, day format
+                if (args.length >= 3) {
+                    const [year, month, day, ...rest] = args;
+                    return new RealDate(new RealDate(year, month, day, ...(rest as [number, number, number])).toISOString());
+                }
+                // For any other case, pass through to the real Date
+                return new RealDate(...args);
+            }
+            
+            // Make sure static methods also work
+            static now() {
+                return RealDate.now();
+            }
+        } as DateConstructor;
+        
         mockUpdateFoodParcelScheduleFn.mockReset();
         mockUpdateFoodParcelScheduleFn.mockResolvedValue({ success: true });
         mockShowNotificationCalls = [];
@@ -427,6 +454,8 @@ describe("WeeklyScheduleGrid Component", () => {
     });
 
     afterEach(() => {
+        // Restore the original Date
+        global.Date = RealDate;
         mockDragEndHandler = null;
     });
 

--- a/__tests__/app/schedule/components/WeeklyScheduleGrid.test.tsx
+++ b/__tests__/app/schedule/components/WeeklyScheduleGrid.test.tsx
@@ -426,6 +426,24 @@ describe("WeeklyScheduleGrid Component", () => {
         // Mock the Date constructor
         global.Date = class extends RealDate {
             constructor(...args: any[]) {
+                if (args.length === 0) {
+                    super();
+                } else if (args.length === 1) {
+                    super(args[0]);
+                } else if (args.length === 2) {
+                    super(args[0], args[1]);
+                } else if (args.length === 3) {
+                    super(args[0], args[1], args[2]);
+                } else if (args.length === 4) {
+                    super(args[0], args[1], args[2], args[3]);
+                } else if (args.length === 5) {
+                    super(args[0], args[1], args[2], args[3], args[4]);
+                } else if (args.length === 6) {
+                    super(args[0], args[1], args[2], args[3], args[4], args[5]);
+                } else if (args.length === 7) {
+                    super(args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
+                }
+
                 // When called with specific dates we're testing, return fixed dates
                 if (args.length === 1 && typeof args[0] === "string") {
                     return new RealDate(args[0]);
@@ -443,7 +461,7 @@ describe("WeeklyScheduleGrid Component", () => {
                     );
                 }
                 // For any other case, pass through to the real Date
-                return new RealDate(...args);
+                // Note: this return is not needed since super() will handle it
             }
 
             // Make sure static methods also work
@@ -613,11 +631,42 @@ describe("WeeklyScheduleGrid Component", () => {
             constructor(...args: any[]) {
                 if (args.length === 0) {
                     super();
-                    return mockDate;
+                } else if (args.length === 1) {
+                    super(args[0]);
+                } else if (args.length === 2) {
+                    super(args[0], args[1]);
+                } else if (args.length === 3) {
+                    super(args[0], args[1], args[2]);
+                } else if (args.length === 4) {
+                    super(args[0], args[1], args[2], args[3]);
+                } else if (args.length === 5) {
+                    super(args[0], args[1], args[2], args[3], args[4]);
+                } else if (args.length === 6) {
+                    super(args[0], args[1], args[2], args[3], args[4], args[5]);
+                } else if (args.length === 7) {
+                    super(args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
                 }
-                // Call super with individual arguments instead of using spread
-                super(args.length > 0 ? args[0] : undefined);
+
+                // When called with specific dates we're testing, return fixed dates
+                if (args.length === 1 && typeof args[0] === "string") {
+                    return new RealDate(args[0]);
+                }
+                // When called with year, month, day format
+                if (args.length >= 3) {
+                    const [year, month, day, ...rest] = args;
+                    return new RealDate(
+                        new RealDate(
+                            year,
+                            month,
+                            day,
+                            ...(rest as [number, number, number]),
+                        ).toISOString(),
+                    );
+                }
+                // For any other case, pass through to the real Date
+                // Note: this return is not needed since super() will handle it
             }
+
             static now() {
                 return mockDate.getTime();
             }
@@ -673,10 +722,42 @@ describe("WeeklyScheduleGrid Component", () => {
                 constructor(...args: any[]) {
                     if (args.length === 0) {
                         super();
-                        return mockDate;
+                    } else if (args.length === 1) {
+                        super(args[0]);
+                    } else if (args.length === 2) {
+                        super(args[0], args[1]);
+                    } else if (args.length === 3) {
+                        super(args[0], args[1], args[2]);
+                    } else if (args.length === 4) {
+                        super(args[0], args[1], args[2], args[3]);
+                    } else if (args.length === 5) {
+                        super(args[0], args[1], args[2], args[3], args[4]);
+                    } else if (args.length === 6) {
+                        super(args[0], args[1], args[2], args[3], args[4], args[5]);
+                    } else if (args.length === 7) {
+                        super(args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
                     }
-                    super(args.length > 0 ? args[0] : undefined);
+
+                    // When called with specific dates we're testing, return fixed dates
+                    if (args.length === 1 && typeof args[0] === "string") {
+                        return new RealDate(args[0]);
+                    }
+                    // When called with year, month, day format
+                    if (args.length >= 3) {
+                        const [year, month, day, ...rest] = args;
+                        return new RealDate(
+                            new RealDate(
+                                year,
+                                month,
+                                day,
+                                ...(rest as [number, number, number]),
+                            ).toISOString(),
+                        );
+                    }
+                    // For any other case, pass through to the real Date
+                    // Note: this return is not needed since super() will handle it
                 }
+
                 static now() {
                     return mockDate.getTime();
                 }

--- a/__tests__/app/schedule/components/WeeklyScheduleGrid.test.tsx
+++ b/__tests__/app/schedule/components/WeeklyScheduleGrid.test.tsx
@@ -381,7 +381,7 @@ mock("@/app/schedule/actions", () => ({
 
 describe("WeeklyScheduleGrid Component", () => {
     let RealDate: DateConstructor;
-    
+
     const mockWeekDates = [
         new Date("2025-04-14"), // Monday
         new Date("2025-04-15"), // Tuesday
@@ -422,29 +422,36 @@ describe("WeeklyScheduleGrid Component", () => {
     beforeEach(() => {
         // Store the real Date constructor
         RealDate = global.Date;
-        
+
         // Mock the Date constructor
         global.Date = class extends RealDate {
             constructor(...args: any[]) {
                 // When called with specific dates we're testing, return fixed dates
-                if (args.length === 1 && typeof args[0] === 'string') {
+                if (args.length === 1 && typeof args[0] === "string") {
                     return new RealDate(args[0]);
                 }
                 // When called with year, month, day format
                 if (args.length >= 3) {
                     const [year, month, day, ...rest] = args;
-                    return new RealDate(new RealDate(year, month, day, ...(rest as [number, number, number])).toISOString());
+                    return new RealDate(
+                        new RealDate(
+                            year,
+                            month,
+                            day,
+                            ...(rest as [number, number, number]),
+                        ).toISOString(),
+                    );
                 }
                 // For any other case, pass through to the real Date
                 return new RealDate(...args);
             }
-            
+
             // Make sure static methods also work
             static now() {
                 return RealDate.now();
             }
         } as DateConstructor;
-        
+
         mockUpdateFoodParcelScheduleFn.mockReset();
         mockUpdateFoodParcelScheduleFn.mockResolvedValue({ success: true });
         mockShowNotificationCalls = [];

--- a/__tests__/app/schedule/utils/date-utils.test.ts
+++ b/__tests__/app/schedule/utils/date-utils.test.ts
@@ -49,34 +49,41 @@ mock("date-fns", () => ({
 
 describe("Schedule Date Utilities", () => {
     let RealDate: DateConstructor;
-    
+
     beforeEach(() => {
         // Store the real Date constructor
         RealDate = global.Date;
-        
+
         // Mock the Date constructor
         global.Date = class extends RealDate {
             constructor(...args: any[]) {
                 // When called with specific dates we're testing, return fixed dates
-                if (args.length === 1 && typeof args[0] === 'string') {
+                if (args.length === 1 && typeof args[0] === "string") {
                     return new RealDate(args[0]);
                 }
                 // When called with year, month, day format
                 if (args.length >= 3) {
                     const [year, month, day, ...rest] = args;
-                    return new RealDate(new RealDate(year, month, day, ...(rest as [number, number, number])).toISOString());
+                    return new RealDate(
+                        new RealDate(
+                            year,
+                            month,
+                            day,
+                            ...(rest as [number, number, number]),
+                        ).toISOString(),
+                    );
                 }
                 // For any other case, pass through to the real Date
                 return new RealDate(...args);
             }
-            
+
             // Make sure static methods also work
             static now() {
                 return RealDate.now();
             }
         } as DateConstructor;
     });
-    
+
     afterEach(() => {
         // Restore the original Date
         global.Date = RealDate;

--- a/__tests__/app/schedule/utils/date-utils.test.ts
+++ b/__tests__/app/schedule/utils/date-utils.test.ts
@@ -3,21 +3,21 @@ import { getISOWeekNumber, getWeekDates } from "@/app/utils/date-utils";
 
 // Since we're using the actual functions, we need to provide stubs for the dependencies
 mock("date-fns-tz", () => ({
-    toZonedTime: date => date,
-    fromZonedTime: date => date,
-    formatInTimeZone: (date, tz, format) => date.toISOString(),
+    toZonedTime: (date: Date | number | string) => date,
+    fromZonedTime: (date: Date | number | string) => date,
+    formatInTimeZone: (date: Date | number | string, tz: string, format: string) => date.toString(),
     getTimezoneOffset: () => 0,
 }));
 
 mock("date-fns", () => ({
-    getISOWeek: date => {
+    getISOWeek: (date: Date) => {
         const dateStr = date.toISOString().split("T")[0];
         if (dateStr === "2025-01-15") return 3;
         if (dateStr === "2024-12-31") return 1;
         if (dateStr === "2025-07-15") return 29;
         return 1;
     },
-    startOfWeek: (date, options) => {
+    startOfWeek: (date: Date, options?: { weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6 }) => {
         const dateStr = date.toISOString().split("T")[0];
 
         if (dateStr === "2025-04-16") return new Date("2025-04-13T00:00:00.000Z");
@@ -28,7 +28,7 @@ mock("date-fns", () => ({
 
         return new Date(date);
     },
-    endOfWeek: (date, options) => {
+    endOfWeek: (date: Date, options?: { weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6 }) => {
         const dateStr = date.toISOString().split("T")[0];
 
         if (dateStr === "2025-04-16") return new Date("2025-04-19T23:59:59.999Z");
@@ -39,8 +39,8 @@ mock("date-fns", () => ({
 
         return new Date(date);
     },
-    startOfDay: date => date,
-    endOfDay: date => date,
+    startOfDay: (date: Date) => date,
+    endOfDay: (date: Date) => date,
     format: () => "",
     parseISO: () => new Date(),
     formatISO: () => "",
@@ -57,6 +57,24 @@ describe("Schedule Date Utilities", () => {
         // Mock the Date constructor
         global.Date = class extends RealDate {
             constructor(...args: any[]) {
+                if (args.length === 0) {
+                    super();
+                } else if (args.length === 1) {
+                    super(args[0]);
+                } else if (args.length === 2) {
+                    super(args[0], args[1]);
+                } else if (args.length === 3) {
+                    super(args[0], args[1], args[2]);
+                } else if (args.length === 4) {
+                    super(args[0], args[1], args[2], args[3]);
+                } else if (args.length === 5) {
+                    super(args[0], args[1], args[2], args[3], args[4]);
+                } else if (args.length === 6) {
+                    super(args[0], args[1], args[2], args[3], args[4], args[5]);
+                } else if (args.length === 7) {
+                    super(args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
+                }
+
                 // When called with specific dates we're testing, return fixed dates
                 if (args.length === 1 && typeof args[0] === "string") {
                     return new RealDate(args[0]);
@@ -66,22 +84,22 @@ describe("Schedule Date Utilities", () => {
                     const [year, month, day, ...rest] = args;
                     return new RealDate(
                         new RealDate(
-                            year,
-                            month,
-                            day,
+                            year as number,
+                            month as number,
+                            day as number,
                             ...(rest as [number, number, number]),
                         ).toISOString(),
                     );
                 }
                 // For any other case, pass through to the real Date
-                return new RealDate(...args);
+                // Note: this return is not needed since super() will handle it
             }
 
             // Make sure static methods also work
             static now() {
                 return RealDate.now();
             }
-        } as DateConstructor;
+        } as unknown as DateConstructor;
     });
 
     afterEach(() => {

--- a/__tests__/app/schedule/utils/schedule-utils.test.ts
+++ b/__tests__/app/schedule/utils/schedule-utils.test.ts
@@ -36,34 +36,41 @@ function getTimeslotCountsImpl(parcels: Array<{ pickupEarliestTime: Date }>) {
 // Tests for schedule utility functions that don't involve React components
 describe("Schedule Utilities", () => {
     let RealDate: DateConstructor;
-    
+
     beforeEach(() => {
         // Store the real Date constructor
         RealDate = global.Date;
-        
+
         // Mock the Date constructor
         global.Date = class extends RealDate {
             constructor(...args: any[]) {
                 // When called with specific dates we're testing, return fixed dates
-                if (args.length === 1 && typeof args[0] === 'string') {
+                if (args.length === 1 && typeof args[0] === "string") {
                     return new RealDate(args[0]);
                 }
                 // When called with year, month, day format
                 if (args.length >= 3) {
                     const [year, month, day, ...rest] = args;
-                    return new RealDate(new RealDate(year, month, day, ...(rest as [number, number, number])).toISOString());
+                    return new RealDate(
+                        new RealDate(
+                            year,
+                            month,
+                            day,
+                            ...(rest as [number, number, number]),
+                        ).toISOString(),
+                    );
                 }
                 // For any other case, pass through to the real Date
                 return new RealDate(...args);
             }
-            
+
             // Make sure static methods also work
             static now() {
                 return RealDate.now();
             }
         } as DateConstructor;
     });
-    
+
     afterEach(() => {
         // Restore the original Date
         global.Date = RealDate;

--- a/__tests__/app/schedule/utils/schedule-utils.test.ts
+++ b/__tests__/app/schedule/utils/schedule-utils.test.ts
@@ -44,6 +44,24 @@ describe("Schedule Utilities", () => {
         // Mock the Date constructor
         global.Date = class extends RealDate {
             constructor(...args: any[]) {
+                if (args.length === 0) {
+                    super();
+                } else if (args.length === 1) {
+                    super(args[0]);
+                } else if (args.length === 2) {
+                    super(args[0], args[1]);
+                } else if (args.length === 3) {
+                    super(args[0], args[1], args[2]);
+                } else if (args.length === 4) {
+                    super(args[0], args[1], args[2], args[3]);
+                } else if (args.length === 5) {
+                    super(args[0], args[1], args[2], args[3], args[4]);
+                } else if (args.length === 6) {
+                    super(args[0], args[1], args[2], args[3], args[4], args[5]);
+                } else if (args.length === 7) {
+                    super(args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
+                }
+
                 // When called with specific dates we're testing, return fixed dates
                 if (args.length === 1 && typeof args[0] === "string") {
                     return new RealDate(args[0]);
@@ -61,7 +79,7 @@ describe("Schedule Utilities", () => {
                     );
                 }
                 // For any other case, pass through to the real Date
-                return new RealDate(...args);
+                // Note: this return is not needed since super() will handle it
             }
 
             // Make sure static methods also work

--- a/app/schedule/components/PickupCard.module.css
+++ b/app/schedule/components/PickupCard.module.css
@@ -1,4 +1,4 @@
 .pickup-card-compact:hover .reschedule-button,
 .pickup-card:hover .reschedule-button {
-  opacity: 1 !important;
+    opacity: 1 !important;
 }

--- a/app/schedule/components/PickupCard.module.css
+++ b/app/schedule/components/PickupCard.module.css
@@ -1,0 +1,4 @@
+.pickup-card-compact:hover .reschedule-button,
+.pickup-card:hover .reschedule-button {
+  opacity: 1 !important;
+}

--- a/app/schedule/components/PickupCard.tsx
+++ b/app/schedule/components/PickupCard.tsx
@@ -1,16 +1,23 @@
 "use client";
 
-import { Paper, Text, Tooltip } from "@mantine/core";
+import { Paper, Text, Tooltip, ActionIcon } from "@mantine/core";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { FoodParcel } from "@/app/schedule/actions";
+import { IconCalendarTime } from "@tabler/icons-react";
+import styles from "./PickupCard.module.css"; // Import the CSS module
 
 interface PickupCardProps {
     foodParcel: FoodParcel;
     isCompact?: boolean;
+    onReschedule?: (foodParcel: FoodParcel) => void;
 }
 
-export default function PickupCard({ foodParcel, isCompact = false }: PickupCardProps) {
+export default function PickupCard({
+    foodParcel,
+    isCompact = false,
+    onReschedule,
+}: PickupCardProps) {
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
         id: foodParcel.id,
         data: {
@@ -42,6 +49,17 @@ export default function PickupCard({ foodParcel, isCompact = false }: PickupCard
         });
     };
 
+    // Handle click to open reschedule modal
+    const handleRescheduleClick = (e: React.MouseEvent) => {
+        // Stop the click from triggering the parent's drag events
+        e.stopPropagation();
+
+        // Call the parent's onReschedule function with the current food parcel
+        if (onReschedule) {
+            onReschedule(foodParcel);
+        }
+    };
+
     const tooltipContent = (
         <div>
             <Text fw={600}>{foodParcel.householdName}</Text>
@@ -62,6 +80,7 @@ export default function PickupCard({ foodParcel, isCompact = false }: PickupCard
                         ...style,
                         "cursor": "grab",
                         "&:hover": { backgroundColor: "var(--mantine-color-blue-0)" },
+                        "position": "relative",
                     }}
                     {...attributes}
                     {...listeners}
@@ -71,11 +90,33 @@ export default function PickupCard({ foodParcel, isCompact = false }: PickupCard
                     withBorder
                     bg="gray.0"
                     shadow="xs"
-                    className="pickup-card-compact"
+                    className={styles["pickup-card-compact"]}
                 >
                     <Text size="xs" truncate fw={500}>
                         {foodParcel.householdName}
                     </Text>
+
+                    {/* Add reschedule button */}
+                    {onReschedule && (
+                        <ActionIcon
+                            size="xs"
+                            variant="subtle"
+                            color="blue"
+                            onClick={handleRescheduleClick}
+                            style={{
+                                position: "absolute",
+                                top: "50%",
+                                right: "4px",
+                                transform: "translateY(-50%)",
+                                opacity: 0, // Hidden by default
+                                transition: "opacity 0.2s",
+                            }}
+                            className={styles["reschedule-button"]}
+                            title="Schemalägg utanför vecka"
+                        >
+                            <IconCalendarTime size="0.8rem" />
+                        </ActionIcon>
+                    )}
                 </Paper>
             </Tooltip>
         );
@@ -91,6 +132,7 @@ export default function PickupCard({ foodParcel, isCompact = false }: PickupCard
                     display: "flex",
                     flexDirection: "column",
                     gap: "4px",
+                    position: "relative",
                 }}
                 {...attributes}
                 {...listeners}
@@ -99,8 +141,7 @@ export default function PickupCard({ foodParcel, isCompact = false }: PickupCard
                 withBorder
                 bg="white"
                 shadow="xs"
-                className="pickup-card"
-                onClick={() => {}} // Add hover style with CSS instead
+                className={styles["pickup-card"]}
             >
                 <div
                     style={{
@@ -126,6 +167,27 @@ export default function PickupCard({ foodParcel, isCompact = false }: PickupCard
                 <Text size="xs" c="dimmed">
                     {formatTime(foodParcel.pickupEarliestTime)}
                 </Text>
+
+                {/* Add reschedule button */}
+                {onReschedule && (
+                    <ActionIcon
+                        size="xs"
+                        variant="subtle"
+                        color="blue"
+                        onClick={handleRescheduleClick}
+                        style={{
+                            position: "absolute",
+                            top: "4px",
+                            right: "4px",
+                            opacity: 0, // Hidden by default
+                            transition: "opacity 0.2s",
+                        }}
+                        className={styles["reschedule-button"]}
+                        title="Schemalägg utanför vecka"
+                    >
+                        <IconCalendarTime size="0.8rem" />
+                    </ActionIcon>
+                )}
             </Paper>
         </Tooltip>
     );

--- a/app/schedule/components/ReschedulePickupModal.tsx
+++ b/app/schedule/components/ReschedulePickupModal.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Modal, Group, Button, Text, Box, Paper } from "@mantine/core";
+import { DatePicker, TimeInput } from "@mantine/dates";
+import { IconClock, IconCheck, IconArrowBackUp } from "@tabler/icons-react";
+import { showNotification } from "@mantine/notifications";
+import { FoodParcel, updateFoodParcelSchedule } from "@/app/schedule/actions";
+import { isPastTimeSlot, formatStockholmDate } from "@/app/utils/date-utils";
+
+interface ReschedulePickupModalProps {
+    opened: boolean;
+    onClose: () => void;
+    foodParcel: FoodParcel | null;
+    onRescheduled: () => void;
+}
+
+export default function ReschedulePickupModal({
+    opened,
+    onClose,
+    foodParcel,
+    onRescheduled,
+}: ReschedulePickupModalProps) {
+    const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+    const [earliestTime, setEarliestTime] = useState("12:00");
+    const [latestTime, setLatestTime] = useState("12:30");
+    const [timeError, setTimeError] = useState<string | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    // Track if any changes have been made
+    const [hasChanges, setHasChanges] = useState(false);
+
+    // Initialize with the food parcel's current date and times when opened
+    useEffect(() => {
+        if (opened && foodParcel) {
+            setSelectedDate(new Date(foodParcel.pickupDate));
+            setEarliestTime(formatTime(foodParcel.pickupEarliestTime));
+            setLatestTime(formatTime(foodParcel.pickupLatestTime));
+            setTimeError(null);
+            setHasChanges(false);
+        }
+    }, [opened, foodParcel]);
+
+    // Check if date or time has changed
+    useEffect(() => {
+        if (!foodParcel || !selectedDate) {
+            setHasChanges(false);
+            return;
+        }
+
+        const originalDate = new Date(foodParcel.pickupDate);
+        const originalDateStr = formatDateForComparison(originalDate);
+        const selectedDateStr = formatDateForComparison(selectedDate);
+
+        const originalEarliestTime = formatTime(foodParcel.pickupEarliestTime);
+        const originalLatestTime = formatTime(foodParcel.pickupLatestTime);
+
+        // Check if anything has changed
+        const dateChanged = originalDateStr !== selectedDateStr;
+        const timeChanged =
+            originalEarliestTime !== earliestTime || originalLatestTime !== latestTime;
+
+        setHasChanges(dateChanged || timeChanged);
+    }, [selectedDate, earliestTime, latestTime, foodParcel]);
+
+    // Format date for comparison (YYYY-MM-DD)
+    const formatDateForComparison = (date: Date): string => {
+        return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+    };
+
+    // Format time to HH:MM format
+    const formatTime = (date: Date): string => {
+        return date.toLocaleTimeString("sv-SE", {
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+        });
+    };
+
+    // Parse time string and create a Date object
+    const parseTimeString = (timeStr: string, baseDate: Date): Date => {
+        let hours = 0;
+        let minutes = 0;
+
+        if (!timeStr) {
+            return new Date(baseDate);
+        }
+
+        const parts = timeStr.split(":");
+        if (parts.length === 2) {
+            hours = parseInt(parts[0], 10) || 0;
+            minutes = parseInt(parts[1], 10) || 0;
+        } else if (timeStr.length === 1 || timeStr.length === 2) {
+            hours = parseInt(timeStr, 10) || 0;
+            minutes = 0;
+        } else if (timeStr.length === 3) {
+            hours = parseInt(timeStr.substring(0, 1), 10) || 0;
+            minutes = parseInt(timeStr.substring(1), 10) || 0;
+        } else if (timeStr.length === 4) {
+            hours = parseInt(timeStr.substring(0, 2), 10) || 0;
+            minutes = parseInt(timeStr.substring(2), 10) || 0;
+        }
+
+        hours = Math.min(Math.max(hours, 0), 23);
+        minutes = Math.min(Math.max(minutes, 0), 59);
+
+        const newDate = new Date(baseDate);
+        newDate.setHours(hours, minutes, 0, 0);
+        return newDate;
+    };
+
+    // Format date for display
+    const formatDate = (date: Date) => {
+        return formatStockholmDate(date, "d MMM yyyy");
+    };
+
+    // Validate the times
+    const validateTimes = (): boolean => {
+        if (!selectedDate) {
+            setTimeError("Du måste välja ett datum");
+            return false;
+        }
+
+        const earliestParts = earliestTime.split(":").map(part => parseInt(part, 10));
+        const latestParts = latestTime.split(":").map(part => parseInt(part, 10));
+
+        const earliestDate = new Date(selectedDate);
+        earliestDate.setHours(earliestParts[0] || 0, earliestParts[1] || 0, 0, 0);
+
+        const latestDate = new Date(selectedDate);
+        latestDate.setHours(latestParts[0] || 0, latestParts[1] || 0, 0, 0);
+
+        if (earliestDate >= latestDate) {
+            setTimeError("Tidigast tid måste vara före senast tid");
+            return false;
+        }
+
+        // Check if time slot is in the past
+        if (isPastTimeSlot(selectedDate, earliestTime)) {
+            setTimeError("Det går inte att boka matstöd i det förflutna");
+            return false;
+        }
+
+        setTimeError(null);
+        return true;
+    };
+
+    // Handle confirmation of rescheduling
+    const handleConfirmReschedule = async () => {
+        if (!foodParcel || !selectedDate) return;
+
+        if (!validateTimes()) {
+            return;
+        }
+
+        try {
+            setIsSubmitting(true);
+
+            const earliestParts = earliestTime.split(":").map(part => parseInt(part, 10));
+            const latestParts = latestTime.split(":").map(part => parseInt(part, 10));
+
+            const startDateTime = new Date(selectedDate);
+            startDateTime.setHours(earliestParts[0] || 0, earliestParts[1] || 0, 0, 0);
+
+            const endDateTime = new Date(selectedDate);
+            endDateTime.setHours(latestParts[0] || 0, latestParts[1] || 0, 0, 0);
+
+            const result = await updateFoodParcelSchedule(foodParcel.id, {
+                date: selectedDate,
+                startTime: startDateTime,
+                endTime: endDateTime,
+            });
+
+            if (result.success) {
+                showNotification({
+                    title: "Schemaläggning uppdaterad",
+                    message: `${foodParcel.householdName} har schemalagts på ny tid.`,
+                    color: "green",
+                });
+                onRescheduled();
+                onClose();
+            } else {
+                showNotification({
+                    title: "Fel vid schemaläggning",
+                    message: result.error || "Ett oväntat fel inträffade.",
+                    color: "red",
+                });
+            }
+        } catch (error) {
+            console.error("Error rescheduling pickup:", error);
+            showNotification({
+                title: "Fel vid schemaläggning",
+                message: "Ett oväntat fel inträffade.",
+                color: "red",
+            });
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    if (!foodParcel) {
+        return null;
+    }
+
+    return (
+        <Modal
+            opened={opened}
+            onClose={onClose}
+            title={`Schemalägg matstöd för ${foodParcel.householdName}`}
+            centered
+            size="md"
+        >
+            <Box p="md">
+                <Paper withBorder p="md" radius="md" mb="md">
+                    <Group justify="space-between" mb="xs">
+                        <Text fw={500}>Från:</Text>
+                        <Text>
+                            {formatDate(foodParcel.pickupDate)},{" "}
+                            {formatTime(foodParcel.pickupEarliestTime)} -{" "}
+                            {formatTime(foodParcel.pickupLatestTime)}
+                        </Text>
+                    </Group>
+                </Paper>
+
+                <Paper withBorder p="md" radius="md" mb="md">
+                    <Group mb="md" align="flex-start">
+                        <Text fw={500} style={{ width: "60px" }}>
+                            Till:
+                        </Text>
+                        <Box style={{ flex: 1 }}>
+                            <DatePicker
+                                value={selectedDate}
+                                onChange={setSelectedDate}
+                                minDate={new Date()}
+                                firstDayOfWeek={1}
+                            />
+                        </Box>
+                    </Group>
+
+                    {timeError && (
+                        <Text size="sm" c="red" mb="md">
+                            {timeError}
+                        </Text>
+                    )}
+
+                    <Group align="flex-start" mb="md">
+                        <Text fw={500} style={{ width: "60px" }}>
+                            &nbsp;
+                        </Text>
+                        <Group grow style={{ flex: 1 }}>
+                            <Box>
+                                <Text fw={500} size="sm" mb={5}>
+                                    Tidigast hämttid
+                                </Text>
+                                <TimeInput
+                                    value={earliestTime}
+                                    onChange={event => setEarliestTime(event.currentTarget.value)}
+                                    leftSection={<IconClock size="1rem" />}
+                                    error={timeError ? " " : ""}
+                                />
+                            </Box>
+                            <Box>
+                                <Text fw={500} size="sm" mb={5}>
+                                    Senast hämttid
+                                </Text>
+                                <TimeInput
+                                    value={latestTime}
+                                    onChange={event => setLatestTime(event.currentTarget.value)}
+                                    leftSection={<IconClock size="1rem" />}
+                                    error={timeError ? " " : ""}
+                                />
+                            </Box>
+                        </Group>
+                    </Group>
+                </Paper>
+
+                <Group justify="flex-end" mt="xl">
+                    <Button
+                        variant="outline"
+                        onClick={onClose}
+                        leftSection={<IconArrowBackUp size="1rem" />}
+                    >
+                        Avbryt
+                    </Button>
+                    <Button
+                        color="blue"
+                        onClick={handleConfirmReschedule}
+                        loading={isSubmitting}
+                        leftSection={<IconCheck size="1rem" />}
+                        disabled={!hasChanges} // Disable if no changes were made
+                    >
+                        Bekräfta ändring
+                    </Button>
+                </Group>
+            </Box>
+        </Modal>
+    );
+}

--- a/app/schedule/components/ReschedulePickupModal.tsx
+++ b/app/schedule/components/ReschedulePickupModal.tsx
@@ -77,38 +77,6 @@ export default function ReschedulePickupModal({
         });
     };
 
-    // Parse time string and create a Date object
-    const parseTimeString = (timeStr: string, baseDate: Date): Date => {
-        let hours = 0;
-        let minutes = 0;
-
-        if (!timeStr) {
-            return new Date(baseDate);
-        }
-
-        const parts = timeStr.split(":");
-        if (parts.length === 2) {
-            hours = parseInt(parts[0], 10) || 0;
-            minutes = parseInt(parts[1], 10) || 0;
-        } else if (timeStr.length === 1 || timeStr.length === 2) {
-            hours = parseInt(timeStr, 10) || 0;
-            minutes = 0;
-        } else if (timeStr.length === 3) {
-            hours = parseInt(timeStr.substring(0, 1), 10) || 0;
-            minutes = parseInt(timeStr.substring(1), 10) || 0;
-        } else if (timeStr.length === 4) {
-            hours = parseInt(timeStr.substring(0, 2), 10) || 0;
-            minutes = parseInt(timeStr.substring(2), 10) || 0;
-        }
-
-        hours = Math.min(Math.max(hours, 0), 23);
-        minutes = Math.min(Math.max(minutes, 0), 59);
-
-        const newDate = new Date(baseDate);
-        newDate.setHours(hours, minutes, 0, 0);
-        return newDate;
-    };
-
     // Format date for display
     const formatDate = (date: Date) => {
         return formatStockholmDate(date, "d MMM yyyy");

--- a/app/schedule/components/TimeSlotCell.tsx
+++ b/app/schedule/components/TimeSlotCell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Paper, Stack } from "@mantine/core";
+import { ReactNode } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { FoodParcel } from "@/app/schedule/actions";
 import { isPastTimeSlot } from "@/app/utils/date-utils";
@@ -9,10 +10,17 @@ import PickupCard from "./PickupCard";
 interface TimeSlotCellProps {
     date: Date;
     time: string;
-    parcels: FoodParcel[];
+    parcels: (
+        | FoodParcel
+        | {
+              element: ReactNode;
+              id: string;
+              [key: string]: any;
+          }
+    )[];
     maxParcelsPerSlot: number;
     isOverCapacity?: boolean;
-    dayIndex?: number; // Add dayIndex parameter
+    dayIndex?: number;
 }
 
 export default function TimeSlotCell({
@@ -59,9 +67,13 @@ export default function TimeSlotCell({
         >
             {/* Parcels stack */}
             <Stack gap={4}>
-                {parcels.map(parcel => (
-                    <PickupCard key={parcel.id} foodParcel={parcel} isCompact={true} />
-                ))}
+                {parcels.map(parcel =>
+                    "element" in parcel ? (
+                        <div key={parcel.id}>{parcel.element}</div>
+                    ) : (
+                        <PickupCard key={parcel.id} foodParcel={parcel} isCompact={true} />
+                    ),
+                )}
             </Stack>
         </Paper>
     );

--- a/app/schedule/components/TimeSlotCell.tsx
+++ b/app/schedule/components/TimeSlotCell.tsx
@@ -15,7 +15,7 @@ interface TimeSlotCellProps {
         | {
               element: ReactNode;
               id: string;
-              [key: string]: any;
+              [key: string]: unknown;
           }
     )[];
     maxParcelsPerSlot: number;

--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "drizzle-kit": "^0.30.6",
         "eslint": "^9.25.0",
         "eslint-config-next": "15.1.5",
+        "eslint-plugin-jest": "^28.11.0",
         "happy-dom": "^17.4.4",
         "postcss": "^8.5.3",
         "postcss-preset-mantine": "^1.17.0",
@@ -534,6 +535,8 @@
     "eslint-module-utils": ["eslint-module-utils@2.12.0", "", { "dependencies": { "debug": "^3.2.7" } }, "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg=="],
 
     "eslint-plugin-import": ["eslint-plugin-import@2.31.0", "", { "dependencies": { "@rtsao/scc": "^1.1.0", "array-includes": "^3.1.8", "array.prototype.findlastindex": "^1.2.5", "array.prototype.flat": "^1.3.2", "array.prototype.flatmap": "^1.3.2", "debug": "^3.2.7", "doctrine": "^2.1.0", "eslint-import-resolver-node": "^0.3.9", "eslint-module-utils": "^2.12.0", "hasown": "^2.0.2", "is-core-module": "^2.15.1", "is-glob": "^4.0.3", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "object.groupby": "^1.0.3", "object.values": "^1.2.0", "semver": "^6.3.1", "string.prototype.trimend": "^1.0.8", "tsconfig-paths": "^3.15.0" }, "peerDependencies": { "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9" } }, "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A=="],
+
+    "eslint-plugin-jest": ["eslint-plugin-jest@28.11.0", "", { "dependencies": { "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "peerDependencies": { "@typescript-eslint/eslint-plugin": "^6.0.0 || ^7.0.0 || ^8.0.0", "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0", "jest": "*" }, "optionalPeers": ["@typescript-eslint/eslint-plugin", "jest"] }, "sha512-QAfipLcNCWLVocVbZW8GimKn5p5iiMcgGbRzz8z/P5q7xw+cNEpYqyzFMtIF/ZgF2HLOyy+dYBut+DoYolvqig=="],
 
     "eslint-plugin-jsx-a11y": ["eslint-plugin-jsx-a11y@6.10.2", "", { "dependencies": { "aria-query": "^5.3.2", "array-includes": "^3.1.8", "array.prototype.flatmap": "^1.3.2", "ast-types-flow": "^0.0.8", "axe-core": "^4.10.0", "axobject-query": "^4.1.0", "damerau-levenshtein": "^1.0.8", "emoji-regex": "^9.2.2", "hasown": "^2.0.2", "jsx-ast-utils": "^3.3.5", "language-tags": "^1.0.9", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "safe-regex-test": "^1.0.3", "string.prototype.includes": "^2.0.1" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9" } }, "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q=="],
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
         "format": "prettier --write .",
         "db:generate": "bun drizzle-kit generate",
         "db:migrate": "bun drizzle-kit migrate",
-        "test": "bun test"
+        "test": "bun test",
+        "typecheck": "tsc --noEmit",
+        "validate": "bun run lint && bun run typecheck && bun run format-check"
     },
     "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -52,6 +54,7 @@
         "drizzle-kit": "^0.30.6",
         "eslint": "^9.25.0",
         "eslint-config-next": "15.1.5",
+        "eslint-plugin-jest": "^28.11.0",
         "happy-dom": "^17.4.4",
         "postcss": "^8.5.3",
         "postcss-preset-mantine": "^1.17.0",


### PR DESCRIPTION
- CI now type-checks as part of the lint workflow (bun run typecheck) – great for catching regressions early.
- Large test refactor: heavy use of Bun’s mocking and a thorough Date stub ensures determinism. 
- lint_and_prettier.yml now fails fast on type errors and keeps formatting checks – healthy pipeline.
