### PR TITLE
Remove orphaned settings translation keys

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1282,13 +1282,6 @@
     },
     "settings": {
         "settings": "Settings",
-        "general": "General Settings",
-        "generalDescription": "Configure privacy policy, enrollment checklist, parcel limits, and follow-up settings.",
-        "locations": "Handout Location Settings",
-        "parcels": "Parcel Limits",
-        "aria": {
-            "settingsMenu": "Settings menu"
-        },
         "nav": {
             "privacyPolicy": "Privacy Policy",
             "userAgreement": "User Agreement",
@@ -1559,11 +1552,6 @@
                 "saveFailedTitle": "Error",
                 "saveFailedMessage": "Failed to save no-show follow-up settings"
             }
-        },
-        "smsTemplates": {
-            "title": "Default SMS Templates",
-            "description": "Customize the text messages sent to households",
-            "comingSoon": "Coming Soon..."
         },
         "users": "Users",
         "usersSection": {

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -1282,13 +1282,6 @@
     },
     "settings": {
         "settings": "Inställningar",
-        "general": "Allmänna inställningar",
-        "generalDescription": "Konfigurera integritetspolicy, registreringsformulär, matkassegränser och uppföljningsinställningar.",
-        "locations": "Utlämningsställen",
-        "parcels": "Matkassegränser",
-        "aria": {
-            "settingsMenu": "Inställningsmeny"
-        },
         "nav": {
             "privacyPolicy": "Integritetspolicy",
             "userAgreement": "Användaravtal",
@@ -1559,11 +1552,6 @@
                 "saveFailedTitle": "Fel",
                 "saveFailedMessage": "Kunde inte spara inställningar för uppföljning vid uteblivna"
             }
-        },
-        "smsTemplates": {
-            "title": "Standard SMS-mallar",
-            "description": "Anpassa textmeddelanden som skickas till hushåll",
-            "comingSoon": "Kommer snart..."
         },
         "users": "Användare",
         "usersSection": {


### PR DESCRIPTION
## Summary

Cleanup after #347 and #348. Removes 6 translation keys (in both EN and SV) that are no longer referenced by any component:

- `settings.general` / `settings.generalDescription` — old page title/description
- `settings.locations` / `settings.parcels` — old dropdown labels
- `settings.aria.settingsMenu` — old dropdown aria label
- `settings.smsTemplates.*` — placeholder "Coming Soon" section never shipped