### PR TITLE
fix: pg_restore --list fails when piped

### DIFF
--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -62,7 +62,7 @@ PGPASS_FILE="/tmp/.pgpass"
 
 # Cleanup function for temporary files
 cleanup() {
-    rm -f "$PGPASS_FILE" "${VALIDATION_OUTPUT:-}" "${VALIDATION_ERRORS:-}"
+    rm -f "$PGPASS_FILE" "${VALIDATION_OUTPUT:-}" "${VALIDATION_ERRORS:-}" "${VALIDATION_FILE:-}"
 }
 
 # Ensure cleanup happens on exit
@@ -167,21 +167,35 @@ log "Validating backup integrity..."
 log "Validating backup by downloading and testing with pg_restore..."
 VALIDATION_OUTPUT=$(mktemp -t backup_validation.XXXXXX)
 VALIDATION_ERRORS=$(mktemp -t backup_errors.XXXXXX)
-chmod 600 "$VALIDATION_OUTPUT" "$VALIDATION_ERRORS"
-if rclone cat "$RCLONE_REMOTE/$BACKUP_FILENAME" --retries=2 | pg_restore --list > "$VALIDATION_OUTPUT" 2>"$VALIDATION_ERRORS"; then
-    # Check if backup file is valid by counting non-empty, non-comment lines
-    # This is more robust than keyword matching and works across PostgreSQL versions
-    CONTENT_LINES=$(grep -v '^$' "$VALIDATION_OUTPUT" | grep -v '^;' | wc -l)
-    if [ "$CONTENT_LINES" -gt 10 ]; then
-        log "Backup validation OK - file contains valid PostgreSQL data ($CONTENT_LINES entries)"
-        DRILL_STATUS="success"
+VALIDATION_FILE=$(mktemp -t backup_download.XXXXXX)
+chmod 600 "$VALIDATION_OUTPUT" "$VALIDATION_ERRORS" "$VALIDATION_FILE"
+
+# Download the backup file temporarily for validation
+# pg_restore --list needs to be able to seek through the file, which doesn't work with piped streams
+if rclone copy "$RCLONE_REMOTE/$BACKUP_FILENAME" "$(dirname "$VALIDATION_FILE")" --retries=2; then
+    mv "$(dirname "$VALIDATION_FILE")/$BACKUP_FILENAME" "$VALIDATION_FILE"
+    
+    if pg_restore --list "$VALIDATION_FILE" > "$VALIDATION_OUTPUT" 2>"$VALIDATION_ERRORS"; then
+        # Check if backup file is valid by counting non-empty, non-comment lines
+        # This is more robust than keyword matching and works across PostgreSQL versions
+        CONTENT_LINES=$(grep -v '^$' "$VALIDATION_OUTPUT" | grep -v '^;' | wc -l)
+        if [ "$CONTENT_LINES" -gt 10 ]; then
+            log "Backup validation OK - file contains valid PostgreSQL data ($CONTENT_LINES entries)"
+            DRILL_STATUS="success"
+        else
+            log "Backup validation FAILED - insufficient content in backup ($CONTENT_LINES entries, expected >10)"
+            DRILL_STATUS="failure"
+        fi
     else
-        log "Backup validation FAILED - insufficient content in backup ($CONTENT_LINES entries, expected >10)"
+        ERROR_MSG=$(head -n 3 "$VALIDATION_ERRORS" | tr '\n' ' ')
+        log "Backup validation FAILED - file appears corrupted or invalid: $ERROR_MSG"
         DRILL_STATUS="failure"
     fi
+    
+    # Clean up validation file
+    rm -f "$VALIDATION_FILE"
 else
-    ERROR_MSG=$(head -n 3 "$VALIDATION_ERRORS" | tr '\n' ' ')
-    log "Backup validation FAILED - file appears corrupted or invalid: $ERROR_MSG"
+    log "Backup validation FAILED - unable to download backup file for validation"
     DRILL_STATUS="failure"
 fi
 

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -172,9 +172,7 @@ chmod 600 "$VALIDATION_OUTPUT" "$VALIDATION_ERRORS" "$VALIDATION_FILE"
 
 # Download the backup file temporarily for validation
 # pg_restore --list needs to be able to seek through the file, which doesn't work with piped streams
-if rclone copy "$RCLONE_REMOTE/$BACKUP_FILENAME" "$(dirname "$VALIDATION_FILE")" --retries=2; then
-    mv "$(dirname "$VALIDATION_FILE")/$BACKUP_FILENAME" "$VALIDATION_FILE"
-    
+if rclone copyto "$RCLONE_REMOTE/$BACKUP_FILENAME" "$VALIDATION_FILE" --retries=2; then
     if pg_restore --list "$VALIDATION_FILE" > "$VALIDATION_OUTPUT" 2>"$VALIDATION_ERRORS"; then
         # Check if backup file is valid by counting non-empty, non-comment lines
         # This is more robust than keyword matching and works across PostgreSQL versions
@@ -191,9 +189,6 @@ if rclone copy "$RCLONE_REMOTE/$BACKUP_FILENAME" "$(dirname "$VALIDATION_FILE")"
         log "Backup validation FAILED - file appears corrupted or invalid: $ERROR_MSG"
         DRILL_STATUS="failure"
     fi
-    
-    # Clean up validation file
-    rm -f "$VALIDATION_FILE"
 else
     log "Backup validation FAILED - unable to download backup file for validation"
     DRILL_STATUS="failure"

--- a/test-backup-validation.sh
+++ b/test-backup-validation.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Quick test to verify pg_restore works with piped input vs file input
+# This demonstrates the issue we fixed
+
+set -euo pipefail
+
+echo "Testing pg_restore behavior with different input methods..."
+
+# Create a test database dump
+TEMP_DIR="/tmp/backup_test"
+mkdir -p "$TEMP_DIR"
+
+# We'll use a simple SQL script to create a test dump
+cat > "$TEMP_DIR/test.sql" << 'EOF'
+CREATE TABLE test_table (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(50)
+);
+INSERT INTO test_table (name) VALUES ('test1'), ('test2'), ('test3');
+EOF
+
+echo "Creating test dump file..."
+# Note: This test assumes you have PostgreSQL client tools installed
+# In production, this would be your actual pg_dump output
+pg_dump --file="$TEMP_DIR/test.dump" --format=custom --schema-only postgres 2>/dev/null || {
+    echo "Note: pg_dump not available for local testing, but the fix should work in production"
+    echo "The key issue was that pg_restore --list cannot work with piped input from rclone cat"
+    echo "The fix downloads the file temporarily for validation instead"
+    exit 0
+}
+
+echo "Testing pg_restore --list with file input (should work):"
+pg_restore --list "$TEMP_DIR/test.dump" | wc -l
+
+echo "Testing pg_restore --list with piped input (often fails):"
+cat "$TEMP_DIR/test.dump" | pg_restore --list 2>&1 | wc -l || echo "Failed as expected"
+
+echo "Cleanup..."
+rm -rf "$TEMP_DIR"
+
+echo "The backup script fix downloads the file temporarily for validation, which should resolve the issue."


### PR DESCRIPTION
pg_restore --list needs to be able to seek through the file (move back and forth within it), which is not possible with a stream/pipe. When pg_restore tries to seek in a piped stream, it fails and reports the file as corrupted.

Instead we do:
1. Download the backup file temporarily using rclone copy instead of rclone cat
2. Run pg_restore --list directly on the downloaded file instead of piping
3. Clean up the temporary file after validation

This allows pg_restore to properly seek through the file and validate its structure.