### PR TITLE
refactor(time): replace custom HH:mm helpers with date-fns; centralize in app/utils/date-utils

### DIFF
--- a/__tests__/app/handout-locations/weekpicker-iso-year.test.ts
+++ b/__tests__/app/handout-locations/weekpicker-iso-year.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { startOfWeek } from "date-fns";
+import { getISOWeekYear } from "date-fns";
+import {
+    getISOWeekNumber,
+    getWeekDateRange,
+} from "../../../app/utils/schedule/schedule-validation";
+
+describe("WeekPicker ISO week-year behavior", () => {
+    it("maps the week containing 2025-12-31 to ISO year 2026, week 1", () => {
+        const date = new Date("2025-12-31T00:00:00Z");
+
+        // Simulate WeekPicker's use of the week's Monday for selection
+        const monday = startOfWeek(date, { weekStartsOn: 1 }); // Monday
+
+        // Week number should be 1
+        expect(getISOWeekNumber(monday)).toBe(1);
+        // ISO week-year should be 2026
+        expect(getISOWeekYear(monday)).toBe(2026);
+
+        // And the corresponding range for { year: 2026, week: 1 } should be Dec 29, 2025 - Jan 4, 2026
+        const { startDate, endDate } = getWeekDateRange(2026, 1);
+        expect(startDate.toISOString().slice(0, 10)).toBe("2025-12-29");
+        expect(endDate.toISOString().slice(0, 10)).toBe("2026-01-04");
+    });
+
+    it("does not incorrectly map {year: 2025, week: 1} to the late-December 2025 week", () => {
+        const { startDate, endDate } = getWeekDateRange(2025, 1);
+        // Week 1 of 2025 should start on 2024-12-30 and end on 2025-01-05
+        expect(startDate.toISOString().slice(0, 10)).toBe("2024-12-30");
+        expect(endDate.toISOString().slice(0, 10)).toBe("2025-01-05");
+    });
+
+    it("returns ISO week number 1 for 2025-12-31 (safety check)", () => {
+        const date = new Date("2025-12-31T00:00:00Z");
+        expect(getISOWeekNumber(date)).toBe(1);
+    });
+});

