### PR TITLE
Improve docker compose build times

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# Build artifacts
+.next
+node_modules
+dist
+build
+
+# Development files
+.env*
+.git
+.gitignore
+README.md
+
+# Test files
+__tests__
+*.test.*
+coverage
+
+# IDE files
+.vscode
+.idea
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Docker files
+Dockerfile*
+docker-compose*.yml
+
+# TypeScript build info (these are regenerated)
+*.tsbuildinfo
+
+# Scripts that aren't needed in container
+deploy.sh
+update.sh
+scripts/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/deploy.sh
+++ b/deploy.sh
@@ -361,6 +361,8 @@ done
 
 # Build the containers with proper error handling
 echo "Building Docker containers..."
+# Enable Docker Compose Bake for potentially better build performance
+export COMPOSE_BAKE=true
 if ! sudo docker compose build --no-cache; then
   echo "Docker build failed. Check the build logs above."
   exit 1

--- a/update.sh
+++ b/update.sh
@@ -44,6 +44,8 @@ fi
 # Build and restart the Docker containers
 echo "Rebuilding and restarting Docker containers..."
 cd $APP_DIR
+# Enable Docker Compose Bake for potentially better build performance
+export COMPOSE_BAKE=true
 sudo docker compose build
 sudo docker compose up -d
 


### PR DESCRIPTION
> Compose can now delegate builds to bake for better performance. To do so, set COMPOSE_BAKE=true.

Also add .dockerignore to remove contents from docker build.