### PR TITLE
Improve logging and alerting for better debugging

### DIFF
--- a/app/api/webhooks/sms-status/handler.ts
+++ b/app/api/webhooks/sms-status/handler.ts
@@ -87,19 +87,13 @@ export async function handleSmsStatusCallback(
             path: logPath,
         });
 
-        // Alert to Slack so webhook processing failures are visible
+        // Alert to Slack so webhook processing failures are visible.
+        // Uses state-transition pattern to avoid flooding Slack during a DB outage.
         import("@/app/utils/notifications/slack")
-            .then(({ sendSlackAlert }) =>
-                sendSlackAlert({
-                    title: "SMS Webhook Processing Error",
-                    message:
-                        "Failed to process an SMS status callback from HelloSMS. " +
-                        "Delivery status for this message may be stale until reconciliation runs.",
-                    status: "error",
-                    details: {
-                        Error: error instanceof Error ? error.message : String(error),
-                        Path: logPath,
-                    },
+            .then(({ sendSmsHealthAlert }) =>
+                sendSmsHealthAlert(false, {
+                    error: error instanceof Error ? error.message : String(error),
+                    component: "sms-webhook",
                 }),
             )
             .catch(err => logError("Failed to send webhook error Slack alert", err));

--- a/app/api/webhooks/sms-status/handler.ts
+++ b/app/api/webhooks/sms-status/handler.ts
@@ -87,6 +87,23 @@ export async function handleSmsStatusCallback(
             path: logPath,
         });
 
+        // Alert to Slack so webhook processing failures are visible
+        import("@/app/utils/notifications/slack")
+            .then(({ sendSlackAlert }) =>
+                sendSlackAlert({
+                    title: "SMS Webhook Processing Error",
+                    message:
+                        "Failed to process an SMS status callback from HelloSMS. " +
+                        "Delivery status for this message may be stale until reconciliation runs.",
+                    status: "error",
+                    details: {
+                        Error: error instanceof Error ? error.message : String(error),
+                        Path: logPath,
+                    },
+                }),
+            )
+            .catch(err => logError("Failed to send webhook error Slack alert", err));
+
         // Return 200 even on errors to prevent HelloSMS from retrying
         return NextResponse.json(
             { received: true, error: "Processing failed but acknowledged" },

--- a/app/utils/logger.js
+++ b/app/utils/logger.js
@@ -23,6 +23,9 @@ if (isServer) {
                 return { level: label.toUpperCase() };
             },
         },
+        serializers: {
+            err: pino.stdSerializers.err,
+        },
         timestamp: pino.stdTimeFunctions.isoTime,
     };
 
@@ -74,13 +77,10 @@ function createLogger(context) {
  * logError('Failed to process SMS', error, { parcelId: '123', userId: 'abc' })
  */
 function logError(message, error, context) {
-    const errorInfo =
-        error instanceof Error ? { error: error.message, stack: error.stack } : { error };
-
     logger.error(
         {
             ...context,
-            ...errorInfo,
+            err: error instanceof Error ? error : new Error(String(error)),
         },
         message,
     );
@@ -91,17 +91,10 @@ function logError(message, error, context) {
  * Use this sparingly for issues that need investigation
  */
 function logCritical(message, error, context) {
-    const errorInfo =
-        error instanceof Error
-            ? { error: error.message, stack: error.stack }
-            : error
-              ? { error }
-              : {};
-
     logger.fatal(
         {
             ...context,
-            ...errorInfo,
+            ...(error ? { err: error instanceof Error ? error : new Error(String(error)) } : {}),
         },
         message,
     );

--- a/app/utils/logger.js
+++ b/app/utils/logger.js
@@ -77,10 +77,15 @@ function createLogger(context) {
  * logError('Failed to process SMS', error, { parcelId: '123', userId: 'abc' })
  */
 function logError(message, error, context) {
+    // Use `err` for real Error objects (Pino's stdSerializers.err preserves cause, code, stack).
+    // Keep non-Error values as raw `error` field to avoid wrapping strings/objects
+    // in synthetic Error instances that lose the original value.
+    const errorField = error instanceof Error ? { err: error } : { error };
+
     logger.error(
         {
             ...context,
-            err: error instanceof Error ? error : new Error(String(error)),
+            ...errorField,
         },
         message,
     );
@@ -91,10 +96,12 @@ function logError(message, error, context) {
  * Use this sparingly for issues that need investigation
  */
 function logCritical(message, error, context) {
+    const errorField = error ? (error instanceof Error ? { err: error } : { error }) : {};
+
     logger.fatal(
         {
             ...context,
-            ...(error ? { err: error instanceof Error ? error : new Error(String(error)) } : {}),
+            ...errorField,
         },
         message,
     );

--- a/app/utils/scheduler.ts
+++ b/app/utils/scheduler.ts
@@ -140,8 +140,13 @@ async function processSmsJIT(): Promise<{ processed: number }> {
 
     if (credits === 0) {
         logger.warn("SMS balance is zero - fail-fasting all eligible SMS as balance failures");
-        sendInsufficientBalanceSlackAlert().catch(err =>
+        sendInsufficientBalanceSlackAlert(0).catch(err =>
             logError("Failed to send balance Slack alert", err),
+        );
+    } else if (credits !== null && credits < 100) {
+        logger.warn({ credits }, "SMS balance is low");
+        sendInsufficientBalanceSlackAlert(credits).catch(err =>
+            logError("Failed to send low balance Slack alert", err),
         );
     }
 
@@ -430,6 +435,9 @@ async function runOrgMembershipSync(): Promise<{
 
         logCron("org-membership-sync", "started", { totalUsers: activeUsers.length, organization });
 
+        // Phase 1: Check membership for all users, collecting non-members
+        const toDeactivate: string[] = [];
+
         for (let i = 0; i < activeUsers.length; i++) {
             const user = activeUsers[i];
             try {
@@ -439,21 +447,7 @@ async function runOrgMembershipSync(): Promise<{
                 );
 
                 if (!isMember) {
-                    // Definitive non-membership — deactivate, preserving first timestamp
-                    await db
-                        .update(users)
-                        .set({ deactivated_at: new Date() })
-                        .where(
-                            and(
-                                eq(users.github_username, user.github_username),
-                                isNull(users.deactivated_at),
-                            ),
-                        );
-                    deactivated++;
-                    logger.info(
-                        { username: user.github_username },
-                        "User deactivated: no longer in GitHub org",
-                    );
+                    toDeactivate.push(user.github_username);
                 }
             } catch (err) {
                 // API error — skip this user, never deactivate on ambiguous result
@@ -469,6 +463,33 @@ async function runOrgMembershipSync(): Promise<{
             // Skipped after the last user — no subsequent call to throttle.
             if (i < activeUsers.length - 1) {
                 await new Promise(resolve => setTimeout(resolve, 1000));
+            }
+        }
+
+        // Phase 2: Safety guard — abort if deactivation count looks like misconfiguration.
+        // >50% AND >2 users would be deactivated → likely a config or API issue, not real churn.
+        if (
+            toDeactivate.length > 2 &&
+            activeUsers.length > 0 &&
+            toDeactivate.length / activeUsers.length > 0.5
+        ) {
+            const pct = Math.round((toDeactivate.length / activeUsers.length) * 100);
+            logger.error(
+                { toDeactivate: toDeactivate.length, totalActive: activeUsers.length, pct },
+                "Org sync aborted: too many deactivations, possible misconfiguration",
+            );
+            errors.push(
+                `Aborted: ${toDeactivate.length}/${activeUsers.length} (${pct}%) users would be deactivated — possible GITHUB_ORG misconfiguration`,
+            );
+        } else {
+            // Phase 3: Apply deactivations
+            for (const username of toDeactivate) {
+                await db
+                    .update(users)
+                    .set({ deactivated_at: new Date() })
+                    .where(and(eq(users.github_username, username), isNull(users.deactivated_at)));
+                deactivated++;
+                logger.info({ username }, "User deactivated: no longer in GitHub org");
             }
         }
 
@@ -503,6 +524,23 @@ async function runOrgMembershipSync(): Promise<{
     } finally {
         schedulerState.orgSyncInFlight = false;
     }
+}
+
+/**
+ * Send Slack alert when SMS processing loop throws an exception.
+ * Uses state-transition pattern to avoid spamming on repeated failures.
+ */
+async function notifySmsProcessingError(error: unknown): Promise<void> {
+    if (process.env.NODE_ENV !== "production") {
+        return;
+    }
+
+    const { sendSmsHealthAlert } = await import("@/app/utils/notifications/slack");
+    await sendSmsHealthAlert(false, {
+        schedulerRunning: schedulerState.isRunning,
+        smsTestMode: getHelloSmsConfig().testMode,
+        error: error instanceof Error ? error.message : String(error),
+    });
 }
 
 async function notifyOrgSyncResult(result: {
@@ -619,6 +657,9 @@ export function startScheduler(): void {
             await processSmsJITWithLock();
         } catch (error) {
             logError("Error in SMS JIT loop", error);
+            notifySmsProcessingError(error).catch(err =>
+                logError("Failed to send SMS processing error Slack alert", err),
+            );
         }
     }, SMS_INTERVAL_MS);
 
@@ -750,38 +791,18 @@ export function startScheduler(): void {
     // Run SMS reconciliation once immediately on startup (uses lock)
     runSmsReconciliation().catch(err => logError("Error in immediate SMS reconciliation", err));
 
-    logger.debug("Scheduler started successfully (pure JIT SMS)");
-
-    // Send Slack notification on startup (production only, first startup)
-    if (process.env.NODE_ENV === "production" && isFirstStartup) {
-        import("@/app/utils/notifications/slack")
-            .then(({ sendSlackAlert }) => {
-                return sendSlackAlert({
-                    title: "🚀 Scheduler Started",
-                    message: "Unified background scheduler started successfully (pure JIT SMS)",
-                    status: "success",
-                    details: {
-                        "SMS Test Mode": testMode ? "Enabled (no real SMS)" : "Disabled (live SMS)",
-                        "SMS Interval": SMS_INTERVAL,
-                        "Anonymization Schedule": ANONYMIZATION_SCHEDULE,
-                        "Anonymization Duration": ANONYMIZATION_INACTIVE_DURATION,
-                        "SMS Report Schedule": SMS_REPORT_SCHEDULE,
-                        "SMS Reconciliation Interval": `${SMS_RECONCILIATION_INTERVAL_MS / 60000} minutes`,
-                        "Environment": process.env.NODE_ENV || "development",
-                    },
-                });
-            })
-            .then(success => {
-                if (success) {
-                    logger.debug("Scheduler startup notification sent to Slack");
-                } else {
-                    logger.debug("Failed to send Slack startup notification");
-                }
-            })
-            .catch(error => {
-                logError("Error sending Slack startup notification", error);
-            });
-    }
+    logger.info(
+        {
+            smsTestMode: testMode,
+            smsInterval: SMS_INTERVAL,
+            anonymizationSchedule: ANONYMIZATION_SCHEDULE,
+            anonymizationDuration: ANONYMIZATION_INACTIVE_DURATION,
+            smsReportSchedule: SMS_REPORT_SCHEDULE,
+            smsReconciliationInterval: `${SMS_RECONCILIATION_INTERVAL_MS / 60000} minutes`,
+            firstStartup: isFirstStartup,
+        },
+        "Scheduler started successfully (pure JIT SMS)",
+    );
 }
 
 /**

--- a/app/utils/scheduler.ts
+++ b/app/utils/scheduler.ts
@@ -12,7 +12,7 @@ import {
     processQueuedSms,
     getSmsHealthStats,
     getAvailableCredits,
-    sendInsufficientBalanceSlackAlert,
+    sendBalanceSlackAlert,
     reconcileStaleMessages,
 } from "@/app/utils/sms/sms-service";
 import { getHelloSmsConfig } from "@/app/utils/sms/hello-sms";
@@ -140,12 +140,10 @@ async function processSmsJIT(): Promise<{ processed: number }> {
 
     if (credits === 0) {
         logger.warn("SMS balance is zero - fail-fasting all eligible SMS as balance failures");
-        sendInsufficientBalanceSlackAlert(0).catch(err =>
-            logError("Failed to send balance Slack alert", err),
-        );
+        sendBalanceSlackAlert(0).catch(err => logError("Failed to send balance Slack alert", err));
     } else if (credits !== null && credits < 100) {
         logger.warn({ credits }, "SMS balance is low");
-        sendInsufficientBalanceSlackAlert(credits).catch(err =>
+        sendBalanceSlackAlert(credits).catch(err =>
             logError("Failed to send low balance Slack alert", err),
         );
     }
@@ -478,7 +476,8 @@ async function runOrgMembershipSync(): Promise<{
                 { toDeactivate: toDeactivate.length, totalActive: activeUsers.length, pct },
                 "Org sync aborted: too many deactivations, possible misconfiguration",
             );
-            errors.push(
+            // Prepend so it's never truncated by errors.slice(0, 5) in Slack notification
+            errors.unshift(
                 `Aborted: ${toDeactivate.length}/${activeUsers.length} (${pct}%) users would be deactivated — possible GITHUB_ORG misconfiguration`,
             );
         } else {
@@ -541,6 +540,19 @@ async function notifySmsProcessingError(error: unknown): Promise<void> {
         smsTestMode: getHelloSmsConfig().testMode,
         error: error instanceof Error ? error.message : String(error),
     });
+}
+
+/**
+ * Notify SMS health recovery after a successful processing run.
+ * Only sends a Slack alert if state transitions from ALARM → OK.
+ */
+async function notifySmsProcessingRecovery(): Promise<void> {
+    if (process.env.NODE_ENV !== "production") {
+        return;
+    }
+
+    const { sendSmsHealthAlert } = await import("@/app/utils/notifications/slack");
+    await sendSmsHealthAlert(true, {});
 }
 
 async function notifyOrgSyncResult(result: {
@@ -655,6 +667,10 @@ export function startScheduler(): void {
     schedulerState.smsInterval = setInterval(async () => {
         try {
             await processSmsJITWithLock();
+            // Reset SMS health state to OK on success (triggers recovery alert if previously in ALARM)
+            notifySmsProcessingRecovery().catch(err =>
+                logError("Failed to send SMS processing recovery Slack alert", err),
+            );
         } catch (error) {
             logError("Error in SMS JIT loop", error);
             notifySmsProcessingError(error).catch(err =>

--- a/app/utils/sms/sms-service.ts
+++ b/app/utils/sms/sms-service.ts
@@ -2265,7 +2265,7 @@ export async function reconcileStaleMessages(): Promise<{
     return { reconciled, checked: staleRecords.length, errors };
 }
 
-export async function sendInsufficientBalanceSlackAlert(): Promise<void> {
+export async function sendInsufficientBalanceSlackAlert(credits: number): Promise<void> {
     const now = Date.now();
     if (now - lastBalanceAlertAt < BALANCE_ALERT_COOLDOWN_MS) {
         return; // Already alerted recently
@@ -2274,17 +2274,24 @@ export async function sendInsufficientBalanceSlackAlert(): Promise<void> {
 
     const { sendSlackAlert } = await import("@/app/utils/notifications/slack");
 
+    const isDepleted = credits === 0;
+
     await sendSlackAlert({
-        title: "SMS Credits Depleted",
-        message:
-            "SMS sending is failing because the HelloSMS account has insufficient credits. " +
-            "The organisation needs to top up the SMS balance. " +
-            "Failed SMS messages can be retried from the admin UI once credits are restored.",
-        status: "error",
+        title: isDepleted ? "SMS Credits Depleted" : "SMS Credits Low",
+        message: isDepleted
+            ? "SMS sending is failing because the HelloSMS account has insufficient credits. " +
+              "The organisation needs to top up the SMS balance. " +
+              "Failed SMS messages can be retried from the admin UI once credits are restored."
+            : `SMS credit balance is low (${credits} remaining). ` +
+              "Top up soon to avoid missed pickup reminders.",
+        status: isDepleted ? "error" : "warning",
         details: {
             "Service": "HelloSMS",
-            "Issue": "Insufficient SMS credits (saldo = 0)",
-            "Action Required": "Top up SMS credits at hellosms.se, then retry from admin UI",
+            "Credits Remaining": String(credits),
+            "Issue": isDepleted
+                ? "Insufficient SMS credits (saldo = 0)"
+                : `Low SMS credits (${credits} remaining)`,
+            "Action Required": "Top up SMS credits at hellosms.se",
         },
     });
 }

--- a/app/utils/sms/sms-service.ts
+++ b/app/utils/sms/sms-service.ts
@@ -2081,16 +2081,20 @@ export async function getAvailableCredits(): Promise<number | null> {
 }
 
 /**
- * Send Slack alert when SMS sending fails due to insufficient balance.
+ * Send Slack alert when SMS balance is low or depleted.
  * Rate-limited to at most once per 10 minutes to avoid spam when
  * multiple SMS fail in the same batch.
+ * Depleted (credits=0) always bypasses the cooldown so it is never
+ * suppressed by a prior low-balance warning.
  */
 let lastBalanceAlertAt = 0;
+let lastBalanceAlertWasDepleted = false;
 const BALANCE_ALERT_COOLDOWN_MS = 10 * 60 * 1000; // 10 minutes
 
 /** Reset Slack alert cooldown. Used by tests. */
 export function resetBalanceAlertCooldown(): void {
     lastBalanceAlertAt = 0;
+    lastBalanceAlertWasDepleted = false;
 }
 
 /**
@@ -2265,16 +2269,27 @@ export async function reconcileStaleMessages(): Promise<{
     return { reconciled, checked: staleRecords.length, errors };
 }
 
-export async function sendInsufficientBalanceSlackAlert(credits: number): Promise<void> {
+export async function sendBalanceSlackAlert(credits: number): Promise<void> {
     const now = Date.now();
-    if (now - lastBalanceAlertAt < BALANCE_ALERT_COOLDOWN_MS) {
+    const isDepleted = credits === 0;
+
+    // Depleted alerts always go through — a low-balance warning must never
+    // suppress the more urgent depleted error.
+    if (!isDepleted && now - lastBalanceAlertAt < BALANCE_ALERT_COOLDOWN_MS) {
         return; // Already alerted recently
     }
+    // If we already sent a depleted alert, don't send another one within the cooldown
+    if (
+        isDepleted &&
+        lastBalanceAlertWasDepleted &&
+        now - lastBalanceAlertAt < BALANCE_ALERT_COOLDOWN_MS
+    ) {
+        return;
+    }
     lastBalanceAlertAt = now;
+    lastBalanceAlertWasDepleted = isDepleted;
 
     const { sendSlackAlert } = await import("@/app/utils/notifications/slack");
-
-    const isDepleted = credits === 0;
 
     await sendSlackAlert({
         title: isDepleted ? "SMS Credits Depleted" : "SMS Credits Low",


### PR DESCRIPTION
## Summary

We audited the logging and alerting across the codebase and found that while the Pino structured logging foundation is solid, there were gaps in error detail preservation, early warning for SMS credit depletion, and visibility into silent background failures. This PR addresses the highest-value improvements identified.

## Changes

**Error serialization fix** — `logError()` and `logCritical()` previously destructured errors into `{ error: message, stack }`, losing `error.cause` and `error.code`. Now uses Pino's `err` serializer which preserves the full error chain — particularly useful for database driver errors where the cause contains the actual connection/query failure.

**SMS low-balance early warning** — Previously only alerted when credits hit exactly zero, by which point SMS sending was already failing. Now alerts at `<100` credits remaining, giving roughly 2-3 days of lead time at typical volume (30-40 households/day). The existing 10-minute cooldown prevents spam. Zero-credit alerts remain as errors; low-balance alerts are warnings.

**SMS processing loop alerting** — If `processSmsJIT()` throws an exception, pickup reminders stop for that 5-minute interval. Previously this was only logged. Now sends a Slack alert via the existing `sendSmsHealthAlert()` which uses state-transition tracking — so it alerts on the transition to unhealthy, not on every failing tick.

**Org sync mass-deactivation guard** — The sync now collects non-members in a first pass, then checks the count before applying deactivations. If >50% AND >2 users would be deactivated, it aborts and reports the anomaly as an error. This catches scenarios like a misconfigured `GITHUB_ORG` env var where every membership check returns false.

**Webhook failure visibility** — The SMS status callback handler catches exceptions and returns HTTP 200 (intentionally, to prevent HelloSMS retry storms — reconciliation already covers gaps). Added a Slack alert in the catch block so these processing failures are now visible without changing the retry behavior.

**Scheduler startup noise reduction** — Replaced the Slack "Scheduler Started" success message with a structured `logger.info()` call containing the same configuration details. Reduces Slack noise on every deploy while keeping the info in logs.