### PR TITLE
Hide inactive preferences from household edit form

### DIFF
--- a/app/[locale]/households/enroll/components/AdditionalNeedsForm.tsx
+++ b/app/[locale]/households/enroll/components/AdditionalNeedsForm.tsx
@@ -39,14 +39,9 @@ export default function AdditionalNeedsForm({ data, updateData }: AdditionalNeed
     const toggleNeed = (need: AdditionalNeed) => {
         if (isSelected(need.id)) {
             updateData(data.filter(item => item.id !== need.id));
-            return;
+        } else {
+            updateData([...data, need]);
         }
-
-        if (need.isActive === false) {
-            return;
-        }
-
-        updateData([...data, need]);
     };
 
     if (loading) {

--- a/app/[locale]/households/enroll/components/AdditionalNeedsForm.tsx
+++ b/app/[locale]/households/enroll/components/AdditionalNeedsForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Group, Title, Text, Chip, Loader, Badge, Stack } from "@mantine/core";
+import { Group, Title, Text, Chip, Loader, Stack } from "@mantine/core";
 import { getAdditionalNeeds } from "../actions";
 import { AdditionalNeed } from "../types";
 import { useTranslations } from "next-intl";
@@ -34,6 +34,8 @@ export default function AdditionalNeedsForm({ data, updateData }: AdditionalNeed
 
     const isSelected = (id: string) => data.some(item => item.id === id);
 
+    const visibleNeeds = availableNeeds.filter(n => n.isActive !== false || isSelected(n.id));
+
     const toggleNeed = (need: AdditionalNeed) => {
         if (isSelected(need.id)) {
             updateData(data.filter(item => item.id !== need.id));
@@ -64,27 +66,20 @@ export default function AdditionalNeedsForm({ data, updateData }: AdditionalNeed
             <Title order={5}>{t("title")}</Title>
 
             <Group gap="xs">
-                {availableNeeds.map(item => {
+                {visibleNeeds.map(item => {
                     const selected = isSelected(item.id);
-                    const disabledForSelection = item.isActive === false && !selected;
 
                     return (
                         <Chip
                             key={item.id}
                             checked={selected}
                             onChange={() => toggleNeed(item)}
-                            disabled={disabledForSelection}
                             variant={selected ? "filled" : "outline"}
                             color={selected ? "cyan" : "gray"}
                             radius="sm"
                             size="sm"
                         >
                             {item.need}
-                            {item.isActive === false && (
-                                <Badge ml={8} color="orange" variant="light" size="xs">
-                                    {t("disabledLabel")}
-                                </Badge>
-                            )}
                         </Chip>
                     );
                 })}

--- a/app/[locale]/households/enroll/components/DietaryRestrictionsForm.tsx
+++ b/app/[locale]/households/enroll/components/DietaryRestrictionsForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Group, Title, Text, Chip, Loader, Badge, Stack } from "@mantine/core";
+import { Group, Title, Text, Chip, Loader, Stack } from "@mantine/core";
 import { getDietaryRestrictions } from "../actions";
 import { DietaryRestriction } from "../types";
 import { useTranslations } from "next-intl";
@@ -38,6 +38,10 @@ export default function DietaryRestrictionsForm({
 
     const isSelected = (id: string) => data.some(item => item.id === id);
 
+    const visibleRestrictions = availableRestrictions.filter(
+        r => r.isActive !== false || isSelected(r.id),
+    );
+
     const toggleRestriction = (restriction: DietaryRestriction) => {
         if (isSelected(restriction.id)) {
             updateData(data.filter(item => item.id !== restriction.id));
@@ -68,27 +72,20 @@ export default function DietaryRestrictionsForm({
             <Title order={5}>{t("title")}</Title>
 
             <Group gap="xs">
-                {availableRestrictions.map(restriction => {
+                {visibleRestrictions.map(restriction => {
                     const selected = isSelected(restriction.id);
-                    const disabledForSelection = restriction.isActive === false && !selected;
 
                     return (
                         <Chip
                             key={restriction.id}
                             checked={selected}
                             onChange={() => toggleRestriction(restriction)}
-                            disabled={disabledForSelection}
                             variant={selected ? "filled" : "outline"}
                             color={selected ? severityToColor(restriction.color) : "gray"}
                             radius="sm"
                             size="sm"
                         >
                             {restriction.name}
-                            {restriction.isActive === false && (
-                                <Badge ml={8} color="orange" variant="light" size="xs">
-                                    {t("disabledLabel")}
-                                </Badge>
-                            )}
                         </Chip>
                     );
                 })}

--- a/app/[locale]/households/enroll/components/DietaryRestrictionsForm.tsx
+++ b/app/[locale]/households/enroll/components/DietaryRestrictionsForm.tsx
@@ -45,14 +45,9 @@ export default function DietaryRestrictionsForm({
     const toggleRestriction = (restriction: DietaryRestriction) => {
         if (isSelected(restriction.id)) {
             updateData(data.filter(item => item.id !== restriction.id));
-            return;
+        } else {
+            updateData([...data, restriction]);
         }
-
-        if (restriction.isActive === false) {
-            return;
-        }
-
-        updateData([...data, restriction]);
     };
 
     if (loading) {

--- a/app/[locale]/households/enroll/components/PetsForm.tsx
+++ b/app/[locale]/households/enroll/components/PetsForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Group, Title, Text, Loader, Stack, Badge } from "@mantine/core";
+import { Group, Title, Text, Loader, Stack } from "@mantine/core";
 import { getPetSpecies } from "../actions";
 import CounterInput from "@/components/CounterInput";
 import { Pet, PetSpecies } from "../types";
@@ -133,42 +133,38 @@ export default function PetsForm({ data, updateData }: PetsFormProps) {
             <Title order={5}>{t("title")}</Title>
 
             <Stack gap="xs">
-                {petTypes.map(petType => {
-                    const currentCount = petCounts[petType.id] || 0;
-                    const isInactive = petType.isActive === false;
+                {petTypes
+                    .filter(
+                        petType => petType.isActive !== false || (petCounts[petType.id] || 0) > 0,
+                    )
+                    .map(petType => {
+                        const currentCount = petCounts[petType.id] || 0;
+                        const isInactive = petType.isActive === false;
 
-                    return (
-                        <Group
-                            key={petType.id}
-                            justify="space-between"
-                            gap="xs"
-                            style={{
-                                borderBottom: "1px solid var(--mantine-color-gray-1)",
-                                paddingBottom: "6px",
-                            }}
-                        >
-                            <Group gap="xs">
+                        return (
+                            <Group
+                                key={petType.id}
+                                justify="space-between"
+                                gap="xs"
+                                style={{
+                                    borderBottom: "1px solid var(--mantine-color-gray-1)",
+                                    paddingBottom: "6px",
+                                }}
+                            >
                                 <Text size="sm" fw={500}>
                                     {petType.name}
                                 </Text>
-                                {isInactive && (
-                                    <Badge color="orange" variant="light" size="xs">
-                                        {t("disabledLabel")}
-                                    </Badge>
-                                )}
+                                <CounterInput
+                                    value={currentCount}
+                                    onChange={value => setCount(petType.id, value)}
+                                    min={0}
+                                    max={99}
+                                    disableIncrement={isInactive}
+                                    disableDirectInput={isInactive}
+                                />
                             </Group>
-                            <CounterInput
-                                value={currentCount}
-                                onChange={value => setCount(petType.id, value)}
-                                min={0}
-                                max={99}
-                                disabled={isInactive && currentCount === 0}
-                                disableIncrement={isInactive}
-                                disableDirectInput={isInactive}
-                            />
-                        </Group>
-                    );
-                })}
+                        );
+                    })}
             </Stack>
         </Stack>
     );

--- a/app/[locale]/households/enroll/components/PetsForm.tsx
+++ b/app/[locale]/households/enroll/components/PetsForm.tsx
@@ -116,6 +116,10 @@ export default function PetsForm({ data, updateData }: PetsFormProps) {
         updatePetsData(updatedCounts);
     };
 
+    const visiblePetTypes = petTypes.filter(
+        petType => petType.isActive !== false || (petCounts[petType.id] || 0) > 0,
+    );
+
     if (isLoading) {
         return (
             <Stack>
@@ -133,38 +137,34 @@ export default function PetsForm({ data, updateData }: PetsFormProps) {
             <Title order={5}>{t("title")}</Title>
 
             <Stack gap="xs">
-                {petTypes
-                    .filter(
-                        petType => petType.isActive !== false || (petCounts[petType.id] || 0) > 0,
-                    )
-                    .map(petType => {
-                        const currentCount = petCounts[petType.id] || 0;
-                        const isInactive = petType.isActive === false;
+                {visiblePetTypes.map(petType => {
+                    const currentCount = petCounts[petType.id] || 0;
+                    const isInactive = petType.isActive === false;
 
-                        return (
-                            <Group
-                                key={petType.id}
-                                justify="space-between"
-                                gap="xs"
-                                style={{
-                                    borderBottom: "1px solid var(--mantine-color-gray-1)",
-                                    paddingBottom: "6px",
-                                }}
-                            >
-                                <Text size="sm" fw={500}>
-                                    {petType.name}
-                                </Text>
-                                <CounterInput
-                                    value={currentCount}
-                                    onChange={value => setCount(petType.id, value)}
-                                    min={0}
-                                    max={99}
-                                    disableIncrement={isInactive}
-                                    disableDirectInput={isInactive}
-                                />
-                            </Group>
-                        );
-                    })}
+                    return (
+                        <Group
+                            key={petType.id}
+                            justify="space-between"
+                            gap="xs"
+                            style={{
+                                borderBottom: "1px solid var(--mantine-color-gray-1)",
+                                paddingBottom: "6px",
+                            }}
+                        >
+                            <Text size="sm" fw={500}>
+                                {petType.name}
+                            </Text>
+                            <CounterInput
+                                value={currentCount}
+                                onChange={value => setCount(petType.id, value)}
+                                min={0}
+                                max={99}
+                                disableIncrement={isInactive}
+                                disableDirectInput={isInactive}
+                            />
+                        </Group>
+                    );
+                })}
             </Stack>
         </Stack>
     );

--- a/messages/en.json
+++ b/messages/en.json
@@ -277,7 +277,6 @@
         "removeConfirmQuestion": "Do you want to remove the following dietary restriction from your application?",
         "cancel": "Cancel",
         "remove": "Remove",
-        "disabledLabel": "Disabled",
         "validation": {
             "minLength": "Dietary restriction must be at least 2 characters"
         }
@@ -297,7 +296,6 @@
         "removeConfirmQuestion": "Do you want to remove the following pet type from your application?",
         "cancel": "Cancel",
         "remove": "Remove",
-        "disabledLabel": "Disabled",
         "defaultPetType": "Pet type {index}",
         "unknownPetType": "Unknown",
         "validation": {
@@ -313,7 +311,6 @@
         "newNeed": "New need",
         "placeholderExample": "E.g. Razors, Shampoo, etc.",
         "add": "Add",
-        "disabledLabel": "Disabled",
         "validation": {
             "minLength": "Need must be at least 2 characters"
         }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -277,7 +277,6 @@
         "removeConfirmQuestion": "Vill du ta bort följande matrestriktion från din ansökan?",
         "cancel": "Avbryt",
         "remove": "Ta bort",
-        "disabledLabel": "Inaktiv",
         "validation": {
             "minLength": "Matrestriktion måste vara minst 2 tecken"
         }
@@ -297,7 +296,6 @@
         "removeConfirmQuestion": "Vill du ta bort följande husdjurstyp från din ansökan?",
         "cancel": "Avbryt",
         "remove": "Ta bort",
-        "disabledLabel": "Inaktiv",
         "defaultPetType": "Husdjurstyp {index}",
         "unknownPetType": "Okänd",
         "validation": {
@@ -313,7 +311,6 @@
         "newNeed": "Nytt behov",
         "placeholderExample": "T.ex. Rakhyvlar, Schampo, etc.",
         "add": "Lägg till",
-        "disabledLabel": "Inaktiv",
         "validation": {
             "minLength": "Behov måste vara minst 2 tecken"
         }


### PR DESCRIPTION
## Summary

When editing a household, inactive preferences (dietary restrictions, additional needs, pet species) were shown as disabled chips with orange "disabled" badges. This cluttered the form with options staff couldn't select anyway.

Now inactive preferences are simply hidden from the form. If a household already has an inactive preference selected (grandfathered in), it remains visible so staff can remove it — but they can't re-add it or (for pets) increment its count.

- **Dietary restrictions & additional needs**: filtered via `visibleRestrictions`/`visibleNeeds` — only active or already-selected items render
- **Pets**: inline `.filter()` hides inactive species with 0 count; `disableIncrement`/`disableDirectInput` kept for inactive-but-visible species so staff can only decrement