### PR TITLE
Anonymize verification notes and document GDPR hard-deletes

### DIFF
--- a/__tests__/integration/utils/anonymize-household-verification-status.integration.test.ts
+++ b/__tests__/integration/utils/anonymize-household-verification-status.integration.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { getTestDb } from "../../db/test-db";
+import {
+    createTestHousehold,
+    createTestLocationWithSchedule,
+    createTestParcel,
+    createTestVerificationQuestion,
+    resetHouseholdCounter,
+    resetLocationCounter,
+} from "../../factories";
+import { daysFromTestNow } from "../../test-time";
+import { householdVerificationStatus, households } from "@/app/db/schema";
+import { removeHousehold } from "@/app/utils/anonymization/anonymize-household";
+
+describe("anonymize household verification status - integration", () => {
+    beforeEach(() => {
+        resetHouseholdCounter();
+        resetLocationCounter();
+    });
+
+    it("hard-deletes verification_status rows so free-text notes don't survive anonymization", async () => {
+        // The notes column on household_verification_status is staff-authored
+        // free text and may contain identifying information. Anonymization
+        // must remove these rows entirely (placeholder values can't obscure
+        // free text). This is the regression test for that GDPR requirement.
+        const db = await getTestDb();
+        const household = await createTestHousehold();
+        const { location } = await createTestLocationWithSchedule();
+
+        // Anonymization (vs hard delete) only happens when a household has
+        // parcel history, so create a past parcel to push removeHousehold
+        // down the anonymization path.
+        await createTestParcel({
+            household_id: household.id,
+            pickup_location_id: location.id,
+            pickup_date_time_earliest: daysFromTestNow(-3),
+            pickup_date_time_latest: new Date(daysFromTestNow(-3).getTime() + 30 * 60 * 1000),
+        });
+
+        // Attach two verification rows to the household — one with notes
+        // (the PII case) and one without (to prove the deletion is
+        // unconditional, not just notes-aware).
+        const question1 = await createTestVerificationQuestion();
+        const question2 = await createTestVerificationQuestion();
+
+        await db.insert(householdVerificationStatus).values([
+            {
+                household_id: household.id,
+                question_id: question1.id,
+                is_verified: true,
+                verified_by_user: "test-admin",
+                verified_at: new Date(),
+                notes: "Mentioned by name in case worker meeting",
+            },
+            {
+                household_id: household.id,
+                question_id: question2.id,
+                is_verified: false,
+                notes: null,
+            },
+        ]);
+
+        // Sanity: rows exist before anonymization
+        const beforeRows = await db
+            .select()
+            .from(householdVerificationStatus)
+            .where(eq(householdVerificationStatus.household_id, household.id));
+        expect(beforeRows).toHaveLength(2);
+
+        const result = await removeHousehold(household.id, "test-admin");
+        expect(result.method).toBe("anonymized");
+
+        // The household row itself should still exist (with anonymized
+        // name/phone) — this is the preserved-statistics invariant.
+        const [anonymizedHousehold] = await db
+            .select()
+            .from(households)
+            .where(eq(households.id, household.id));
+        expect(anonymizedHousehold).toBeDefined();
+        expect(anonymizedHousehold?.anonymized_at).toBeInstanceOf(Date);
+        expect(anonymizedHousehold?.first_name).toBe("Anonymized");
+
+        // But ALL verification status rows must be gone — both the one
+        // with notes and the one without.
+        const afterRows = await db
+            .select()
+            .from(householdVerificationStatus)
+            .where(eq(householdVerificationStatus.household_id, household.id));
+        expect(afterRows).toHaveLength(0);
+    });
+});

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -40,6 +40,11 @@ export const weekdayEnum = pgEnum("weekday", [
     "sunday",
 ]);
 
