### PR TITLE
Fix settings revalidation and add redirects for old routes

### DIFF
--- a/app/[locale]/handout-locations/actions.ts
+++ b/app/[locale]/handout-locations/actions.ts
@@ -167,6 +167,7 @@ export const createLocation = protectedAgreementAction(
 
             // Revalidate the path to update the UI
             revalidatePath(`/${locale}/handout-locations`, "page");
+            revalidatePath(`/${locale}/settings/locations`, "page");
 
             // Return the created location with empty schedules array
             return success({
@@ -220,6 +221,7 @@ export const updateLocation = protectedAgreementAction(
 
             // Revalidate the path to update the UI
             revalidatePath(`/${locale}/handout-locations`, "page");
+            revalidatePath(`/${locale}/settings/locations`, "page");
             return success(undefined);
         } catch (error) {
             logError("Error updating location", error, {
@@ -248,6 +250,7 @@ export const deleteLocation = protectedAgreementAction(
 
             // Revalidate the path to update the UI
             revalidatePath(`/${locale}/handout-locations`, "page");
+            revalidatePath(`/${locale}/settings/locations`, "page");
             return success(undefined);
         } catch (error) {
             logError("Error deleting location", error, {
@@ -348,6 +351,7 @@ export const createSchedule = protectedAgreementAction(
 
             // Revalidate the path to update the UI
             revalidatePath(`/${locale}/handout-locations`, "page");
+            revalidatePath(`/${locale}/settings/locations`, "page");
 
             // Recompute outside-hours count after schedule change
             try {
@@ -508,6 +512,7 @@ export const updateSchedule = protectedAgreementAction(
 
             // Revalidate the path to update the UI
             revalidatePath(`/${locale}/handout-locations`, "page");
+            revalidatePath(`/${locale}/settings/locations`, "page");
 
             // Recompute outside-hours count with fresh data
             try {
@@ -576,6 +581,7 @@ export const deleteSchedule = protectedAgreementAction(
 
             // Revalidate the path to update the UI
             revalidatePath(`/${locale}/handout-locations`, "page");
+            revalidatePath(`/${locale}/settings/locations`, "page");
 
             // Recompute outside-hours count with fresh data
             try {

--- a/app/[locale]/settings/general/page.tsx
+++ b/app/[locale]/settings/general/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "@/app/i18n/navigation";
+import { getLocale } from "next-intl/server";
+
+export default async function GeneralSettingsRedirect() {
+    const locale = await getLocale();
+    redirect({ href: "/settings/locations", locale });
+}

--- a/app/[locale]/settings/parcels/page.tsx
+++ b/app/[locale]/settings/parcels/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "@/app/i18n/navigation";
+import { getLocale } from "next-intl/server";
+
+export default async function ParcelsSettingsRedirect() {
+    const locale = await getLocale();
+    redirect({ href: "/settings/parcel-limits", locale });
+}


### PR DESCRIPTION
## Summary

Follow-up to #347 (unified settings page). Addresses two issues found in review:

- **Stale UI after location edits**: The handout locations actions only revalidated `/handout-locations`, not the new `/settings/locations` route. Mutations made from the settings page wouldn't refresh the page. Now revalidates both paths.

- **Broken bookmarks**: Old URLs `/settings/general` and `/settings/parcels` would 404 after removal. Added redirect pages that send users to the correct new routes (`/settings/locations` and `/settings/parcel-limits` respectively).