### PR TITLE
Use action verbs for issue page buttons

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1636,8 +1636,8 @@
             "noShowFollowup": "No-show follow-up needed"
         },
         "actions": {
-            "handedOut": "Handed out",
-            "noShow": "No-show",
+            "handedOut": "Mark as handed out",
+            "noShow": "Mark as no-show",
             "cancelParcel": "Cancel parcel",
             "reschedule": "Reschedule",
             "retry": "Retry",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -1636,8 +1636,8 @@
             "noShowFollowup": "Uppföljning behövs"
         },
         "actions": {
-            "handedOut": "Utlämnad",
-            "noShow": "Uteblev",
+            "handedOut": "Markera utlämnad",
+            "noShow": "Markera utebliven",
             "cancelParcel": "Avboka paket",
             "reschedule": "Omboka",
             "retry": "Försök igen",


### PR DESCRIPTION
## Summary

The "Handed out" and "No-show" buttons on the issues page read as passive states rather than actions. This is confusing because they are clickable action buttons — users expect verbs that describe what will happen when they click.

Changed to "Mark as handed out" / "Mark as no-show" (EN) and "Markera utlämnad" / "Markera utebliven" (SV).

The other buttons on the page (Cancel parcel, Reschedule, Retry, Dismiss, etc.) already use action verbs, so no changes needed there.