### PR TITLE
Use Docker-native health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN bun run build
 FROM base AS runner
 WORKDIR /app
 
+# Install curl for health checks
+RUN apk add --no-cache curl
+
 # Auth.js requirements
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ To keep the git commit history in `main` clean, we use the **squash and merge** 
 2. Purchase a Linux Ubuntu server (e.g. [droplet](https://www.digitalocean.com/products/droplets))
 3. Create an `A` DNS record pointing to your server IPv4 address
 
+### Docker Requirements
+
+This project uses Docker Compose with health checks and requires:
+- **Docker Compose v2.13+** for `--wait` flag and `condition: service_healthy` features
+- The deployment script automatically checks version compatibility and will fail with clear error messages if requirements aren't met
+
 ## Continuous integration and deployment
 
 This project runs on both a staging and production environment.

--- a/README.md
+++ b/README.md
@@ -14,13 +14,6 @@ To keep the git commit history in `main` clean, we use the **squash and merge** 
 2. Purchase a Linux Ubuntu server (e.g. [droplet](https://www.digitalocean.com/products/droplets))
 3. Create an `A` DNS record pointing to your server IPv4 address
 
-### Docker Requirements
-
-This project uses Docker Compose with health checks and requires:
-- **Docker Compose v2.13+** for `--wait`, `--wait-timeout`, and `condition: service_healthy` features
-- The deployment script automatically checks version compatibility and will fail with clear error messages if requirements aren't met
-- Health checks have a 5-minute timeout to prevent indefinite hangs in CI/CD pipelines
-
 ## Continuous integration and deployment
 
 This project runs on both a staging and production environment.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ To keep the git commit history in `main` clean, we use the **squash and merge** 
 ### Docker Requirements
 
 This project uses Docker Compose with health checks and requires:
-- **Docker Compose v2.13+** for `--wait` flag and `condition: service_healthy` features
+- **Docker Compose v2.13+** for `--wait`, `--wait-timeout`, and `condition: service_healthy` features
 - The deployment script automatically checks version compatibility and will fail with clear error messages if requirements aren't met
+- Health checks have a 5-minute timeout to prevent indefinite hangs in CI/CD pipelines
 
 ## Continuous integration and deployment
 

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,26 @@
+// Health check endpoint for deployment verification
+import { NextResponse } from "next/server";
+
+export async function GET() {
+    try {
+        // Simple health check - could be extended to check database connectivity
+        return NextResponse.json(
+            {
+                status: "healthy",
+                timestamp: new Date().toISOString(),
+                service: "matkassen-web",
+            },
+            { status: 200 },
+        );
+    } catch (error) {
+        return NextResponse.json(
+            {
+                status: "unhealthy",
+                error: error instanceof Error ? error.message : "Unknown error",
+                timestamp: new Date().toISOString(),
+                service: "matkassen-web",
+            },
+            { status: 500 },
+        );
+    }
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,24 +1,76 @@
 // Health check endpoint for deployment verification
 import { NextResponse } from "next/server";
+import { client } from "@/app/db/drizzle";
 
 export async function GET() {
+    const timestamp = new Date().toISOString();
+
     try {
-        // Simple health check - could be extended to check database connectivity
-        return NextResponse.json(
-            {
-                status: "healthy",
-                timestamp: new Date().toISOString(),
-                service: "matkassen-web",
+        // Check if we're in a test environment
+        const isTestEnvironment = process.env.NODE_ENV === "test" || process.env.BUN_ENV === "test";
+
+        if (isTestEnvironment) {
+            // Skip database checks in test environment
+            return NextResponse.json(
+                {
+                    status: "healthy",
+                    timestamp,
+                    service: "matkassen-web",
+                    environment: "test",
+                    checks: {
+                        webServer: "ok",
+                        database: "skipped (test environment)",
+                    },
+                },
+                { status: 200 },
+            );
+        }
+
+        // Test database connectivity
+        let dbStatus = "unknown";
+        let dbError = null;
+
+        try {
+            // Simple query to test database connectivity
+            await client`SELECT 1 as health_check`;
+            dbStatus = "ok";
+        } catch (error) {
+            dbStatus = "error";
+            dbError = error instanceof Error ? error.message : "Database connection failed";
+            console.error("Database health check failed:", error);
+        }
+
+        // Determine overall health status
+        const isHealthy = dbStatus === "ok";
+        const status = isHealthy ? "healthy" : "unhealthy";
+        const httpStatus = isHealthy ? 200 : 503;
+
+        const response = {
+            status,
+            timestamp,
+            service: "matkassen-web",
+            checks: {
+                webServer: "ok",
+                database: dbStatus,
+                ...(dbError && { databaseError: dbError }),
             },
-            { status: 200 },
-        );
+        };
+
+        return NextResponse.json(response, { status: httpStatus });
     } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "Unknown error";
+        console.error("Health check failed:", error);
+
         return NextResponse.json(
             {
                 status: "unhealthy",
-                error: error instanceof Error ? error.message : "Unknown error",
-                timestamp: new Date().toISOString(),
+                error: errorMessage,
+                timestamp,
                 service: "matkassen-web",
+                checks: {
+                    webServer: "error",
+                    database: "unknown",
+                },
             },
             { status: 500 },
         );

--- a/deploy.sh
+++ b/deploy.sh
@@ -123,7 +123,7 @@ echo "Verifying Docker Compose version compatibility..."
 DOCKER_COMPOSE_VERSION=$(docker compose version --short 2>/dev/null || echo "unknown")
 echo "Docker Compose version: $DOCKER_COMPOSE_VERSION"
 
-# Check if version meets minimum requirements (v2.13+ for --wait flag)
+# Check if version meets minimum requirements (v2.13+ for --wait and --wait-timeout flags)
 if [[ "$DOCKER_COMPOSE_VERSION" == "unknown" ]]; then
   echo "❌ Error: Could not determine Docker Compose version"
   exit 1
@@ -137,7 +137,7 @@ if [[ $DOCKER_COMPOSE_VERSION =~ ^v?([0-9]+)\.([0-9]+) ]]; then
   # Check if version is 2.13 or higher
   if [[ $MAJOR_VERSION -lt 2 ]] || [[ $MAJOR_VERSION -eq 2 && $MINOR_VERSION -lt 13 ]]; then
     echo "❌ Error: Docker Compose version $DOCKER_COMPOSE_VERSION is not supported"
-    echo "This deployment script requires Docker Compose v2.13+ for health check features"
+    echo "This deployment script requires Docker Compose v2.13+ for health check and timeout features"
     echo "Please upgrade Docker Compose to continue"
     echo "Installation guide: https://docs.docker.com/compose/install/"
     exit 1
@@ -368,8 +368,8 @@ fi
 
 # Start the containers with health check dependencies
 echo "Starting Docker containers with health checks..."
-if ! sudo docker compose up -d --wait; then
-  echo "Failed to start Docker containers or health checks failed."
+if ! sudo docker compose up -d --wait --wait-timeout 300; then
+  echo "Failed to start Docker containers or health checks failed within 5 minutes."
   echo "Container status:"
   sudo docker compose ps
   echo "Logs:"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,7 +22,7 @@ services:
             - NODE_ENV=development # Enables hot reloading
 
     db:
-        image: postgres:latest
+        image: postgres:17.5
         restart: always
         environment:
             POSTGRES_USER: ${POSTGRES_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+# Docker Compose configuration with health checks
+# Requires Docker Compose v2.13+ for --wait flag and service health conditions
+# Health checks ensure services are fully operational before considering deployment complete
+
 services:
     web:
         build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,9 @@ services:
             start_period: 40s
 
     db:
-        image: postgres:latest
+        # Using specific PostgreSQL version for reproducible builds
+        # postgres:17.5 is the latest stable release with security updates
+        image: postgres:17.5
         restart: always
         environment:
             POSTGRES_USER: ${POSTGRES_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,18 @@ services:
         env_file:
             - .env
         depends_on:
-            - db
+            db:
+                condition: service_healthy
         networks:
             - my_network
         volumes:
             - ./app:/usr/src/app
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+            start_period: 40s
 
     db:
         image: postgres:latest
@@ -28,6 +35,12 @@ services:
             - postgres_data:/var/lib/postgresql/data
         networks:
             - my_network
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+            start_period: 30s
 
 volumes:
     postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 # Docker Compose configuration with health checks
-# Requires Docker Compose v2.13+ for --wait flag and service health conditions
+# Requires Docker Compose v2.13+ for --wait, --wait-timeout, and service health conditions
 # Health checks ensure services are fully operational before considering deployment complete
+# Deployment uses 5-minute timeout to prevent indefinite hangs
 
 services:
     web:

--- a/middleware.ts
+++ b/middleware.ts
@@ -126,9 +126,10 @@ export const config = {
          * - flags (flag images)
          * - api/auth (Auth.js routes)
          * - api/csp-report (CSP reporting endpoint)
+         * - api/health (Health check endpoint)
          * This ensures that all other routes, including other API routes and all page routes,
          * are processed by the middleware.
          */
-        "/((?!_next/static|_next/image|favicon.svg|flags/|api/auth|api/csp-report).*)",
+        "/((?!_next/static|_next/image|favicon.svg|flags/|api/auth|api/csp-report|api/health).*)",
     ],
 };


### PR DESCRIPTION
Benefits of Docker-Native Health Checks
1. Built-in Orchestration depends_on with condition: service_healthy ensures web service only starts after database is healthy --wait flag makes deployment script wait for all health checks to pass No custom shell scripting needed
2. Continuous Monitoring Health checks run continuously every 30s (configurable) Docker can restart unhealthy containers automatically Better integration with monitoring tools
3. Standardized Interface docker compose ps shows health status directly
Works with Docker Swarm, Kubernetes, etc.
Industry standard approach
4. Better Error Handling start_period gives containers time to initialize before health checks begin Configurable retry logic and timeouts
Clear failure states
5. Production Ready Health checks continue running after deployment
Can be integrated with load balancers and service discovery Better for container orchestration platforms