### PR TITLE
fix: Prevent database connection attempts during Docker build

### DIFF
--- a/app/db/drizzle.ts
+++ b/app/db/drizzle.ts
@@ -4,19 +4,27 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-// Check if we're running in a test environment
+// Check if we're running in a test environment or during build
 const isTestEnvironment = process.env.NODE_ENV === "test";
+// Better build detection: check if we're in build phase or if DATABASE_URL is missing
+const isBuildTime =
+    process.env.NEXT_PHASE === "phase-production-build" ||
+    (typeof window === "undefined" &&
+        !process.env.DATABASE_URL &&
+        (process.env.NODE_ENV === "production" || !process.env.NODE_ENV));
 
-// Only require DATABASE_URL in non-test environments
-if (!process.env.DATABASE_URL && !isTestEnvironment) {
+// Only require DATABASE_URL in non-test environments and not during build
+if (!process.env.DATABASE_URL && !isTestEnvironment && !isBuildTime) {
     throw new Error("DATABASE_URL environment variable is not set");
 }
 
 // Use a mock or real client based on environment
-export const client = isTestEnvironment
-    ? ({} as ReturnType<typeof postgres>) // Mock client for tests
-    : postgres(process.env.DATABASE_URL as string);
+export const client =
+    isTestEnvironment || isBuildTime
+        ? ({} as ReturnType<typeof postgres>) // Mock client for tests and build
+        : postgres(process.env.DATABASE_URL as string);
 
-export const db = isTestEnvironment
-    ? ({} as ReturnType<typeof drizzle>) // Mock DB for tests
-    : drizzle(client);
+export const db =
+    isTestEnvironment || isBuildTime
+        ? ({} as ReturnType<typeof drizzle>) // Mock DB for tests and build
+        : drizzle(client);


### PR DESCRIPTION
Docker Build Phase 
  Problem: During pnpm run build in Docker, there's no .env file (excluded by .dockerignore) 
  Solution: Enhanced build detection prevents database connection attempts during build
  Result: Build completes successfully without "DATABASE_URL environment variable is not set" error

Production Runtime
  Problem: Need real database connection when the app actually runs
  Solution: At runtime, DATABASE_URL is available (provided by your deployment platform)
  Result: Database connections work normally in production