+// Household record. Anonymization replaces name/phone in-place but leaves
+// the row, so historical statistics tied to food_parcels remain meaningful.
+// Any NEW child table keyed to household_id that stores free-text PII must
+// also be hard-deleted in app/utils/anonymization/anonymize-household.ts —
+// the schema does not enforce this invariant.
 export const households = pgTable(
     "households",
     {
@@ -282,7 +287,10 @@ export const verificationQuestions = pgTable(
     ],
 );
 
-// Household verification status tracking
+// Household verification status tracking. The `notes` column is free-text
+// authored by staff and may contain identifying information, so rows are
+// HARD-DELETED on household anonymization — see
+// app/utils/anonymization/anonymize-household.ts.
 export const householdVerificationStatus = pgTable(
     "household_verification_status",
     {

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -81,6 +81,9 @@ export const households = pgTable(
     ],
 );
 
+// Free-text staff notes about a household. Contains PII (may reference the
+// person by name or describe their situation), so rows are HARD-DELETED on
+// household anonymization — see app/utils/anonymization/anonymize-household.ts.
 export const householdComments = pgTable("household_comments", {
     id: text("id")
         .primaryKey()
@@ -380,6 +383,9 @@ export const foodParcels = pgTable(
     ],
 );
 
+// Outbound SMS records. Contains PII (recipient phone number and the exact
+// rendered message body), so rows are HARD-DELETED on household anonymization
+// — see app/utils/anonymization/anonymize-household.ts.
 export const outgoingSms = pgTable(
     "outgoing_sms",
     {

--- a/app/utils/anonymization/anonymize-household.ts
+++ b/app/utils/anonymization/anonymize-household.ts
@@ -119,10 +119,24 @@ async function anonymizeHousehold(
             .where(eq(householdAdditionalNeeds.household_id, householdId));
         await tx.delete(pets).where(eq(pets.household_id, householdId));
 
-        // 3. Delete comments (hard delete)
+        // 3. Hard-delete free-text PII associated with the household.
+        //
+        // This is deliberate, not an oversight. Both household_comments and
+        // outgoing_sms can contain identifying information that placeholder
+        // values cannot meaningfully obscure: comments are free-text staff
+        // notes that may reference the person by name or describe their
+        // situation, and SMS rows hold the recipient phone number plus the
+        // exact rendered message body. GDPR right-to-erasure requires this
+        // data to actually disappear.
+        //
+        // What is preserved: the households row itself (with anonymized
+        // name/phone) and all food_parcels rows, so historical statistics
+        // (parcels handed out per location, per month, etc.) remain intact.
+        //
+        // If you add a new table that stores PII keyed to household_id,
+        // delete it here too. See also schema.ts comments on the affected
+        // tables.
         await tx.delete(householdComments).where(eq(householdComments.household_id, householdId));
-
-        // 4. Delete SMS records (hard delete)
         await tx.delete(outgoingSms).where(eq(outgoingSms.household_id, householdId));
     });
 

--- a/app/utils/anonymization/anonymize-household.ts
+++ b/app/utils/anonymization/anonymize-household.ts
@@ -3,8 +3,8 @@
  *
  * Implements GDPR-compliant data anonymization:
  * - Replaces personal identifiers with placeholders
- * - Deletes comments and SMS records
- * - Preserves statistical data (parcels, locale)
+ * - Hard-deletes free-text PII (comments, SMS, verification notes)
+ * - Preserves statistical data (parcels, locale, member demographics)
  */
 
 import { db } from "@/app/db/drizzle";
@@ -15,6 +15,7 @@ import {
     foodParcels,
     householdDietaryRestrictions,
     householdAdditionalNeeds,
+    householdVerificationStatus,
     pets,
 } from "@/app/db/schema";
 import { eq, and, gte, isNull, sql, desc } from "drizzle-orm";
@@ -98,7 +99,8 @@ async function anonymizeHousehold(
     const phoneNumber = `000000${sequence.toString().padStart(4, "0")}`; // e.g., "0000000001"
 
     await db.transaction(async tx => {
-        // 1. Anonymize household record
+        // Anonymize the household record itself — name and phone become
+        // placeholders, anonymized_at marks the row as inactive.
         await tx
             .update(households)
             .set({
@@ -110,7 +112,9 @@ async function anonymizeHousehold(
             })
             .where(eq(households.id, householdId));
 
-        // 2. Remove option/pet links so anonymized households never block option pruning
+        // Remove option/pet links so anonymized households never block option
+        // pruning. These rows hold no PII themselves; the deletion is purely
+        // operational, not GDPR-driven.
         await tx
             .delete(householdDietaryRestrictions)
             .where(eq(householdDietaryRestrictions.household_id, householdId));
@@ -119,25 +123,30 @@ async function anonymizeHousehold(
             .where(eq(householdAdditionalNeeds.household_id, householdId));
         await tx.delete(pets).where(eq(pets.household_id, householdId));
 
-        // 3. Hard-delete free-text PII associated with the household.
+        // Hard-delete free-text PII keyed to the household. Placeholder values
+        // cannot meaningfully obscure free-text content, so GDPR right-to-
+        // erasure requires the rows to actually disappear:
         //
-        // This is deliberate, not an oversight. Both household_comments and
-        // outgoing_sms can contain identifying information that placeholder
-        // values cannot meaningfully obscure: comments are free-text staff
-        // notes that may reference the person by name or describe their
-        // situation, and SMS rows hold the recipient phone number plus the
-        // exact rendered message body. GDPR right-to-erasure requires this
-        // data to actually disappear.
+        //   - household_comments: staff notes that may reference the person
+        //     by name, family situation, or other identifying details.
+        //   - outgoing_sms: recipient phone number plus the rendered message
+        //     body, which often contains the recipient's name.
+        //   - household_verification_status: free-text `notes` column for
+        //     enrollment verification, which may describe the household.
         //
-        // What is preserved: the households row itself (with anonymized
-        // name/phone) and all food_parcels rows, so historical statistics
-        // (parcels handed out per location, per month, etc.) remain intact.
+        // Preserved: the households row (with anonymized name/phone),
+        // household_members (age + sex demographics, no direct identifiers),
+        // and all food_parcels rows — these support aggregate statistics and
+        // are not personally identifying once name and phone are placeholders.
         //
-        // If you add a new table that stores PII keyed to household_id,
-        // delete it here too. See also schema.ts comments on the affected
-        // tables.
+        // INVARIANT for future contributors: any new table that stores
+        // free-text PII keyed to household_id must be hard-deleted here.
+        // See also the comments on the affected tables in schema.ts.
         await tx.delete(householdComments).where(eq(householdComments.household_id, householdId));
         await tx.delete(outgoingSms).where(eq(outgoingSms.household_id, householdId));
+        await tx
+            .delete(householdVerificationStatus)
+            .where(eq(householdVerificationStatus.household_id, householdId));
     });
 
     logger.info(


### PR DESCRIPTION
## Why

Two related problems, fixed together:

**1. The anonymization helper was missing a free-text PII source.** `household_verification_status.notes` is a staff-authored free-text column keyed to `household_id`. When a household was anonymized, comments and SMS rows were hard-deleted but verification notes survived indefinitely. Placeholder values can't obscure free text — GDPR right-to-erasure requires the rows to actually disappear.

The table is currently unused by application code (only defined in the schema, no read or write paths anywhere outside the anonymization helper itself). Adding the deletion now is purely defensive: any future enrollment-verification UI inherits a correctly-anonymizing data store from day one rather than having to retrofit GDPR handling later.

**2. The deletion site lacked an explanation.** The two existing delete calls (`householdComments`, `outgoingSms`) were marked with bare `// 3. Delete comments (hard delete)` comments — accurate but easily misread as oversights. A future contributor could "fix" them and undo GDPR compliance in the process.

## What

- **Hard-delete `household_verification_status` rows** in `anonymizeHousehold`, alongside the existing comment and SMS deletions.
- **Replace the terse delete-site comments** with one explanatory block covering the rationale, what gets preserved, and a forward-compat invariant for new contributors.
- **Add table-local schema comments** above `householdComments`, `outgoingSms`, and `householdVerificationStatus` pointing back to the anonymization helper.
- **Add a forward-compat comment to the `households` table itself** so contributors adding new PII tables discover the anonymization invariant from the schema rather than having to find the helper first.
- **Add an integration test** that creates a household with two verification rows (one with notes, one without), anonymizes it, and asserts both rows are gone while the household row survives. Covers the regression for the gap fixed here.

## Notes

- `household_members` (age + sex demographics) is intentionally **preserved** across anonymization. It contains no direct identifiers and is valuable for aggregate statistics. The new comment makes this explicit (the previous version was silent on it, which review feedback flagged as misleading).
- `food_parcels` rows are also preserved (untouched by anonymization), which is what makes the historical statistics tied to anonymized households still meaningful.
- The original "deliberate, not an oversight" line in the comment block was cut as defensive — the rest of the paragraph already makes the point.
- Scope intentionally stayed narrow: this PR fixes one real GDPR gap and documents the surrounding behaviour. It does not touch `anonymize-user.ts` (no hard deletes there), `hardDeleteHousehold` (already self-explanatory), or any other anonymization-adjacent code.

This is the second small PR from a broader audit-trail planning effort. The first was Vasteras-Stadsmission/matkassen#352 (the schedule audit log cascade FK fix). The remaining PRs in that effort are larger and will land separately.