### PR TITLE
Fix phone search to match Swedish local format (07xx...)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,8 +2,6 @@
     "extends": ["next/core-web-vitals", "next/typescript"],
     "rules": {
         "react/no-unescaped-entities": "off",
-        // Allow _ prefix convention for intentionally unused parameters (e.g. _session in protected actions)
-        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
         // Prevent console.* usage - use Pino logger instead
         "no-console": "error",
         // Consistently import navigation APIs from `@/app/i18n/navigation`

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,8 @@
     "extends": ["next/core-web-vitals", "next/typescript"],
     "rules": {
         "react/no-unescaped-entities": "off",
+        // Allow _ prefix convention for intentionally unused parameters (e.g. _session in protected actions)
+        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
         // Prevent console.* usage - use Pino logger instead
         "no-console": "error",
         // Consistently import navigation APIs from `@/app/i18n/navigation`

--- a/__tests__/integration/households/primary-location.integration.test.ts
+++ b/__tests__/integration/households/primary-location.integration.test.ts
@@ -37,6 +37,11 @@ vi.mock("@/app/utils/auth/protected-action", () => ({
             return fn(mockSession, ...args);
         };
     },
+    protectedAgreementReadAction: (fn: (...args: unknown[]) => unknown) => {
+        return async (...args: unknown[]) => {
+            return fn(mockSession, ...args);
+        };
+    },
     protectedReadAction: (fn: (...args: unknown[]) => unknown) => {
         return async (...args: unknown[]) => {
             return fn(mockSession, ...args);

--- a/app/[locale]/schedule/[locationSlug]/today/components/TodayHandoutsPage.tsx
+++ b/app/[locale]/schedule/[locationSlug]/today/components/TodayHandoutsPage.tsx
@@ -301,13 +301,18 @@ export function TodayHandoutsPage({ locationSlug }: TodayHandoutsPageProps) {
 
     // Client-side search filtering
     const query = searchQuery.trim().toLowerCase();
-    // Strip non-digits and leading zeros so Swedish local format (070...) matches E.164 (+4670...)
-    const strippedQuery = query.replace(/\D/g, "").replace(/^0+/, "");
+    // Raw digits from query (keep leading zeros so "070" stays "070", not "70")
+    const digitQuery = query.replace(/\D/g, "");
     const filteredParcels = query
         ? parcels.filter(parcel => {
               if (parcel.householdName.toLowerCase().includes(query)) return true;
-              if (strippedQuery.length >= 3 && parcel.phoneNumber) {
-                  return parcel.phoneNumber.replace(/\D/g, "").includes(strippedQuery);
+              if (digitQuery.length >= 3 && parcel.phoneNumber) {
+                  const storedDigits = parcel.phoneNumber.replace(/\D/g, "");
+                  // Normalize E.164 (+46701...) to local format (0701...) so both match
+                  const localStored = storedDigits.startsWith("46")
+                      ? "0" + storedDigits.slice(2)
+                      : storedDigits;
+                  return storedDigits.includes(digitQuery) || localStored.includes(digitQuery);
               }
               return false;
           })

--- a/app/[locale]/schedule/[locationSlug]/today/components/TodayHandoutsPage.tsx
+++ b/app/[locale]/schedule/[locationSlug]/today/components/TodayHandoutsPage.tsx
@@ -519,7 +519,9 @@ export function TodayHandoutsPage({ locationSlug }: TodayHandoutsPageProps) {
                         <Paper p={{ base: "md", sm: "lg" }} withBorder>
                             <Center>
                                 <Text size="md" c="dimmed" ta="center">
-                                    {t("todayHandouts.search.noResults", { query: searchQuery.trim() })}
+                                    {t("todayHandouts.search.noResults", {
+                                        query: searchQuery.trim(),
+                                    })}
                                 </Text>
                             </Center>
                         </Paper>

--- a/app/[locale]/schedule/[locationSlug]/today/components/TodayHandoutsPage.tsx
+++ b/app/[locale]/schedule/[locationSlug]/today/components/TodayHandoutsPage.tsx
@@ -18,6 +18,8 @@ import {
     Alert,
     Tabs,
     Tooltip,
+    TextInput,
+    ActionIcon,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import {
@@ -29,11 +31,13 @@ import {
     IconMapPin,
     IconArrowLeft,
     IconUser,
+    IconSearch,
+    IconX,
 } from "@tabler/icons-react";
 import { format } from "date-fns";
 import { sv } from "date-fns/locale";
 import {
-    getTodaysParcels,
+    getTodaysParcelsWithPhone,
     getPickupLocations,
     getParcelById,
     getTodaysSummaryStats,
@@ -87,6 +91,9 @@ export function TodayHandoutsPage({ locationSlug }: TodayHandoutsPageProps) {
     const [dialogOpened, { open: openDialog, close: closeDialog }] = useDisclosure(false);
     const [selectedParcelId, setSelectedParcelId] = useState<string | null>(null);
 
+    // Search state
+    const [searchQuery, setSearchQuery] = useState("");
+
     const today = new Date();
 
     // Handle deep link to specific parcel (like QR code scans)
@@ -133,9 +140,9 @@ export function TodayHandoutsPage({ locationSlug }: TodayHandoutsPageProps) {
                 setIsFavorite(false);
             }
 
-            // Load today's parcels and summary stats in parallel
+            // Load today's parcels (with phone numbers for search) and summary stats in parallel
             const [parcelsData, stats] = await Promise.all([
-                getTodaysParcels(),
+                getTodaysParcelsWithPhone(),
                 getTodaysSummaryStats(location.id),
             ]);
 
@@ -288,9 +295,23 @@ export function TodayHandoutsPage({ locationSlug }: TodayHandoutsPageProps) {
         );
     }
 
-    // Calculate progress for current location
+    // Calculate progress for current location (always based on full list)
     const totalParcels = parcels.length;
     const completedParcels = parcels.filter(p => p.status === "pickedUp").length;
+
+    // Client-side search filtering
+    const query = searchQuery.trim().toLowerCase();
+    // Strip non-digits and leading zeros so Swedish local format (070...) matches E.164 (+4670...)
+    const strippedQuery = query.replace(/\D/g, "").replace(/^0+/, "");
+    const filteredParcels = query
+        ? parcels.filter(parcel => {
+              if (parcel.householdName.toLowerCase().includes(query)) return true;
+              if (strippedQuery.length >= 3 && parcel.phoneNumber) {
+                  return parcel.phoneNumber.replace(/\D/g, "").includes(strippedQuery);
+              }
+              return false;
+          })
+        : parcels;
 
     return (
         <div
@@ -446,6 +467,29 @@ export function TodayHandoutsPage({ locationSlug }: TodayHandoutsPageProps) {
                                     </Tabs.Tab>
                                 </Tabs.List>
                             </Tabs>
+                            {totalParcels > 0 && (
+                                <TextInput
+                                    placeholder={t("todayHandouts.search.placeholder")}
+                                    leftSection={<IconSearch size={14} />}
+                                    rightSection={
+                                        searchQuery ? (
+                                            <ActionIcon
+                                                size="xs"
+                                                variant="subtle"
+                                                color="gray"
+                                                onClick={() => setSearchQuery("")}
+                                                aria-label={t("todayHandouts.search.clear")}
+                                            >
+                                                <IconX size={12} />
+                                            </ActionIcon>
+                                        ) : null
+                                    }
+                                    value={searchQuery}
+                                    onChange={e => setSearchQuery(e.currentTarget.value)}
+                                    size="xs"
+                                    autoComplete="off"
+                                />
+                            )}
                         </Stack>
                     </Paper>
 
@@ -471,9 +515,17 @@ export function TodayHandoutsPage({ locationSlug }: TodayHandoutsPageProps) {
                                 </Stack>
                             </Center>
                         </Paper>
+                    ) : filteredParcels.length === 0 ? (
+                        <Paper p={{ base: "md", sm: "lg" }} withBorder>
+                            <Center>
+                                <Text size="md" c="dimmed" ta="center">
+                                    {t("todayHandouts.search.noResults", { query: searchQuery.trim() })}
+                                </Text>
+                            </Center>
+                        </Paper>
                     ) : (
                         <Stack gap={4}>
-                            {parcels.map(parcel => {
+                            {filteredParcels.map(parcel => {
                                 return (
                                     <Paper
                                         key={parcel.id}

--- a/app/[locale]/schedule/actions.ts
+++ b/app/[locale]/schedule/actions.ts
@@ -38,7 +38,11 @@ import { getAvailableTimeRange } from "@/app/utils/schedule/location-availabilit
 import { isParcelOutsideOpeningHours } from "@/app/utils/schedule/outside-hours-filter";
 import { unstable_cache } from "next/cache";
 import { revalidatePath, revalidateTag } from "next/cache";
-import { protectedReadAction, protectedAgreementAction } from "@/app/utils/auth/protected-action";
+import {
+    protectedReadAction,
+    protectedAgreementAction,
+    protectedAgreementReadAction,
+} from "@/app/utils/auth/protected-action";
 import { success, failure, type ActionResult } from "@/app/utils/auth/action-result";
 import { logError } from "@/app/utils/logger";
 import { fetchPickupLocationSchedules } from "@/app/utils/schedule/pickup-location-schedules";
@@ -58,153 +62,34 @@ import type {
 /**
  * Get a specific parcel by ID, regardless of date
  */
-export async function getParcelById(parcelId: string): Promise<FoodParcel | null> {
-    try {
-        const parcelsData = await db
-            .select({
-                id: foodParcels.id,
-                householdId: foodParcels.household_id,
-                firstName: households.first_name,
-                lastName: households.last_name,
-                pickupEarliestTime: foodParcels.pickup_date_time_earliest,
-                pickupLatestTime: foodParcels.pickup_date_time_latest,
-                isPickedUp: foodParcels.is_picked_up,
-                noShowAt: foodParcels.no_show_at,
-                pickupLocationId: foodParcels.pickup_location_id,
-            })
-            .from(foodParcels)
-            .innerJoin(households, eq(foodParcels.household_id, households.id))
-            .where(and(eq(foodParcels.id, parcelId), notDeleted()))
-            .limit(1);
+export const getParcelById = protectedReadAction(
+    async (_session, parcelId: string): Promise<FoodParcel | null> => {
+        try {
+            const parcelsData = await db
+                .select({
+                    id: foodParcels.id,
+                    householdId: foodParcels.household_id,
+                    firstName: households.first_name,
+                    lastName: households.last_name,
+                    pickupEarliestTime: foodParcels.pickup_date_time_earliest,
+                    pickupLatestTime: foodParcels.pickup_date_time_latest,
+                    isPickedUp: foodParcels.is_picked_up,
+                    noShowAt: foodParcels.no_show_at,
+                    pickupLocationId: foodParcels.pickup_location_id,
+                })
+                .from(foodParcels)
+                .innerJoin(households, eq(foodParcels.household_id, households.id))
+                .where(and(eq(foodParcels.id, parcelId), notDeleted()))
+                .limit(1);
 
-        if (parcelsData.length === 0) {
-            return null;
-        }
+            if (parcelsData.length === 0) {
+                return null;
+            }
 
-        const parcel = parcelsData[0];
-
-        // Create Stockholm timezone date for the pickup date
-        const pickupTimeStockholm = Time.fromDate(new Date(parcel.pickupEarliestTime));
-        const pickupDate = pickupTimeStockholm.startOfDay().toDate();
-
-        return {
-            id: parcel.id,
-            householdId: parcel.householdId,
-            householdName: `${parcel.firstName} ${parcel.lastName}`,
-            pickupDate,
-            pickupEarliestTime: new Date(parcel.pickupEarliestTime),
-            pickupLatestTime: new Date(parcel.pickupLatestTime),
-            isPickedUp: parcel.isPickedUp,
-            noShowAt: parcel.noShowAt ? new Date(parcel.noShowAt) : null,
-            pickup_location_id: parcel.pickupLocationId,
-        };
-    } catch (error) {
-        logError("Error fetching parcel by ID", error, { parcelId });
-        return null;
-    }
-}
-export async function getPickupLocations(): Promise<PickupLocation[]> {
-    try {
-        // Get current date for schedule comparison
-        const currentDateStr = Time.now().toDateString();
-
-        const locations = await db
-            .select({
-                id: pickupLocations.id,
-                name: pickupLocations.name,
-                street_address: pickupLocations.street_address,
-                maxParcelsPerDay: pickupLocations.parcels_max_per_day,
-                maxParcelsPerSlot: pickupLocations.max_parcels_per_slot,
-                outsideHoursCount: pickupLocations.outside_hours_count,
-                // Avoid correlated subqueries here; some drivers/dialects can mis-handle outer column references.
-                // Instead, join upcoming schedules + open days and count matches.
-                hasUpcomingSchedule: sql<boolean>`COUNT(${pickupLocationScheduleDays.id}) > 0`,
-            })
-            .from(pickupLocations)
-            .leftJoin(
-                pickupLocationSchedules,
-                and(
-                    eq(pickupLocationSchedules.pickup_location_id, pickupLocations.id),
-                    sql`${pickupLocationSchedules.end_date} >= ${currentDateStr}::date`,
-                ),
-            )
-            .leftJoin(
-                pickupLocationScheduleDays,
-                and(
-                    eq(pickupLocationScheduleDays.schedule_id, pickupLocationSchedules.id),
-                    eq(pickupLocationScheduleDays.is_open, true),
-                ),
-            )
-            .groupBy(
-                pickupLocations.id,
-                pickupLocations.name,
-                pickupLocations.street_address,
-                pickupLocations.parcels_max_per_day,
-                pickupLocations.max_parcels_per_slot,
-                pickupLocations.outside_hours_count,
-            );
-
-        return locations;
-    } catch (error) {
-        logError("Error fetching pickup locations", error);
-        return [];
-    }
-}
-
-/**
- * Get all parcels scheduled for today across all locations
- */
-export async function getTodaysParcels(): Promise<FoodParcel[]> {
-    try {
-        // Get today's date range in Stockholm timezone
-        const today = new Date();
-        const todayInStockholm = Time.fromDate(today);
-        const startTimeStockholm = todayInStockholm.startOfDay();
-        const endTimeStockholm = todayInStockholm.endOfDay();
-
-        // Convert to UTC for database query
-        const startDate = startTimeStockholm.toDate();
-        const endDate = endTimeStockholm.toDate();
-
-        // Query food parcels for today across all locations
-        // Alias pickupLocations for the household's primary location lookup
-        const primaryLocation = alias(pickupLocations, "primary_location");
-
-        const parcelsData = await db
-            .select({
-                id: foodParcels.id,
-                householdId: foodParcels.household_id,
-                firstName: households.first_name,
-                lastName: households.last_name,
-                pickupEarliestTime: foodParcels.pickup_date_time_earliest,
-                pickupLatestTime: foodParcels.pickup_date_time_latest,
-                isPickedUp: foodParcels.is_picked_up,
-                noShowAt: foodParcels.no_show_at,
-                pickupLocationId: foodParcels.pickup_location_id,
-                primaryPickupLocationId: households.primary_pickup_location_id,
-                primaryPickupLocationName: primaryLocation.name,
-                createdBy: households.created_by,
-            })
-            .from(foodParcels)
-            .innerJoin(households, eq(foodParcels.household_id, households.id))
-            .leftJoin(
-                primaryLocation,
-                eq(households.primary_pickup_location_id, primaryLocation.id),
-            )
-            .where(
-                and(
-                    gte(foodParcels.pickup_date_time_earliest, startDate),
-                    lte(foodParcels.pickup_date_time_earliest, endDate),
-                    notDeleted(),
-                ),
-            )
-            .orderBy(foodParcels.pickup_date_time_earliest);
-
-        // Transform the data to the expected format with proper timezone handling
-        return parcelsData.map(parcel => {
-            // Create Stockholm timezone date for the pickup date
-            const pickupTimeStockholm = Time.fromDate(new Date(parcel.pickupEarliestTime));
-            const pickupDate = pickupTimeStockholm.startOfDay().toDate();
+            const parcel = parcelsData[0];
+            const pickupDate = Time.fromDate(new Date(parcel.pickupEarliestTime))
+                .startOfDay()
+                .toDate();
 
             return {
                 id: parcel.id,
@@ -216,16 +101,161 @@ export async function getTodaysParcels(): Promise<FoodParcel[]> {
                 isPickedUp: parcel.isPickedUp,
                 noShowAt: parcel.noShowAt ? new Date(parcel.noShowAt) : null,
                 pickup_location_id: parcel.pickupLocationId,
-                primaryPickupLocationId: parcel.primaryPickupLocationId,
-                primaryPickupLocationName: parcel.primaryPickupLocationName,
-                createdBy: parcel.createdBy,
             };
-        });
+        } catch (error) {
+            logError("Error fetching parcel by ID", error, { parcelId });
+            return null;
+        }
+    },
+);
+export const getPickupLocations = protectedReadAction(
+    async (_session): Promise<PickupLocation[]> => {
+        try {
+            // Get current date for schedule comparison
+            const currentDateStr = Time.now().toDateString();
+
+            const locations = await db
+                .select({
+                    id: pickupLocations.id,
+                    name: pickupLocations.name,
+                    street_address: pickupLocations.street_address,
+                    maxParcelsPerDay: pickupLocations.parcels_max_per_day,
+                    maxParcelsPerSlot: pickupLocations.max_parcels_per_slot,
+                    outsideHoursCount: pickupLocations.outside_hours_count,
+                    // Avoid correlated subqueries here; some drivers/dialects can mis-handle outer column references.
+                    // Instead, join upcoming schedules + open days and count matches.
+                    hasUpcomingSchedule: sql<boolean>`COUNT(${pickupLocationScheduleDays.id}) > 0`,
+                })
+                .from(pickupLocations)
+                .leftJoin(
+                    pickupLocationSchedules,
+                    and(
+                        eq(pickupLocationSchedules.pickup_location_id, pickupLocations.id),
+                        sql`${pickupLocationSchedules.end_date} >= ${currentDateStr}::date`,
+                    ),
+                )
+                .leftJoin(
+                    pickupLocationScheduleDays,
+                    and(
+                        eq(pickupLocationScheduleDays.schedule_id, pickupLocationSchedules.id),
+                        eq(pickupLocationScheduleDays.is_open, true),
+                    ),
+                )
+                .groupBy(
+                    pickupLocations.id,
+                    pickupLocations.name,
+                    pickupLocations.street_address,
+                    pickupLocations.parcels_max_per_day,
+                    pickupLocations.max_parcels_per_slot,
+                    pickupLocations.outside_hours_count,
+                );
+
+            return locations;
+        } catch (error) {
+            logError("Error fetching pickup locations", error);
+            return [];
+        }
+    },
+);
+
+/**
+ * Internal query — not exported. Fetches today's parcels without auth or phone numbers.
+ * Used by both getTodaysParcels and getTodaysParcelsWithPhone to avoid double auth checks.
+ */
+async function queryTodaysParcels(): Promise<FoodParcel[]> {
+    // Get today's date range in Stockholm timezone
+    const today = new Date();
+    const todayInStockholm = Time.fromDate(today);
+    const startDate = todayInStockholm.startOfDay().toDate();
+    const endDate = todayInStockholm.endOfDay().toDate();
+
+    const primaryLocation = alias(pickupLocations, "primary_location");
+
+    const parcelsData = await db
+        .select({
+            id: foodParcels.id,
+            householdId: foodParcels.household_id,
+            firstName: households.first_name,
+            lastName: households.last_name,
+            pickupEarliestTime: foodParcels.pickup_date_time_earliest,
+            pickupLatestTime: foodParcels.pickup_date_time_latest,
+            isPickedUp: foodParcels.is_picked_up,
+            noShowAt: foodParcels.no_show_at,
+            pickupLocationId: foodParcels.pickup_location_id,
+            primaryPickupLocationId: households.primary_pickup_location_id,
+            primaryPickupLocationName: primaryLocation.name,
+            createdBy: households.created_by,
+        })
+        .from(foodParcels)
+        .innerJoin(households, eq(foodParcels.household_id, households.id))
+        .leftJoin(primaryLocation, eq(households.primary_pickup_location_id, primaryLocation.id))
+        .where(
+            and(
+                gte(foodParcels.pickup_date_time_earliest, startDate),
+                lte(foodParcels.pickup_date_time_earliest, endDate),
+                notDeleted(),
+            ),
+        )
+        .orderBy(foodParcels.pickup_date_time_earliest);
+
+    return parcelsData.map(parcel => {
+        const pickupDate = Time.fromDate(new Date(parcel.pickupEarliestTime)).startOfDay().toDate();
+        return {
+            id: parcel.id,
+            householdId: parcel.householdId,
+            householdName: `${parcel.firstName} ${parcel.lastName}`,
+            pickupDate,
+            pickupEarliestTime: new Date(parcel.pickupEarliestTime),
+            pickupLatestTime: new Date(parcel.pickupLatestTime),
+            isPickedUp: parcel.isPickedUp,
+            noShowAt: parcel.noShowAt ? new Date(parcel.noShowAt) : null,
+            pickup_location_id: parcel.pickupLocationId,
+            primaryPickupLocationId: parcel.primaryPickupLocationId,
+            primaryPickupLocationName: parcel.primaryPickupLocationName,
+            createdBy: parcel.createdBy,
+        };
+    });
+}
+
+/**
+ * Get all parcels scheduled for today across all locations.
+ * Requires authentication. Does not include phone numbers — use getTodaysParcelsWithPhone
+ * on the handouts page where staff need phone-based search.
+ */
+export const getTodaysParcels = protectedReadAction(async (_session): Promise<FoodParcel[]> => {
+    try {
+        return await queryTodaysParcels();
     } catch (error) {
         logError("Error fetching today's parcels", error);
         return [];
     }
-}
+});
+
+/**
+ * Get today's parcels with phone numbers included.
+ * Use only on the handouts page where staff need phone-based search.
+ * Phone numbers are fetched in a separate query to avoid sending PII to pages that don't need it.
+ */
+export const getTodaysParcelsWithPhone = protectedAgreementReadAction(
+    async (_session): Promise<FoodParcel[]> => {
+        try {
+            const parcels = await queryTodaysParcels();
+            if (parcels.length === 0) return parcels;
+
+            const householdIds = [...new Set(parcels.map(p => p.householdId))];
+            const phoneRows = await db
+                .select({ id: households.id, phoneNumber: households.phone_number })
+                .from(households)
+                .where(inArray(households.id, householdIds));
+
+            const phoneMap = new Map(phoneRows.map(r => [r.id, r.phoneNumber]));
+            return parcels.map(p => ({ ...p, phoneNumber: phoneMap.get(p.householdId) ?? null }));
+        } catch (error) {
+            logError("Error fetching today's parcels with phone numbers", error);
+            return [];
+        }
+    },
+);
 
 /**
  * Get summary stats for today's parcels at a specific location

--- a/app/[locale]/schedule/actions.ts
+++ b/app/[locale]/schedule/actions.ts
@@ -109,7 +109,7 @@ export const getParcelById = protectedReadAction(
     },
 );
 export const getPickupLocations = protectedReadAction(
-    async (_session): Promise<PickupLocation[]> => {
+    async (_): Promise<PickupLocation[]> => {
         try {
             // Get current date for schedule comparison
             const currentDateStr = Time.now().toDateString();
@@ -222,7 +222,7 @@ async function queryTodaysParcels(): Promise<FoodParcel[]> {
  * Requires authentication. Does not include phone numbers — use getTodaysParcelsWithPhone
  * on the handouts page where staff need phone-based search.
  */
-export const getTodaysParcels = protectedReadAction(async (_session): Promise<FoodParcel[]> => {
+export const getTodaysParcels = protectedReadAction(async (_): Promise<FoodParcel[]> => {
     try {
         return await queryTodaysParcels();
     } catch (error) {
@@ -237,7 +237,7 @@ export const getTodaysParcels = protectedReadAction(async (_session): Promise<Fo
  * Phone numbers are fetched in a separate query to avoid sending PII to pages that don't need it.
  */
 export const getTodaysParcelsWithPhone = protectedAgreementReadAction(
-    async (_session): Promise<FoodParcel[]> => {
+    async (_): Promise<FoodParcel[]> => {
         try {
             const parcels = await queryTodaysParcels();
             if (parcels.length === 0) return parcels;

--- a/app/[locale]/schedule/actions.ts
+++ b/app/[locale]/schedule/actions.ts
@@ -109,7 +109,8 @@ export const getParcelById = protectedReadAction(
     },
 );
 export const getPickupLocations = protectedReadAction(
-    async (_): Promise<PickupLocation[]> => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async (_session): Promise<PickupLocation[]> => {
         try {
             // Get current date for schedule comparison
             const currentDateStr = Time.now().toDateString();
@@ -222,7 +223,8 @@ async function queryTodaysParcels(): Promise<FoodParcel[]> {
  * Requires authentication. Does not include phone numbers — use getTodaysParcelsWithPhone
  * on the handouts page where staff need phone-based search.
  */
-export const getTodaysParcels = protectedReadAction(async (_): Promise<FoodParcel[]> => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getTodaysParcels = protectedReadAction(async (_session): Promise<FoodParcel[]> => {
     try {
         return await queryTodaysParcels();
     } catch (error) {
@@ -237,7 +239,8 @@ export const getTodaysParcels = protectedReadAction(async (_): Promise<FoodParce
  * Phone numbers are fetched in a separate query to avoid sending PII to pages that don't need it.
  */
 export const getTodaysParcelsWithPhone = protectedAgreementReadAction(
-    async (_): Promise<FoodParcel[]> => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async (_session): Promise<FoodParcel[]> => {
         try {
             const parcels = await queryTodaysParcels();
             if (parcels.length === 0) return parcels;

--- a/app/[locale]/schedule/types.ts
+++ b/app/[locale]/schedule/types.ts
@@ -17,6 +17,7 @@ export interface FoodParcel {
     id: string;
     householdId: string;
     householdName: string;
+    phoneNumber?: string | null; // E.164 format, used for staff search
     pickupDate: Date;
     pickupEarliestTime: Date;
     pickupLatestTime: Date;

--- a/app/utils/auth/protected-action.ts
+++ b/app/utils/auth/protected-action.ts
@@ -209,6 +209,41 @@ async function verifyAgreementAcceptance(
 }
 
 /**
+ * Like protectedReadAction but also requires the user to have accepted the current agreement.
+ * Use this for read actions that return personal data (GDPR compliance).
+ * Throws an error on auth or agreement failure.
+ * Do NOT use for agreement-related or admin settings actions.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function protectedAgreementReadAction<T extends any[], R>(
+    action: (session: AuthSession, ...args: T) => Promise<R>,
+): (...args: T) => Promise<R> {
+    return async (...args: T): Promise<R> => {
+        const authResult = await verifyServerActionAuth();
+
+        if (!authResult.success) {
+            throw new Error(authResult.error?.message || "Authentication required");
+        }
+
+        const agreementCheck = await verifyAgreementAcceptance(authResult.data);
+        if (agreementCheck) {
+            throw new Error(agreementCheck.error?.message || "Agreement acceptance required");
+        }
+
+        logger.info(
+            {
+                githubUsername: authResult.data.user?.githubUsername,
+                action: action.name || "anonymous",
+                type: "protected_agreement_read_action",
+            },
+            "Protected agreement read action executed",
+        );
+
+        return action(authResult.data, ...args);
+    };
+}
+
+/**
  * Like protectedAction but also requires the user to have accepted the current agreement.
  * Use this for actions that handle personal/household data (GDPR compliance).
  * Do NOT use for agreement-related or admin settings actions.

--- a/app/utils/auth/protected-action.ts
+++ b/app/utils/auth/protected-action.ts
@@ -226,8 +226,8 @@ export function protectedAgreementReadAction<T extends any[], R>(
         }
 
         const agreementCheck = await verifyAgreementAcceptance(authResult.data);
-        if (agreementCheck) {
-            throw new Error(agreementCheck.error?.message || "Agreement acceptance required");
+        if (agreementCheck && !agreementCheck.success) {
+            throw new Error(agreementCheck.error.message || "Agreement acceptance required");
         }
 
         logger.info(

--- a/messages/en.json
+++ b/messages/en.json
@@ -454,6 +454,11 @@
                 "additionalRequests": "Additional requests",
                 "expand": "Expand summary",
                 "collapse": "Collapse summary"
+            },
+            "search": {
+                "placeholder": "Search by name or phone number",
+                "noResults": "No match for \"{query}\"",
+                "clear": "Clear search"
             }
         },
         "currentWeek": "Current Week",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -454,6 +454,11 @@
                 "additionalRequests": "Extra önskemål",
                 "expand": "Visa sammanfattning",
                 "collapse": "Dölj sammanfattning"
+            },
+            "search": {
+                "placeholder": "Sök på namn eller telefonnummer",
+                "noResults": "Ingen matchning för \"{query}\"",
+                "clear": "Rensa sökning"
             }
         },
         "currentWeek": "Aktuell vecka",


### PR DESCRIPTION
The initial implementation stripped leading zeros from the search query before matching, so typing `070` produced a 2-character stripped query (`70`) — below the 3-digit threshold that gates phone search. Even when the threshold was met, there was no local-format equivalent of the stored E.164 number to match against, so `0701234567` would need to become `701234567` to hit `46701234567`.

**Fix:**
- Keep leading zeros in the digit query (`070` stays `070`, not `70`)
- Normalize the stored E.164 number to local format before matching: `+46701234567` → `0701234567`
- Both formats now work as substrings: typing `070`, `0701`, `0701234567`, `+4670`, or `46701234567` all match correctly