### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
     pull_request:
         branches: [main]
 
+permissions:
+    contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest

--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -4,6 +4,9 @@ on:
     push:
         branches: [main]
 
+permissions:
+    contents: read
+
 jobs:
     deploy-to-staging:
         runs-on: ubuntu-latest

--- a/.github/workflows/init_deploy.yml
+++ b/.github/workflows/init_deploy.yml
@@ -12,6 +12,9 @@ on:
                     - staging
                 default: "staging"
 
+permissions:
+    contents: read
+
 jobs:
     deploy:
         name: Deploy to ${{ github.event.inputs.environment }}

--- a/.github/workflows/lint_and_prettier.yml
+++ b/.github/workflows/lint_and_prettier.yml
@@ -5,6 +5,9 @@ on:
         types: [opened, synchronize, reopened]
         branches: [main]
 
+permissions:
+    contents: read
+
 # Prevent multiple workflow runs
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
- Add `contents: read` to build, lint, and deployment workflows
- Follows principle of least privilege to resolve security warning
- Prevents inheritance of organization-wide read-write permissions
- No functional changes - workflows only need to read repository contents