--- a/app/[locale]/handout-locations/actions.ts
+++ b/app/[locale]/handout-locations/actions.ts
@@ -219,33 +219,14 @@ export async function createSchedule(
                 .values({
                     pickup_location_id: locationId,
                     name: scheduleData.name,
+                    // Persist dates as ISO YYYY-MM-DD derived from UTC to avoid TZ shifts
                     start_date:
                         scheduleData.start_date instanceof Date
-                            ? new Date(
-                                  scheduleData.start_date.getFullYear(),
-                                  scheduleData.start_date.getMonth(),
-                                  scheduleData.start_date.getDate(),
-                                  12, // Set to noon to avoid any timezone issues
-                                  0,
-                                  0,
-                                  0,
-                              )
-                                  .toISOString()
-                                  .split("T")[0]
+                            ? scheduleData.start_date.toISOString().split("T")[0]
                             : scheduleData.start_date,
                     end_date:
                         scheduleData.end_date instanceof Date
-                            ? new Date(
-                                  scheduleData.end_date.getFullYear(),
-                                  scheduleData.end_date.getMonth(),
-                                  scheduleData.end_date.getDate(),
-                                  12, // Set to noon to avoid any timezone issues
-                                  0,
-                                  0,
-                                  0,
-                              )
-                                  .toISOString()
-                                  .split("T")[0]
+                            ? scheduleData.end_date.toISOString().split("T")[0]
                             : scheduleData.end_date,
                 })
                 .returning();
@@ -326,33 +307,14 @@ export async function updateSchedule(
                 .update(pickupLocationSchedules)
                 .set({
                     name: scheduleData.name,
+                    // Persist dates as ISO YYYY-MM-DD derived from UTC to avoid TZ shifts
                     start_date:
                         scheduleData.start_date instanceof Date
-                            ? new Date(
-                                  scheduleData.start_date.getFullYear(),
-                                  scheduleData.start_date.getMonth(),
-                                  scheduleData.start_date.getDate(),
-                                  12, // Set to noon to avoid any timezone issues
-                                  0,
-                                  0,
-                                  0,
-                              )
-                                  .toISOString()
-                                  .split("T")[0]
+                            ? scheduleData.start_date.toISOString().split("T")[0]
                             : scheduleData.start_date,
                     end_date:
                         scheduleData.end_date instanceof Date
-                            ? new Date(
-                                  scheduleData.end_date.getFullYear(),
-                                  scheduleData.end_date.getMonth(),
-                                  scheduleData.end_date.getDate(),
-                                  12, // Set to noon to avoid any timezone issues
-                                  0,
-                                  0,
-                                  0,
-                              )
-                                  .toISOString()
-                                  .split("T")[0]
+                            ? scheduleData.end_date.toISOString().split("T")[0]
                             : scheduleData.end_date,
                 })
                 .where(eq(pickupLocationSchedules.id, scheduleId))

--- a/app/[locale]/handout-locations/components/SchedulesTab.tsx
+++ b/app/[locale]/handout-locations/components/SchedulesTab.tsx
@@ -38,7 +38,7 @@ export function SchedulesTab({ location, onUpdated }: SchedulesTabProps) {
             const newSchedule = await createSchedule(location.id, scheduleData);
             setSchedules(prevSchedules => [...prevSchedules, newSchedule]);
             onUpdated?.();
-        } catch (err) {
+        } catch {
             setError(t("scheduleCreateError"));
             notifications.show({
                 title: t("errorSaving"),
@@ -61,7 +61,7 @@ export function SchedulesTab({ location, onUpdated }: SchedulesTabProps) {
                 prevSchedules.map(s => (s.id === scheduleId ? updatedSchedule : s)),
             );
             onUpdated?.();
-        } catch (err) {
+        } catch {
             setError(t("scheduleUpdateError"));
             notifications.show({
                 title: t("errorSaving"),
@@ -94,7 +94,7 @@ export function SchedulesTab({ location, onUpdated }: SchedulesTabProps) {
                 message: t("scheduleDeleteError"), // Using the error message key without parameters
                 color: "green",
             });
-        } catch (err) {
+        } catch {
             setError(t("scheduleDeleteError"));
             notifications.show({
                 title: t("errorDeleting"),

--- a/app/[locale]/handout-locations/components/SchedulesTab.tsx
+++ b/app/[locale]/handout-locations/components/SchedulesTab.tsx
@@ -39,7 +39,6 @@ export function SchedulesTab({ location, onUpdated }: SchedulesTabProps) {
             setSchedules(prevSchedules => [...prevSchedules, newSchedule]);
             onUpdated?.();
         } catch (err) {
-            console.error("Error creating schedule:", err);
             setError(t("scheduleCreateError"));
             notifications.show({
                 title: t("errorSaving"),
@@ -63,7 +62,6 @@ export function SchedulesTab({ location, onUpdated }: SchedulesTabProps) {
             );
             onUpdated?.();
         } catch (err) {
-            console.error("Error updating schedule:", err);
             setError(t("scheduleUpdateError"));
             notifications.show({
                 title: t("errorSaving"),
@@ -97,7 +95,6 @@ export function SchedulesTab({ location, onUpdated }: SchedulesTabProps) {
                 color: "green",
             });
         } catch (err) {
-            console.error("Error deleting schedule:", err);
             setError(t("scheduleDeleteError"));
             notifications.show({
                 title: t("errorDeleting"),

--- a/app/[locale]/handout-locations/components/schedules/ScheduleForm.tsx
+++ b/app/[locale]/handout-locations/components/schedules/ScheduleForm.tsx
@@ -32,6 +32,7 @@ import {
     getWeekDateRange,
     getISOWeekNumber,
 } from "@/app/utils/schedule/schedule-validation";
+import { getISOWeekYear } from "date-fns";
 import { format } from "date-fns";
 import { WeekPicker } from "./WeekPicker";
 
@@ -104,7 +105,7 @@ export function ScheduleForm({
         if (initialValues?.start_date) {
             const date = new Date(initialValues.start_date);
             return {
-                year: date.getFullYear(),
+                year: getISOWeekYear(date),
                 week: getISOWeekNumber(date),
             };
         }
@@ -115,7 +116,7 @@ export function ScheduleForm({
         if (initialValues?.end_date) {
             const date = new Date(initialValues.end_date);
             return {
-                year: date.getFullYear(),
+                year: getISOWeekYear(date),
                 week: getISOWeekNumber(date),
             };
         }
@@ -369,6 +370,7 @@ export function ScheduleForm({
                             onChange={
                                 handleStartWeekChange as (selection: WeekSelection | null) => void
                             }
+                            displayMode="start"
                             // Default behavior now prevents selecting weeks in the past
                         />
                         <WeekPicker
@@ -377,11 +379,11 @@ export function ScheduleForm({
                             onChange={
                                 handleEndWeekChange as (selection: WeekSelection | null) => void
                             }
-                            // Allow selecting the same week as the start week by using the start of that week
-                            // instead of using the start date directly, which would disable the week itself
+                            displayMode="end"
+                            // Use the actual start date of the selected start week
                             minDate={
                                 startWeek
-                                    ? new Date(startWeek.year, 0, 1 + (startWeek.week - 1) * 7)
+                                    ? getWeekDateRange(startWeek.year, startWeek.week).startDate
                                     : undefined
                             }
                         />

--- a/app/[locale]/handout-locations/components/schedules/ScheduleForm.tsx
+++ b/app/[locale]/handout-locations/components/schedules/ScheduleForm.tsx
@@ -35,6 +35,12 @@ import {
 import { format } from "date-fns";
 import { WeekPicker } from "./WeekPicker";
 
+// Placed in module scope to avoid re-creation on each submit
+const toMinutes = (time: string): number => {
+    const [hours, minutes] = time.split(":");
+    return Number(hours) * 60 + Number(minutes);
+};
+
 interface ScheduleFormProps {
     onSubmit: (data: ScheduleInput) => Promise<void>;
     existingSchedules: PickupLocationScheduleWithDays[];
@@ -253,6 +259,9 @@ export function ScheduleForm({
     // Use a ref to track if we should perform date validation
     const dateFieldsChanged = useRef(false);
 
+    // Track which weekday rows have changed to limit per-day validation work
+    const changedDayIndexesRef = useRef<Set<number>>(new Set());
+
     // Check for overlapping schedules with debounce only when date fields change
     useEffect(() => {
         dateFieldsChanged.current = true;
@@ -276,19 +285,17 @@ export function ScheduleForm({
                 return;
             }
 
-            // Client-side validation for weekday times to avoid DB constraint errors
+            // Client-side validation for weekday times: only validate rows that changed or are open
             let hasTimeErrors = false;
-            const toMinutes = (time: string): number => {
-                const [h, m] = time.split(":");
-                return Number(h) * 60 + Number(m);
-            };
-
             values.days.forEach((day, idx) => {
-                // Clear previous errors for this row
+                const changed = changedDayIndexesRef.current.has(idx);
+                if (!changed && !day.is_open) return;
+
+                // Clear previous errors for this row before re-validating
                 form.clearFieldError(`days.${idx}.opening_time`);
                 form.clearFieldError(`days.${idx}.closing_time`);
 
-                if (!day.is_open) return;
+                if (!day.is_open) return; // closed rows need no further validation
 
                 if (!day.opening_time) {
                     form.setFieldError(`days.${idx}.opening_time`, t("timeErrors.openingRequired"));
@@ -303,14 +310,9 @@ export function ScheduleForm({
                     const start = toMinutes(day.opening_time);
                     const end = toMinutes(day.closing_time);
                     if (start >= end) {
-                        form.setFieldError(
-                            `days.${idx}.opening_time`,
-                            t("timeErrors.openingBeforeClosing"),
-                        );
-                        form.setFieldError(
-                            `days.${idx}.closing_time`,
-                            t("timeErrors.closingAfterOpening"),
-                        );
+                        const sameMessage = t("timeErrors.openingBeforeClosing");
+                        form.setFieldError(`days.${idx}.opening_time`, sameMessage);
+                        form.setFieldError(`days.${idx}.closing_time`, sameMessage);
                         hasTimeErrors = true;
                     }
                 }
@@ -330,6 +332,8 @@ export function ScheduleForm({
                 end_date: values.end_date, // Keep end_date as a Date for the API
             };
             await onSubmit(formattedValues);
+            // Clear tracked changes on successful submit
+            changedDayIndexesRef.current.clear();
         } finally {
             setSaving(false);
         }
@@ -426,6 +430,17 @@ export function ScheduleForm({
                                                     `days.${index}.is_open`,
                                                     event.currentTarget.checked,
                                                 );
+                                                // Mark row as changed
+                                                changedDayIndexesRef.current.add(index);
+                                                // If toggled closed, clear existing time field errors for this row
+                                                if (!event.currentTarget.checked) {
+                                                    form.clearFieldError(
+                                                        `days.${index}.opening_time`,
+                                                    );
+                                                    form.clearFieldError(
+                                                        `days.${index}.closing_time`,
+                                                    );
+                                                }
                                             }}
                                             label={t(`weekdays.${day.weekday}`)}
                                         />
@@ -439,6 +454,7 @@ export function ScheduleForm({
                                                 `days.${index}.opening_time`,
                                                 value || "09:00",
                                             );
+                                            changedDayIndexesRef.current.add(index);
                                         }}
                                         min="08:00"
                                         max="20:00"
@@ -462,6 +478,7 @@ export function ScheduleForm({
                                                 `days.${index}.closing_time`,
                                                 value || "17:00",
                                             );
+                                            changedDayIndexesRef.current.add(index);
                                         }}
                                         min="08:00"
                                         max="20:00"

--- a/app/[locale]/handout-locations/components/schedules/SchedulesList.tsx
+++ b/app/[locale]/handout-locations/components/schedules/SchedulesList.tsx
@@ -21,7 +21,7 @@ import { IconCalendarStats, IconEdit, IconTrash, IconDots, IconPlus } from "@tab
 import { format } from "date-fns";
 import { PickupLocationScheduleWithDays, ScheduleInput } from "../../types";
 import { ScheduleForm } from "./ScheduleForm";
-import { getISOWeekNumber } from "../../../../utils/schedule/schedule-validation";
+import { getISOWeekNumber } from "@/app/utils/date-utils";
 
 interface SchedulesListProps {
     schedules: PickupLocationScheduleWithDays[];

--- a/app/[locale]/handout-locations/components/schedules/SchedulesTab.tsx
+++ b/app/[locale]/handout-locations/components/schedules/SchedulesTab.tsx
@@ -53,16 +53,17 @@ export function SchedulesTab({ location, onUpdated, onLocationUpdated }: Schedul
 
         try {
             const result = await operation();
-            setSchedules(prev => {
-                const updated = updateSchedules(result, prev);
 
-                // Update parent component's state optimistically
-                if (onLocationUpdated) {
-                    onLocationUpdated(location.id, { schedules: updated });
-                }
+            // Compute next schedules from current state outside of render phase
+            const nextSchedules = updateSchedules(result, schedules);
 
-                return updated;
-            });
+            // Update local state
+            setSchedules(nextSchedules);
+
+            // Notify parent AFTER local state update scheduling to avoid setState during render warnings
+            if (onLocationUpdated) {
+                onLocationUpdated(location.id, { schedules: nextSchedules });
+            }
 
             if (onUpdated) onUpdated();
         } catch (err) {

--- a/app/[locale]/households/enroll/components/FoodParcelsForm.tsx
+++ b/app/[locale]/households/enroll/components/FoodParcelsForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { showNotification } from "@mantine/notifications";
 import {
     SimpleGrid,
     Title,
@@ -20,7 +21,12 @@ import {
 } from "@mantine/core";
 import { DatePicker } from "@mantine/dates";
 import { nanoid } from "@/app/db/schema";
-import { toStockholmTime } from "@/app/utils/date-utils";
+import {
+    toStockholmTime,
+    minutesToHHmm,
+    normalizeToHHmm,
+    subtractMinutesFromHHmm,
+} from "@/app/utils/date-utils";
 import {
     IconClock,
     IconCalendar,
@@ -39,6 +45,7 @@ import {
 } from "../client-actions";
 import { FoodParcels, FoodParcel } from "../types";
 import { useTranslations } from "next-intl";
+import { TranslationFunction } from "../../../types";
 
 interface ValidationError {
     field: string;
@@ -85,7 +92,7 @@ interface LocationSchedules {
 }
 
 export default function FoodParcelsForm({ data, updateData, error }: FoodParcelsFormProps) {
-    const t = useTranslations("foodParcels");
+    const t = useTranslations("foodParcels") as TranslationFunction;
     const tCommon = useTranslations("handoutLocations");
 
     const [pickupLocations, setPickupLocations] = useState<PickupLocation[]>([]);
@@ -99,13 +106,84 @@ export default function FoodParcelsForm({ data, updateData, error }: FoodParcels
     // Add state for slot duration
     const [slotDuration, setSlotDuration] = useState<number>(15); // Default to 15 minutes
 
-    // Add state for selected schedule data
-    const [selectedScheduleData] = useState<{
-        openingTime: string;
-        closingTime: string;
-    } | null>(null);
+    // Derive opening hours for dates from location schedules
+    const getOpeningHoursForDate = useCallback(
+        (date: Date): { openingTime: string; closingTime: string } | null => {
+            if (!locationSchedules) return null;
 
-    // We need to actually use this variable in the component
+            const dateOnly = new Date(date);
+            dateOnly.setHours(0, 0, 0, 0);
+
+            // Check special day override first
+            const special = locationSchedules.specialDays.find(
+                d =>
+                    new Date(d.date).toISOString().split("T")[0] ===
+                    dateOnly.toISOString().split("T")[0],
+            );
+            if (special) {
+                if (special.isClosed) return null;
+                return { openingTime: special.openingTime, closingTime: special.closingTime };
+            }
+
+            // Aggregate regular schedules covering this date
+            // Note: Sunday is 0, Saturday is 6
+            const weekdayNames = [
+                "sunday",
+                "monday",
+                "tuesday",
+                "wednesday",
+                "thursday",
+                "friday",
+                "saturday",
+            ];
+            const weekday = weekdayNames[dateOnly.getDay()];
+
+            let earliest: string | null = null;
+            let latest: string | null = null;
+
+            for (const schedule of locationSchedules.schedules) {
+                const start = new Date(schedule.startDate);
+                const end = new Date(schedule.endDate);
+                start.setHours(0, 0, 0, 0);
+                end.setHours(23, 59, 59, 999);
+
+                if (dateOnly < start || dateOnly > end) continue;
+
+                const day = schedule.days.find(d => d.weekday === weekday);
+                if (!day || !day.isOpen || !day.openingTime || !day.closingTime) continue;
+
+                if (earliest === null || day.openingTime < earliest) earliest = day.openingTime;
+                if (latest === null || day.closingTime > latest) latest = day.closingTime;
+            }
+
+            if (!earliest || !latest) return null;
+            return { openingTime: earliest, closingTime: latest };
+        },
+        [locationSchedules],
+    );
+
+    const getCommonOpeningHoursForDates = useCallback(
+        (dates: Date[]): { openingTime: string; closingTime: string } | null => {
+            if (!dates.length) return null;
+            let maxOpening: string | null = null;
+            let minClosing: string | null = null;
+
+            for (const d of dates) {
+                const range = getOpeningHoursForDate(d);
+                if (!range) return null; // any closed date breaks common range
+
+                const { openingTime, closingTime } = range;
+                if (maxOpening === null || openingTime > maxOpening) maxOpening = openingTime;
+                if (minClosing === null || closingTime < minClosing) minClosing = closingTime;
+            }
+
+            if (!maxOpening || !minClosing) return null;
+            if (maxOpening >= minClosing) return null;
+            return { openingTime: maxOpening, closingTime: minClosing };
+        },
+        [getOpeningHoursForDate],
+    );
+
     const [capacityNotification, setCapacityNotification] = useState<{
         date: Date;
         message: string;
@@ -124,6 +202,10 @@ export default function FoodParcelsForm({ data, updateData, error }: FoodParcels
     // State for time selection modal
     const [timeModalOpened, setTimeModalOpened] = useState(false);
     const [selectedParcelIndex, setSelectedParcelIndex] = useState<number | null>(null);
+
+    // Use shared date utils from app/utils/date-utils
+
+    // moved below where formState is declared
 
     // Check if a date is in the past (entire day) using Stockholm timezone
     const isPastDate = useCallback((date: Date) => {
@@ -148,6 +230,55 @@ export default function FoodParcelsForm({ data, updateData, error }: FoodParcels
     const [selectedDates, setSelectedDates] = useState<Date[]>(
         data.parcels?.map(parcel => new Date(parcel.pickupDate)) || [],
     );
+
+    // Precompute common opening hours for bulk selection (needs formState)
+    const bulkCommonRange = useMemo(() => {
+        if (!locationSchedules || formState.parcels.length === 0) return null;
+        // Consider only non-past dates for bulk operations
+        const dates = formState.parcels
+            .map(p => new Date(p.pickupDate))
+            .filter(d => !isPastDate(d));
+        if (dates.length === 0) return null;
+        return getCommonOpeningHoursForDates(dates);
+    }, [locationSchedules, formState.parcels, getCommonOpeningHoursForDates, isPastDate]);
+
+    // Check whether all selected parcel dates share identical opening/closing times
+    const doAllSelectedDatesShareSameHours = useCallback((): {
+        same: boolean;
+        representative?: { openingTime: string; closingTime: string } | null;
+        summary?: Record<string, number>;
+    } => {
+        if (!locationSchedules || formState.parcels.length === 0) {
+            return { same: false };
+        }
+
+        const counts: Record<string, number> = {};
+        let representative: { openingTime: string; closingTime: string } | null = null;
+
+        for (const parcel of formState.parcels) {
+            const parcelDate = new Date(parcel.pickupDate);
+            // Ignore past dates in bulk edit checks
+            if (isPastDate(parcelDate)) {
+                continue;
+            }
+            const range = getOpeningHoursForDate(parcelDate);
+            if (!range) {
+                // Closed date or unknown hours — treat as unique bucket
+                const key = "CLOSED";
+                counts[key] = (counts[key] || 0) + 1;
+                continue;
+            }
+            const key = `${range.openingTime}-${range.closingTime}`;
+            counts[key] = (counts[key] || 0) + 1;
+            if (!representative) representative = range;
+        }
+
+        const distinct = Object.keys(counts);
+        if (distinct.length === 1 && distinct[0] !== "CLOSED") {
+            return { same: true, representative, summary: counts };
+        }
+        return { same: false, representative, summary: counts };
+    }, [locationSchedules, formState.parcels, getOpeningHoursForDate]);
 
     useEffect(() => {
         if (data.pickupLocationId) {
@@ -626,10 +757,10 @@ export default function FoodParcelsForm({ data, updateData, error }: FoodParcels
             }
 
             // Use the first available slot as default time, or noon as fallback
-            const defaultTimeSlot = getFirstAvailableSlot(
-                selectedScheduleData?.openingTime || "09:00",
-                selectedScheduleData?.closingTime || "17:00",
-            );
+            const range = getOpeningHoursForDate(date);
+            const defaultTimeSlot = range
+                ? getFirstAvailableSlot(range.openingTime, range.closingTime)
+                : "12:00";
             const [hours, minutes] = defaultTimeSlot.split(":").map((n: string) => parseInt(n, 10));
 
             const earliestTime = new Date(date);
@@ -652,7 +783,7 @@ export default function FoodParcelsForm({ data, updateData, error }: FoodParcels
         formState.parcels,
         slotDuration,
         getFirstAvailableSlot,
-        selectedScheduleData,
+        getOpeningHoursForDate,
     ]);
 
     const handleDatesChange = (dates: string[]) => {
@@ -806,11 +937,45 @@ export default function FoodParcelsForm({ data, updateData, error }: FoodParcels
 
         setBulkTimeError(null);
 
-        // Calculate end time based on slot duration for each parcel
+        // Validate against opening hours for each upcoming parcel date
+        const invalidDates: string[] = [];
+        formState.parcels.forEach(parcel => {
+            const parcelDate = new Date(parcel.pickupDate);
+            if (isPastDate(parcelDate)) {
+                return; // skip past dates
+            }
+            const range = getOpeningHoursForDate(parcelDate);
+            if (!range) {
+                invalidDates.push(parcelDate.toLocaleDateString("sv-SE"));
+                return;
+            }
+
+            const [openH, openM] = range.openingTime.split(":").map(n => parseInt(n, 10));
+            const [closeH, closeM] = range.closingTime.split(":").map(n => parseInt(n, 10));
+            const openingTotal = openH * 60 + openM;
+            const closingTotal = closeH * 60 + closeM;
+            const latestAllowedStart = closingTotal - slotDuration;
+            const chosenTotal = hours * 60 + roundedMinutes;
+
+            if (chosenTotal < openingTotal || chosenTotal > latestAllowedStart) {
+                invalidDates.push(parcelDate.toLocaleDateString("sv-SE"));
+            }
+        });
+
+        if (invalidDates.length > 0) {
+            setBulkTimeError(
+                `Vald tid (${bulkStartTime}) ligger utanför öppettiderna för: ${invalidDates.join(", ")}`,
+            );
+            return;
+        }
+
+        // Calculate end time based on slot duration for each parcel (only upcoming updated)
         const updatedParcels = formState.parcels.map(parcel => {
             // Set the new start time
             const newStartTime = new Date(parcel.pickupDate);
-            newStartTime.setHours(hours, roundedMinutes, 0, 0);
+            if (!isPastDate(newStartTime)) {
+                newStartTime.setHours(hours, roundedMinutes, 0, 0);
+            }
 
             // Calculate the end time based on slot duration
             const newEndTime = new Date(newStartTime);
@@ -1039,7 +1204,46 @@ export default function FoodParcelsForm({ data, updateData, error }: FoodParcels
                                     color: "var(--mantine-color-indigo-6)",
                                 }}
                                 size="xs"
-                                onClick={() => setBulkTimeMode(true)}
+                                onClick={() => {
+                                    const check = doAllSelectedDatesShareSameHours();
+                                    if (!check.same) {
+                                        // Build a concise explanation for the user
+                                        const summaryParts = Object.entries(check.summary || {})
+                                            .map(
+                                                ([k, v]) =>
+                                                    `${k === "CLOSED" ? "closed" : k} (${v})`,
+                                            )
+                                            .join(", ");
+                                        showNotification({
+                                            title: t("bulk.notAvailableTitle"),
+                                            message:
+                                                summaryParts && summaryParts.length > 0
+                                                    ? t("bulk.notAvailableMsgWithSummary", {
+                                                          summary: summaryParts,
+                                                      })
+                                                    : t("bulk.notAvailableMsg"),
+                                            color: "yellow",
+                                        });
+                                        return;
+                                    }
+                                    // Initialize bulk start time from first upcoming parcel's current time
+                                    const firstUpcoming = formState.parcels.find(
+                                        p => !isPastDate(new Date(p.pickupDate)),
+                                    );
+                                    if (firstUpcoming) {
+                                        const hh = firstUpcoming.pickupEarliestTime
+                                            .getHours()
+                                            .toString()
+                                            .padStart(2, "0");
+                                        const minsRaw =
+                                            firstUpcoming.pickupEarliestTime.getMinutes();
+                                        const mins = Math.floor(minsRaw / 15) * 15;
+                                        setBulkStartTime(
+                                            `${hh}:${mins.toString().padStart(2, "0")}`,
+                                        );
+                                    }
+                                    setBulkTimeMode(true);
+                                }}
                             >
                                 {t("setBulkTimes")}
                             </Button>
@@ -1054,7 +1258,7 @@ export default function FoodParcelsForm({ data, updateData, error }: FoodParcels
                         <Paper p="md" withBorder radius="md" mb="md">
                             <Stack>
                                 <Text fw={500} size="sm">
-                                    {t("bulkTimeHint")}
+                                    {t("bulkTimeHint")} – {t("bulk.upcomingOnly" as any, {})}
                                 </Text>
 
                                 {bulkTimeError && (
@@ -1187,7 +1391,9 @@ export default function FoodParcelsForm({ data, updateData, error }: FoodParcels
                     ) : null}
 
                     <Text size="sm" mb="md" style={{ color: "var(--mantine-color-dimmed)" }}>
-                        {bulkTimeMode ? t("bulkTimeHint") : t("individualTimeHint")}
+                        {bulkTimeMode
+                            ? `${t("bulkTimeHint")} – ${t("bulk.upcomingOnly" as any, {})}`
+                            : t("individualTimeHint")}
                     </Text>
 
                     {/* Slot Duration Info - Always visible */}
@@ -1607,8 +1813,11 @@ export default function FoodParcelsForm({ data, updateData, error }: FoodParcels
                             if (!timeString) return;
 
                             if (selectedParcelIndex === -1) {
-                                // Bulk mode
-                                setBulkStartTime(timeString);
+                                // Bulk mode: ensure stored value is HH:mm (strip seconds if provided)
+                                const parts = timeString.split(":");
+                                const hh = (parts[0] || "00").padStart(2, "0");
+                                const mm = (parts[1] || "00").padStart(2, "0");
+                                setBulkStartTime(`${hh}:${mm}`);
                             } else if (selectedParcelIndex !== null) {
                                 // Individual parcel mode
                                 const [hours, minutes] = timeString.split(":");
@@ -1626,11 +1835,44 @@ export default function FoodParcelsForm({ data, updateData, error }: FoodParcels
                             setTimeModalOpened(false);
                             setSelectedParcelIndex(null);
                         }}
-                        data={getTimeRange({
-                            startTime: selectedScheduleData?.openingTime || "09:00",
-                            endTime: selectedScheduleData?.closingTime || "17:00",
-                            interval: `00:${slotDuration.toString().padStart(2, "0")}`,
-                        })}
+                        data={(() => {
+                            const interval = minutesToHHmm(slotDuration);
+                            if (selectedParcelIndex === -1) {
+                                // Bulk mode is only enabled when hours match
+                                const start = bulkCommonRange?.openingTime || "09:00";
+                                const rawEnd = bulkCommonRange?.closingTime || "17:00";
+                                // Ensure last selectable start fits within closing - slotDuration
+                                const adjustedEnd = subtractMinutesFromHHmm(rawEnd, slotDuration);
+                                return getTimeRange({
+                                    startTime: start,
+                                    endTime: adjustedEnd,
+                                    interval,
+                                });
+                            }
+
+                            if (
+                                selectedParcelIndex !== null &&
+                                formState.parcels[selectedParcelIndex]
+                            ) {
+                                const parcel = formState.parcels[selectedParcelIndex];
+                                const range = getOpeningHoursForDate(new Date(parcel.pickupDate));
+                                const start = range?.openingTime || "09:00";
+                                const rawEnd = range?.closingTime || "17:00";
+                                const adjustedEnd = subtractMinutesFromHHmm(rawEnd, slotDuration);
+                                return getTimeRange({
+                                    startTime: start,
+                                    endTime: adjustedEnd,
+                                    interval,
+                                });
+                            }
+
+                            const adjusted = subtractMinutesFromHHmm("17:00", slotDuration);
+                            return getTimeRange({
+                                startTime: "09:00",
+                                endTime: adjusted,
+                                interval,
+                            });
+                        })()}
                         size="sm"
                         styles={{
                             control: {

--- a/messages/en.json
+++ b/messages/en.json
@@ -473,6 +473,12 @@
         "selectWeekday": "Select weekday",
         "openingTime": "Opening Time",
         "closingTime": "Closing Time",
+        "timeErrors": {
+            "openingRequired": "Opening time is required",
+            "closingRequired": "Closing time is required",
+            "openingBeforeClosing": "Opening must be before closing",
+            "closingAfterOpening": "Closing must be after opening"
+        },
         "actions": "Actions",
         "monday": "Monday",
         "tuesday": "Tuesday",

--- a/messages/en.json
+++ b/messages/en.json
@@ -181,6 +181,12 @@
         "setBulkTimes": "Set all times",
         "editingAllTimes": "Editing all times",
         "bulkTimeHint": "Set the same time for all food parcels, or cancel to edit individually.",
+        "bulk": {
+            "upcomingOnly": "applies to upcoming parcels only",
+            "notAvailableTitle": "Bulk change not available",
+            "notAvailableMsg": "Selected dates have different opening hours. Edit times per date.",
+            "notAvailableMsgWithSummary": "Selected dates have different opening hours: {summary}. Edit times per date."
+        },
         "individualTimeHint": "Click on the times to change pickup time for each individual food parcel.",
         "calendar": {
             "unavailableClosedDay": "Closed on this day",

--- a/messages/en.json
+++ b/messages/en.json
@@ -476,8 +476,7 @@
         "timeErrors": {
             "openingRequired": "Opening time is required",
             "closingRequired": "Closing time is required",
-            "openingBeforeClosing": "Opening must be before closing",
-            "closingAfterOpening": "Closing must be after opening"
+            "openingBeforeClosing": "Opening must be before closing"
         },
         "actions": "Actions",
         "monday": "Monday",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -470,6 +470,12 @@
         "selectWeekday": "Välj veckodag",
         "openingTime": "Öppningstid",
         "closingTime": "Stängningstid",
+        "timeErrors": {
+            "openingRequired": "Öppningstid krävs",
+            "closingRequired": "Stängningstid krävs",
+            "openingBeforeClosing": "Öppningstid måste vara före stängningstid",
+            "closingAfterOpening": "Stängningstid måste vara efter öppningstid"
+        },
         "actions": "Åtgärder",
         "monday": "Måndag",
         "tuesday": "Tisdag",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -178,6 +178,12 @@
         "setBulkTimes": "Sätt alla tider",
         "editingAllTimes": "Redigerar alla tider",
         "bulkTimeHint": "Ställ in samma tid för alla matkassar, eller avbryt för att redigera individuellt.",
+        "bulk": {
+            "upcomingOnly": "gäller endast kommande matkassar",
+            "notAvailableTitle": "Massändring ej tillgänglig",
+            "notAvailableMsg": "Valda datum har olika öppettider. Redigera tider per datum.",
+            "notAvailableMsgWithSummary": "Valda datum har olika öppettider: {summary}. Redigera tider per datum."
+        },
         "individualTimeHint": "Klicka på tiderna för att ändra upphämtningstid för varje enskild matkasse.",
         "calendar": {
             "unavailableClosedDay": "Stängt denna dag",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -473,8 +473,7 @@
         "timeErrors": {
             "openingRequired": "Öppningstid krävs",
             "closingRequired": "Stängningstid krävs",
-            "openingBeforeClosing": "Öppningstid måste vara före stängningstid",
-            "closingAfterOpening": "Stängningstid måste vara efter öppningstid"
+            "openingBeforeClosing": "Öppningstid måste vara före stängningstid"
         },
         "actions": "Åtgärder",
         "monday": "Måndag",


### PR DESCRIPTION
- Use shared utils (minutesToHHmm, normalizeToHHmm, subtractMinutesFromHHmm, generateTimeSlotsBetween)
- Refactor FoodParcelsForm, schedule/actions, WeeklyScheduleGrid, ReschedulePickupModal
- Update tests and en/sv messages