### PR TITLE
fix: make sure migrations are run when running initial deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
                 condition: service_healthy
         networks:
             - my_network
-        volumes:
-            - ./app:/usr/src/app
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
             interval: 30s


### PR DESCRIPTION
The volume mount was overwriting the container's app directory, preventing migrations from being accessible during deployment.