### PR TITLE
Add generic audit_log table and recordAuditEvent helper

### DIFF
--- a/__tests__/db/test-db.ts
+++ b/__tests__/db/test-db.ts
@@ -69,6 +69,7 @@ export async function cleanupTestDb() {
     // Order matters due to foreign key constraints - CASCADE handles it
     await pglite.exec(`
         TRUNCATE TABLE
+            audit_log,
             outgoing_sms,
             food_parcels,
             household_verification_status,

--- a/__tests__/integration/utils/audit-log.integration.test.ts
+++ b/__tests__/integration/utils/audit-log.integration.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { getTestDb } from "../../db/test-db";
+import { auditLog } from "@/app/db/schema";
+import {
+    recordAuditEvent,
+    MISSING_ACTOR_SENTINEL,
+    SYSTEM_ACTOR,
+    type AuditTransaction,
+} from "@/app/utils/audit/log";
+import * as logger from "@/app/utils/logger";
+
+// The test db is the pglite drizzle instance. Its tx type is structurally
+// identical to the production postgres-js tx type the helper expects, but
+// nominally different — cast in tests so the helper signature stays strict
+// for production callers.
+function asAuditTx<T>(tx: T): AuditTransaction {
+    return tx as unknown as AuditTransaction;
+}
+
+describe("recordAuditEvent — integration", () => {
+    let logErrorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        logErrorSpy = vi.spyOn(logger, "logError").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        logErrorSpy.mockRestore();
+    });
+
+    describe("actor resolution", () => {
+        it("uses the session's githubUsername when present", async () => {
+            const db = await getTestDb();
+
+            await db.transaction(async tx => {
+                await recordAuditEvent(asAuditTx(tx), {
+                    session: { user: { githubUsername: "alice" } },
+                    entityType: "household",
+                    entityId: "h_123",
+                    action: "updated",
+                    summary: "Updated household name",
+                    details: { name: { from: "Alice A.", to: "Alice B." } },
+                });
+            });
+
+            const rows = await db.select().from(auditLog).where(eq(auditLog.entity_id, "h_123"));
+            expect(rows).toHaveLength(1);
+            expect(rows[0].actor_username).toBe("alice");
+            expect(rows[0].entity_type).toBe("household");
+            expect(rows[0].action).toBe("updated");
+            expect(rows[0].summary).toBe("Updated household name");
+            expect(rows[0].details).toEqual({
+                name: { from: "Alice A.", to: "Alice B." },
+            });
+            expect(logErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it("uses 'system' when caller explicitly passes null session", async () => {
+            const db = await getTestDb();
+
+            await db.transaction(async tx => {
+                await recordAuditEvent(asAuditTx(tx), {
+                    session: null,
+                    entityType: "household",
+                    entityId: "h_cron_1",
+                    action: "anonymized",
+                    summary: "Auto-anonymized after retention period",
+                });
+            });
+
+            const [row] = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.entity_id, "h_cron_1"));
+            expect(row.actor_username).toBe(SYSTEM_ACTOR);
+            expect(logErrorSpy).not.toHaveBeenCalled();
+        });
+
+        it("falls back to '__missing__' and logs an error when session has no username", async () => {
+            const db = await getTestDb();
+
+            await db.transaction(async tx => {
+                await recordAuditEvent(asAuditTx(tx), {
+                    // Session object exists but the username is missing —
+                    // this is a bug, not an intentional system call.
+                    session: { user: { githubUsername: null } },
+                    entityType: "user_role",
+                    entityId: "u_42",
+                    action: "role_changed",
+                    summary: "Promoted user to admin",
+                });
+            });
+
+            const [row] = await db.select().from(auditLog).where(eq(auditLog.entity_id, "u_42"));
+            expect(row.actor_username).toBe(MISSING_ACTOR_SENTINEL);
+
+            // The audit row was still written — that's the point of the
+            // sentinel. The error log is the alarm channel, not a block.
+            expect(logErrorSpy).toHaveBeenCalledTimes(1);
+            const [message, error, context] = logErrorSpy.mock.calls[0];
+            expect(message).toContain("without resolvable actor");
+            expect(error).toBeInstanceOf(Error);
+            expect(context).toMatchObject({
+                entityType: "user_role",
+                entityId: "u_42",
+                action: "role_changed",
+            });
+        });
+
+        it("also falls back to '__missing__' when session.user itself is missing", async () => {
+            const db = await getTestDb();
+
+            await db.transaction(async tx => {
+                await recordAuditEvent(asAuditTx(tx), {
+                    session: {}, // No `user` at all.
+                    entityType: "household",
+                    entityId: "h_no_user",
+                    action: "updated",
+                    summary: "Edge case: empty session object",
+                });
+            });
+
+            const [row] = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.entity_id, "h_no_user"));
+            expect(row.actor_username).toBe(MISSING_ACTOR_SENTINEL);
+            expect(logErrorSpy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("transaction semantics", () => {
+        it("rolls the audit row back when the surrounding transaction throws", async () => {
+            const db = await getTestDb();
+
+            await expect(
+                db.transaction(async tx => {
+                    await recordAuditEvent(asAuditTx(tx), {
+                        session: { user: { githubUsername: "alice" } },
+                        entityType: "household",
+                        entityId: "h_rolled_back",
+                        action: "updated",
+                        summary: "This should not survive",
+                    });
+                    throw new Error("simulated business mutation failure");
+                }),
+            ).rejects.toThrow("simulated business mutation failure");
+
+            const rows = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.entity_id, "h_rolled_back"));
+            // The audit row must have rolled back with the transaction.
+            // This is the contract: audit rows can never outlive a failed
+            // business mutation.
+            expect(rows).toHaveLength(0);
+        });
+
+        it("commits the audit row when the surrounding transaction commits", async () => {
+            const db = await getTestDb();
+
+            await db.transaction(async tx => {
+                await recordAuditEvent(asAuditTx(tx), {
+                    session: { user: { githubUsername: "bob" } },
+                    entityType: "household",
+                    entityId: "h_committed",
+                    action: "updated",
+                    summary: "This should survive",
+                });
+                // No throw — transaction commits normally.
+            });
+
+            const rows = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.entity_id, "h_committed"));
+            expect(rows).toHaveLength(1);
+            expect(rows[0].actor_username).toBe("bob");
+        });
+    });
+
+    describe("optional fields", () => {
+        it("accepts a null entity_id for actions without a single subject", async () => {
+            const db = await getTestDb();
+
+            await db.transaction(async tx => {
+                await recordAuditEvent(asAuditTx(tx), {
+                    session: { user: { githubUsername: "alice" } },
+                    entityType: "settings",
+                    entityId: null,
+                    action: "imported_csv",
+                    summary: "Imported 42 records from CSV",
+                    details: { count: 42, source: "manual_upload.csv" },
+                });
+            });
+
+            const rows = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.actor_username, "alice"));
+            const row = rows.find(r => r.action === "imported_csv");
+            expect(row).toBeDefined();
+            expect(row?.entity_id).toBeNull();
+            expect(row?.details).toEqual({ count: 42, source: "manual_upload.csv" });
+        });
+
+        it("stores null details when caller omits them", async () => {
+            const db = await getTestDb();
+
+            await db.transaction(async tx => {
+                await recordAuditEvent(asAuditTx(tx), {
+                    session: { user: { githubUsername: "alice" } },
+                    entityType: "household",
+                    entityId: "h_no_details",
+                    action: "deleted",
+                    summary: "Deleted empty household",
+                });
+            });
+
+            const [row] = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.entity_id, "h_no_details"));
+            expect(row.details).toBeNull();
+        });
+    });
+});

--- a/__tests__/integration/utils/audit-log.integration.test.ts
+++ b/__tests__/integration/utils/audit-log.integration.test.ts
@@ -180,6 +180,103 @@ describe("recordAuditEvent — integration", () => {
         });
     });
 
+    describe("type safety on details", () => {
+        // These assertions are verified by `tsc --noEmit` (and by the
+        // pre-push validation hook), not at runtime. Each `@ts-expect-error`
+        // is a contract: removing one without also widening the `details`
+        // type will fail compilation. The body of this test is never
+        // executed (`it.skip`); we just need TypeScript to type-check it.
+        it.skip("rejects non-JSON values at the type level (compile-time check)", () => {
+            const dummyTx = null as unknown as AuditTransaction;
+            const dummySession = { user: { githubUsername: "alice" } };
+
+            // Date silently becomes an ISO string under JSON.stringify —
+            // the audit log should never accept Date so callers convert
+            // explicitly and the recorded value is unambiguous.
+            void recordAuditEvent(dummyTx, {
+                session: dummySession,
+                entityType: "test",
+                entityId: null,
+                action: "test",
+                summary: "test",
+                details: {
+                    // @ts-expect-error — Date is not a JsonValue
+                    when: new Date(),
+                },
+            });
+
+            // BigInt throws inside JSON.stringify, which would roll back
+            // the surrounding business mutation. Compile-time rejection
+            // is the only safe option.
+            void recordAuditEvent(dummyTx, {
+                session: dummySession,
+                entityType: "test",
+                entityId: null,
+                action: "test",
+                summary: "test",
+                details: {
+                    // @ts-expect-error — BigInt is not a JsonValue
+                    big: 42n,
+                },
+            });
+
+            // Map and Set serialize to {} silently — worst-case data
+            // loss in an audit log.
+            void recordAuditEvent(dummyTx, {
+                session: dummySession,
+                entityType: "test",
+                entityId: null,
+                action: "test",
+                summary: "test",
+                details: {
+                    // @ts-expect-error — Map is not a JsonValue
+                    cache: new Map<string, string>(),
+                },
+            });
+
+            void recordAuditEvent(dummyTx, {
+                session: dummySession,
+                entityType: "test",
+                entityId: null,
+                action: "test",
+                summary: "test",
+                details: {
+                    // @ts-expect-error — Set is not a JsonValue
+                    members: new Set<string>(),
+                },
+            });
+
+            // Functions don't serialize at all.
+            void recordAuditEvent(dummyTx, {
+                session: dummySession,
+                entityType: "test",
+                entityId: null,
+                action: "test",
+                summary: "test",
+                details: {
+                    // @ts-expect-error — function is not a JsonValue
+                    callback: () => "nope",
+                },
+            });
+
+            // Sanity: legitimate nested JSON values must still compile.
+            void recordAuditEvent(dummyTx, {
+                session: dummySession,
+                entityType: "test",
+                entityId: null,
+                action: "test",
+                summary: "test",
+                details: {
+                    name: { from: "Alice", to: "Bob" },
+                    counts: [1, 2, 3],
+                    flag: true,
+                    optional: null,
+                    nested: { deep: { deeper: { value: "ok" } } },
+                },
+            });
+        });
+    });
+
     describe("optional fields", () => {
         it("accepts a null entity_id for actions without a single subject", async () => {
             const db = await getTestDb();

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -289,8 +289,10 @@ export const auditLog = pgTable(
         entity_type: text("entity_type").notNull(), // 'household' | 'user_role' | 'parcel' | ...
         entity_id: text("entity_id"),
         action: text("action").notNull(), // 'created' | 'updated' | 'deleted' | 'role_changed' | ...
-        // Human-readable summary for direct UI display, plus a structured
-        // before/after blob for richer queries. Both are populated.
+        // Human-readable one-line summary for direct UI display (always
+        // present), plus an optional structured before/after blob in
+        // jsonb for richer queries. Writers populate `details` only when
+        // there is a meaningful diff to record.
         summary: text("summary").notNull(),
         details: jsonb("details"),
     },

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -14,6 +14,7 @@ import {
     index,
     uniqueIndex,
     unique,
+    jsonb,
 } from "drizzle-orm/pg-core";
 import { customAlphabet } from "nanoid";
 
@@ -259,6 +260,44 @@ export const scheduleAuditLog = pgTable(
     table => [
         index("idx_schedule_audit_log_location").on(table.pickup_location_id),
         index("idx_schedule_audit_log_schedule").on(table.schedule_id),
+    ],
+);
+
+// Generic audit log for business mutations across the app.
+//
+// Same plain-text-id pattern as scheduleAuditLog so audit rows survive
+// deletion of the entity they describe. Writes go through the helper at
+// app/utils/audit/log.ts — see that file for the philosophy (log-and-
+// continue, log values not redactions, always inside a transaction).
+//
+// scheduleAuditLog stays as-is; it predates this table and the two can
+// converge later if it ever matters.
+export const auditLog = pgTable(
+    "audit_log",
+    {
+        id: text("id")
+            .primaryKey()
+            .notNull()
+            .$defaultFn(() => nanoid(8)),
+        created_at: timestamp({ precision: 1, withTimezone: true }).defaultNow().notNull(),
+        // Username only — no FK to users, no separate snapshot column.
+        // Matches the rest of the schema's actor convention. Username
+        // instability is a theoretical problem we have not observed.
+        actor_username: varchar("actor_username", { length: 100 }).notNull(),
+        // What was acted on. entity_id is plain text (no FK) so audit rows
+        // outlive deletion of the entity they describe.
+        entity_type: text("entity_type").notNull(), // 'household' | 'user_role' | 'parcel' | ...
+        entity_id: text("entity_id"),
+        action: text("action").notNull(), // 'created' | 'updated' | 'deleted' | 'role_changed' | ...
+        // Human-readable summary for direct UI display, plus a structured
+        // before/after blob for richer queries. Both are populated.
+        summary: text("summary").notNull(),
+        details: jsonb("details"),
+    },
+    table => [
+        index("idx_audit_log_entity").on(table.entity_type, table.entity_id),
+        index("idx_audit_log_actor").on(table.actor_username),
+        index("idx_audit_log_created").on(table.created_at),
     ],
 );
 

--- a/app/utils/audit/log.ts
+++ b/app/utils/audit/log.ts
@@ -1,0 +1,173 @@
+/**
+ * Audit log helper.
+ *
+ * Single entry point for writing rows to `audit_log`. Read this file before
+ * adding new audit call sites — it is the source of truth for the audit
+ * philosophy in this codebase.
+ *
+ * ## Philosophy
+ *
+ * 1. **Audit must NEVER block the business action.** Log-and-continue. A
+ *    failed actor lookup logs to Pino and writes the row with a sentinel
+ *    actor value (`__missing__`); a failed insert is not handled here at
+ *    all and will roll the surrounding transaction back, which is correct
+ *    — the business mutation should not commit if its audit write failed.
+ *    Sentinel actors should be alerted on, never accepted as normal.
+ *
+ * 2. **Log values, not redactions.** The audience for `audit_log` is a
+ *    small trusted admin team behind GitHub OAuth. PII length-diffs are
+ *    useless for forensics, useless for GDPR subject access requests, and
+ *    useless for undo. Pass real before/after values in `details`. The
+ *    threat model does not justify field-level redaction.
+ *
+ * 3. **Always pass a transaction.** The `tx` parameter is required so the
+ *    audit write is atomic with the business mutation. No orphan audit
+ *    rows on rollback, no missing audit rows on commit.
+ *
+ * 4. **Business mutations only.** Use this helper when an admin (or the
+ *    system on behalf of an admin) makes a meaningful change you might
+ *    want to investigate later. Operational events (cron starts, request
+ *    traces, errors) belong in Pino, not here.
+ *
+ * ## Why one generic table instead of one per entity
+ *
+ * The existing `scheduleAuditLog` is entity-specific (it has a
+ * `pickup_location_id` column). That table predates this one and stays as
+ * it is — don't fork the design twice. Everything else routes through
+ * `auditLog` with `entity_type` + `entity_id` so we can add new audited
+ * entities without a migration.
+ */
+
+import { db } from "@/app/db/drizzle";
+import { auditLog } from "@/app/db/schema";
+import { logError } from "@/app/utils/logger";
+
+/**
+ * Drizzle transaction handle. Same shape as the parameter type used by
+ * `app/db/insert-parcels.ts` — extracts the tx type from `db.transaction`.
+ */
+export type AuditTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * Minimal session shape this helper needs. Intentionally narrower than
+ * next-auth's `Session` so we don't pull NextAuth types into utility code
+ * that may run from cron and from server actions alike.
+ */
+export interface AuditActorSession {
+    user?: {
+        githubUsername?: string | null;
+    };
+}
+
+/**
+ * Sentinel actor used when an authenticated session was passed but the
+ * username could not be resolved. This indicates a bug — alert on it,
+ * never accept as normal.
+ */
+export const MISSING_ACTOR_SENTINEL = "__missing__";
+
+/**
+ * Sentinel actor used when the caller explicitly passes `null` for the
+ * session, signalling an automated/system action (cron job, scheduled task,
+ * webhook handler with no user context).
+ */
+export const SYSTEM_ACTOR = "system";
+
+export interface RecordAuditEventArgs {
+    /**
+     * The actor who performed the action. Pass:
+     *  - the authenticated session for user-initiated actions
+     *  - `null` (explicitly) for automated/system actions
+     *
+     * If a session is passed but `user.githubUsername` is missing, the
+     * helper logs an error and writes the row with `actor_username =
+     * MISSING_ACTOR_SENTINEL` so the event is never lost.
+     */
+    session: AuditActorSession | null;
+
+    /**
+     * Coarse classifier for what was acted on. Examples:
+     * `'household'`, `'user_role'`, `'parcel'`. Keep these stable across
+     * call sites — they form the index used for "show me everything that
+     * happened to X" queries.
+     */
+    entityType: string;
+
+    /**
+     * The id of the affected entity, or `null` for actions that don't have
+     * a single subject. Stored as plain text — no FK — so audit rows
+     * outlive the entity they describe.
+     */
+    entityId: string | null;
+
+    /**
+     * What happened. Examples: `'created'`, `'updated'`, `'deleted'`,
+     * `'role_changed'`, `'picked_up'`, `'no_show_undone'`. Keep verbs
+     * consistent within an entity_type so log readers can scan them.
+     */
+    action: string;
+
+    /**
+     * Human-readable one-line description for direct UI display. Should
+     * make sense without parsing `details`. Example: `"Promoted bob to
+     * admin"`.
+     */
+    summary: string;
+
+    /**
+     * Optional structured before/after blob. Log real values — see
+     * philosophy point 2 at the top of this file.
+     */
+    details?: Record<string, unknown>;
+}
+
+/**
+ * Record one audit event inside the caller's transaction.
+ *
+ * Throws only on database failure (which will roll back the surrounding
+ * transaction along with the business mutation). Never throws on
+ * actor-resolution problems — see philosophy point 1.
+ */
+export async function recordAuditEvent(
+    tx: AuditTransaction,
+    args: RecordAuditEventArgs,
+): Promise<void> {
+    const actorUsername = resolveActor(args);
+
+    await tx.insert(auditLog).values({
+        actor_username: actorUsername,
+        entity_type: args.entityType,
+        entity_id: args.entityId,
+        action: args.action,
+        summary: args.summary,
+        details: args.details ?? null,
+    });
+}
+
+function resolveActor(args: RecordAuditEventArgs): string {
+    // Explicit null = system action (cron, scheduled task). The caller has
+    // affirmed there is no human actor, so this is not an error condition.
+    if (args.session === null) {
+        return SYSTEM_ACTOR;
+    }
+
+    const username = args.session.user?.githubUsername;
+    if (username) {
+        return username;
+    }
+
+    // A session object was passed but the username is missing. This is a
+    // bug somewhere upstream — surface it loudly via Pino but still write
+    // the audit row with a sentinel so the event is preserved. The
+    // business action must not be blocked by an audit-actor problem.
+    logError(
+        "Audit event recorded without resolvable actor — investigate",
+        new Error("audit_event_missing_actor"),
+        {
+            entityType: args.entityType,
+            entityId: args.entityId,
+            action: args.action,
+        },
+    );
+    return MISSING_ACTOR_SENTINEL;
+}

--- a/app/utils/audit/log.ts
+++ b/app/utils/audit/log.ts
@@ -60,9 +60,26 @@ export interface AuditActorSession {
 }
 
 /**
+ * Recursive JSON-serializable value type. The `details` column is `jsonb`,
+ * so anything passed to it must round-trip through `JSON.stringify` without
+ * loss. Typing `details` as `JsonObject` (instead of `Record<string,
+ * unknown>`) lets the compiler reject `Date`, `Map`, `Set`, `BigInt`, and
+ * functions at the call site — values that would otherwise either silently
+ * corrupt audit data (`Map` → `{}`) or throw at insert time and roll back
+ * the surrounding business mutation (`BigInt`).
+ */
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | JsonObject;
+export type JsonObject = { [key: string]: JsonValue };
+
+/**
  * Sentinel actor used when an authenticated session was passed but the
  * username could not be resolved. This indicates a bug — alert on it,
  * never accept as normal.
+ *
+ * Double-underscored to be provably non-colliding with real GitHub
+ * usernames (GitHub usernames are alphanumeric plus single internal
+ * hyphens, max 39 chars — no underscores allowed).
  */
 export const MISSING_ACTOR_SENTINEL = "__missing__";
 
@@ -70,8 +87,13 @@ export const MISSING_ACTOR_SENTINEL = "__missing__";
  * Sentinel actor used when the caller explicitly passes `null` for the
  * session, signalling an automated/system action (cron job, scheduled task,
  * webhook handler with no user context).
+ *
+ * Double-underscored for the same reason as `MISSING_ACTOR_SENTINEL` —
+ * `system` (without the underscores) is a valid GitHub username and is
+ * already used as a free-text fallback in a few places in this codebase,
+ * so a non-colliding sentinel is required to keep audit queries unambiguous.
  */
-export const SYSTEM_ACTOR = "system";
+export const SYSTEM_ACTOR = "__system__";
 
 export interface RecordAuditEventArgs {
     /**
@@ -116,9 +138,12 @@ export interface RecordAuditEventArgs {
 
     /**
      * Optional structured before/after blob. Log real values — see
-     * philosophy point 2 at the top of this file.
+     * philosophy point 2 at the top of this file. The recursive
+     * `JsonObject` type rejects values that don't round-trip through
+     * `JSON.stringify` (`Date`, `Map`, `Set`, `BigInt`, functions) at
+     * compile time; convert them yourself before passing.
      */
-    details?: Record<string, unknown>;
+    details?: JsonObject;
 }
 
 /**

--- a/migrations/0059_add_audit_log_table.sql
+++ b/migrations/0059_add_audit_log_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "audit_log" (
+	"id" text PRIMARY KEY NOT NULL,
+	"created_at" timestamp (1) with time zone DEFAULT now() NOT NULL,
+	"actor_username" varchar(100) NOT NULL,
+	"entity_type" text NOT NULL,
+	"entity_id" text,
+	"action" text NOT NULL,
+	"summary" text NOT NULL,
+	"details" jsonb
+);
+--> statement-breakpoint
+CREATE INDEX "idx_audit_log_entity" ON "audit_log" USING btree ("entity_type","entity_id");--> statement-breakpoint
+CREATE INDEX "idx_audit_log_actor" ON "audit_log" USING btree ("actor_username");--> statement-breakpoint
+CREATE INDEX "idx_audit_log_created" ON "audit_log" USING btree ("created_at");

--- a/migrations/meta/0059_snapshot.json
+++ b/migrations/meta/0059_snapshot.json
@@ -1,0 +1,2313 @@
+{
+  "id": "6d9a1662-75f2-4741-b148-76f21fa375a6",
+  "prevId": "d874fff8-bfac-45b9-868a-dc890d175102",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.additional_needs": {
+      "name": "additional_needs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "need": {
+          "name": "need",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_by": {
+          "name": "deactivated_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "additional_needs_need_unique": {
+          "name": "additional_needs_need_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "need"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_audit_log_entity": {
+          "name": "idx_audit_log_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_actor": {
+          "name": "idx_audit_log_actor",
+          "columns": [
+            {
+              "expression": "actor_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_created": {
+          "name": "idx_audit_log_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.csp_violations": {
+      "name": "csp_violations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "blocked_uri": {
+          "name": "blocked_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "violated_directive": {
+          "name": "violated_directive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_directive": {
+          "name": "effective_directive",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_policy": {
+          "name": "original_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_file": {
+          "name": "source_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column_number": {
+          "name": "column_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script_sample": {
+          "name": "script_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dietary_restrictions": {
+      "name": "dietary_restrictions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_by": {
+          "name": "deactivated_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dietary_restrictions_name_unique": {
+          "name": "dietary_restrictions_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.food_parcels": {
+      "name": "food_parcels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_location_id": {
+          "name": "pickup_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_date_time_earliest": {
+          "name": "pickup_date_time_earliest",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_date_time_latest": {
+          "name": "pickup_date_time_latest",
+          "type": "timestamp (0) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_picked_up": {
+          "name": "is_picked_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "picked_up_at": {
+          "name": "picked_up_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picked_up_by_user_id": {
+          "name": "picked_up_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by_user_id": {
+          "name": "deleted_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_show_at": {
+          "name": "no_show_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_show_by_user_id": {
+          "name": "no_show_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "food_parcels_household_id_households_id_fk": {
+          "name": "food_parcels_household_id_households_id_fk",
+          "tableFrom": "food_parcels",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "food_parcels_pickup_location_id_pickup_locations_id_fk": {
+          "name": "food_parcels_pickup_location_id_pickup_locations_id_fk",
+          "tableFrom": "food_parcels",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "pickup_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pickup_time_range_check": {
+          "name": "pickup_time_range_check",
+          "value": "\"food_parcels\".\"pickup_date_time_earliest\" <= \"food_parcels\".\"pickup_date_time_latest\""
+        },
+        "no_show_pickup_exclusivity_check": {
+          "name": "no_show_pickup_exclusivity_check",
+          "value": "NOT (\"food_parcels\".\"no_show_at\" IS NOT NULL AND \"food_parcels\".\"is_picked_up\" = true)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.global_settings": {
+      "name": "global_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "global_settings_key_unique": {
+          "name": "global_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.household_additional_needs": {
+      "name": "household_additional_needs",
+      "schema": "",
+      "columns": {
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "additional_need_id": {
+          "name": "additional_need_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "household_additional_needs_household_id_households_id_fk": {
+          "name": "household_additional_needs_household_id_households_id_fk",
+          "tableFrom": "household_additional_needs",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "household_additional_needs_additional_need_id_additional_needs_id_fk": {
+          "name": "household_additional_needs_additional_need_id_additional_needs_id_fk",
+          "tableFrom": "household_additional_needs",
+          "tableTo": "additional_needs",
+          "columnsFrom": [
+            "additional_need_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "household_additional_needs_household_id_additional_need_id_pk": {
+          "name": "household_additional_needs_household_id_additional_need_id_pk",
+          "columns": [
+            "household_id",
+            "additional_need_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.household_comments": {
+      "name": "household_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "author_github_username": {
+          "name": "author_github_username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "household_comments_household_id_households_id_fk": {
+          "name": "household_comments_household_id_households_id_fk",
+          "tableFrom": "household_comments",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.household_dietary_restrictions": {
+      "name": "household_dietary_restrictions",
+      "schema": "",
+      "columns": {
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dietary_restriction_id": {
+          "name": "dietary_restriction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "household_dietary_restrictions_household_id_households_id_fk": {
+          "name": "household_dietary_restrictions_household_id_households_id_fk",
+          "tableFrom": "household_dietary_restrictions",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "household_dietary_restrictions_dietary_restriction_id_dietary_restrictions_id_fk": {
+          "name": "household_dietary_restrictions_dietary_restriction_id_dietary_restrictions_id_fk",
+          "tableFrom": "household_dietary_restrictions",
+          "tableTo": "dietary_restrictions",
+          "columnsFrom": [
+            "dietary_restriction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "household_dietary_restrictions_household_id_dietary_restriction_id_pk": {
+          "name": "household_dietary_restrictions_household_id_dietary_restriction_id_pk",
+          "columns": [
+            "household_id",
+            "dietary_restriction_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.household_members": {
+      "name": "household_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "household_members_household_id_households_id_fk": {
+          "name": "household_members_household_id_households_id_fk",
+          "tableFrom": "household_members",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.household_verification_status": {
+      "name": "household_verification_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_by_user": {
+          "name": "verified_by_user",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_household_verification_household": {
+          "name": "idx_household_verification_household",
+          "columns": [
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_household_verification_status": {
+          "name": "idx_household_verification_status",
+          "columns": [
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_verified",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "household_verification_status_household_id_households_id_fk": {
+          "name": "household_verification_status_household_id_households_id_fk",
+          "tableFrom": "household_verification_status",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "household_verification_status_question_id_verification_questions_id_fk": {
+          "name": "household_verification_status_question_id_verification_questions_id_fk",
+          "tableFrom": "household_verification_status",
+          "tableTo": "verification_questions",
+          "columnsFrom": [
+            "question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "household_question_unique": {
+          "name": "household_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "household_id",
+            "question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.households": {
+      "name": "households",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsible_user_id": {
+          "name": "responsible_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymized_at": {
+          "name": "anonymized_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymized_by": {
+          "name": "anonymized_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noshow_followup_dismissed_at": {
+          "name": "noshow_followup_dismissed_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noshow_followup_dismissed_by": {
+          "name": "noshow_followup_dismissed_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_pickup_location_id": {
+          "name": "primary_pickup_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_households_phone_unique": {
+          "name": "idx_households_phone_unique",
+          "columns": [
+            {
+              "expression": "phone_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"households\".\"anonymized_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_households_primary_location": {
+          "name": "idx_households_primary_location",
+          "columns": [
+            {
+              "expression": "primary_pickup_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"households\".\"primary_pickup_location_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_households_responsible_user": {
+          "name": "idx_households_responsible_user",
+          "columns": [
+            {
+              "expression": "responsible_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "households_responsible_user_id_users_id_fk": {
+          "name": "households_responsible_user_id_users_id_fk",
+          "tableFrom": "households",
+          "tableTo": "users",
+          "columnsFrom": [
+            "responsible_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "households_primary_pickup_location_id_pickup_locations_id_fk": {
+          "name": "households_primary_pickup_location_id_pickup_locations_id_fk",
+          "tableFrom": "households",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "primary_pickup_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outgoing_sms": {
+      "name": "outgoing_sms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "sms_intent",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcel_id": {
+          "name": "parcel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_e164": {
+          "name": "to_e164",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sms_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_status_updated_at": {
+          "name": "provider_status_updated_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_failure": {
+          "name": "balance_failure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_by_user_id": {
+          "name": "dismissed_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_outgoing_sms_parcel_intent_unique": {
+          "name": "idx_outgoing_sms_parcel_intent_unique",
+          "columns": [
+            {
+              "expression": "intent",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parcel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outgoing_sms_ready_to_send": {
+          "name": "idx_outgoing_sms_ready_to_send",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outgoing_sms_idempotency_unique": {
+          "name": "idx_outgoing_sms_idempotency_unique",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outgoing_sms_sent_at": {
+          "name": "idx_outgoing_sms_sent_at",
+          "columns": [
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"outgoing_sms\".\"sent_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outgoing_sms_provider_message_id": {
+          "name": "idx_outgoing_sms_provider_message_id",
+          "columns": [
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"outgoing_sms\".\"provider_message_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outgoing_sms_active_failures": {
+          "name": "idx_outgoing_sms_active_failures",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"outgoing_sms\".\"status\" = 'failed' AND \"outgoing_sms\".\"dismissed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outgoing_sms_balance_failures": {
+          "name": "idx_outgoing_sms_balance_failures",
+          "columns": [
+            {
+              "expression": "balance_failure",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"outgoing_sms\".\"status\" = 'failed' AND \"outgoing_sms\".\"dismissed_at\" IS NULL AND \"outgoing_sms\".\"balance_failure\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outgoing_sms_parcel_id_food_parcels_id_fk": {
+          "name": "outgoing_sms_parcel_id_food_parcels_id_fk",
+          "tableFrom": "outgoing_sms",
+          "tableTo": "food_parcels",
+          "columnsFrom": [
+            "parcel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "outgoing_sms_household_id_households_id_fk": {
+          "name": "outgoing_sms_household_id_households_id_fk",
+          "tableFrom": "outgoing_sms",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pet_species_types": {
+      "name": "pet_species_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_by": {
+          "name": "deactivated_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pet_species_types_name_unique": {
+          "name": "pet_species_types_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pets": {
+      "name": "pets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pet_species_id": {
+          "name": "pet_species_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pets_household_id_households_id_fk": {
+          "name": "pets_household_id_households_id_fk",
+          "tableFrom": "pets",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pets_pet_species_id_pet_species_types_id_fk": {
+          "name": "pets_pet_species_id_pet_species_types_id_fk",
+          "tableFrom": "pets",
+          "tableTo": "pet_species_types",
+          "columnsFrom": [
+            "pet_species_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pickup_location_schedule_days": {
+      "name": "pickup_location_schedule_days",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weekday": {
+          "name": "weekday",
+          "type": "weekday",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_open": {
+          "name": "is_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "opening_time": {
+          "name": "opening_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closing_time": {
+          "name": "closing_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pickup_location_schedule_days_schedule_id_pickup_location_schedules_id_fk": {
+          "name": "pickup_location_schedule_days_schedule_id_pickup_location_schedules_id_fk",
+          "tableFrom": "pickup_location_schedule_days",
+          "tableTo": "pickup_location_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "opening_hours_check": {
+          "name": "opening_hours_check",
+          "value": "NOT \"pickup_location_schedule_days\".\"is_open\" OR (\"pickup_location_schedule_days\".\"opening_time\" IS NOT NULL AND \"pickup_location_schedule_days\".\"closing_time\" IS NOT NULL AND \"pickup_location_schedule_days\".\"opening_time\" < \"pickup_location_schedule_days\".\"closing_time\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pickup_location_schedules": {
+      "name": "pickup_location_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pickup_location_id": {
+          "name": "pickup_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pickup_location_schedules_location": {
+          "name": "idx_pickup_location_schedules_location",
+          "columns": [
+            {
+              "expression": "pickup_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pickup_location_schedule_no_overlap": {
+          "name": "idx_pickup_location_schedule_no_overlap",
+          "columns": [
+            {
+              "expression": "pickup_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pickup_location_schedules_pickup_location_id_pickup_locations_id_fk": {
+          "name": "pickup_location_schedules_pickup_location_id_pickup_locations_id_fk",
+          "tableFrom": "pickup_location_schedules",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "pickup_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "schedule_date_range_check": {
+          "name": "schedule_date_range_check",
+          "value": "\"pickup_location_schedules\".\"start_date\" <= \"pickup_location_schedules\".\"end_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pickup_locations": {
+      "name": "pickup_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street_address": {
+          "name": "street_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parcels_max_per_day": {
+          "name": "parcels_max_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_parcels_per_slot": {
+          "name": "max_parcels_per_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 4
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone_number": {
+          "name": "contact_phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_slot_duration_minutes": {
+          "name": "default_slot_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "outside_hours_count": {
+          "name": "outside_hours_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pickup_locations_postal_code_check": {
+          "name": "pickup_locations_postal_code_check",
+          "value": "LENGTH(\"pickup_locations\".\"postal_code\") = 5 AND \"pickup_locations\".\"postal_code\" ~ '^[0-9]{5}$'"
+        },
+        "pickup_locations_email_format_check": {
+          "name": "pickup_locations_email_format_check",
+          "value": "\"pickup_locations\".\"contact_email\" ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$'"
+        },
+        "pickup_locations_slot_duration_check": {
+          "name": "pickup_locations_slot_duration_check",
+          "value": "\"pickup_locations\".\"default_slot_duration_minutes\" > 0 AND \"pickup_locations\".\"default_slot_duration_minutes\" <= 240 AND \"pickup_locations\".\"default_slot_duration_minutes\" % 15 = 0"
+        },
+        "pickup_locations_max_parcels_per_slot_check": {
+          "name": "pickup_locations_max_parcels_per_slot_check",
+          "value": "\"pickup_locations\".\"max_parcels_per_slot\" IS NULL OR \"pickup_locations\".\"max_parcels_per_slot\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.privacy_policies": {
+      "name": "privacy_policies",
+      "schema": "",
+      "columns": {
+        "language": {
+          "name": "language",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "privacy_policies_language_created_at_pk": {
+          "name": "privacy_policies_language_created_at_pk",
+          "columns": [
+            "language",
+            "created_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_audit_log": {
+      "name": "schedule_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_location_id": {
+          "name": "pickup_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "changes_summary": {
+          "name": "changes_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_schedule_audit_log_location": {
+          "name": "idx_schedule_audit_log_location",
+          "columns": [
+            {
+              "expression": "pickup_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedule_audit_log_schedule": {
+          "name": "idx_schedule_audit_log_schedule",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_agreement_acceptances": {
+      "name": "user_agreement_acceptances",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_id": {
+          "name": "agreement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_agreement_acceptances_user": {
+          "name": "idx_user_agreement_acceptances_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_agreement_acceptances_agreement": {
+          "name": "idx_user_agreement_acceptances_agreement",
+          "columns": [
+            {
+              "expression": "agreement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_agreement_acceptances_user_id_users_id_fk": {
+          "name": "user_agreement_acceptances_user_id_users_id_fk",
+          "tableFrom": "user_agreement_acceptances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_agreement_acceptances_agreement_id_user_agreements_id_fk": {
+          "name": "user_agreement_acceptances_agreement_id_user_agreements_id_fk",
+          "tableFrom": "user_agreement_acceptances",
+          "tableTo": "user_agreements",
+          "columnsFrom": [
+            "agreement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_agreement_acceptances_user_id_agreement_id_pk": {
+          "name": "user_agreement_acceptances_user_id_agreement_id_pk",
+          "columns": [
+            "user_id",
+            "agreement_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_agreements": {
+      "name": "user_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_agreements_effective_from": {
+          "name": "idx_user_agreements_effective_from",
+          "columns": [
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_agreements_version_unique": {
+          "name": "user_agreements_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favorite_pickup_location_id": {
+          "name": "favorite_pickup_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'handout_staff'"
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_favorite_pickup_location_id_pickup_locations_id_fk": {
+          "name": "users_favorite_pickup_location_id_pickup_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "pickup_locations",
+          "columnsFrom": [
+            "favorite_pickup_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_username_unique": {
+          "name": "users_github_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_questions": {
+      "name": "verification_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "help_text": {
+          "name": "help_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (1) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_global_verification_questions_active_order": {
+          "name": "idx_global_verification_questions_active_order",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "other"
+      ]
+    },
+    "public.sms_intent": {
+      "name": "sms_intent",
+      "schema": "public",
+      "values": [
+        "pickup_reminder",
+        "pickup_updated",
+        "pickup_cancelled",
+        "consent_enrolment",
+        "enrolment",
+        "food_parcels_ended"
+      ]
+    },
+    "public.sms_status": {
+      "name": "sms_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "sending",
+        "sent",
+        "retrying",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "handout_staff"
+      ]
+    },
+    "public.weekday": {
+      "name": "weekday",
+      "schema": "public",
+      "values": [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1775851677129,
       "tag": "0058_typical_blackheart",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1776022154421,
+      "tag": "0059_add_audit_log_table",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Why

Phase 2 of the broader audit-trail effort. Pure infrastructure — no call sites yet, no behaviour change to anything that exists today. The gap fixes (household edits, role changes, parcel lifecycle, anonymization) land in subsequent PRs and route through this helper.

The earlier review pass cut the original plan from three audit tables to one. The reasoning: `scheduleAuditLog` already exists and shows the pattern works, but it is entity-specific (it has a `pickup_location_id` column). Adding a new table for every audited entity means a migration per entity. Routing through `audit_log` with `entity_type` + `entity_id` lets new audited entities ship without schema changes.

## Design decisions worth flagging

**One generic table, not three.** `entity_id` is plain text — no FK — so audit rows survive deletion of the entity they describe. Same trick `scheduleAuditLog.schedule_id` already uses. `scheduleAuditLog` itself stays untouched; the two can converge later if it ever matters, but that is not in scope.

**No `actor_user_id` FK, no snapshot column. Just `actor_username`.** Every other actor field in the schema (`created_by`, `changed_by`, `picked_up_by_user_id`, …) stores a GitHub username string. Username instability is a theoretical problem we have not observed, and adding a stable internal id alongside the snapshot doubles the write surface for marginal benefit. Match the existing convention. Revisit if it ever bites.

**Three rules enforced by the helper from day one** — see the comment block at the top of `app/utils/audit/log.ts`:

1. **Audit must never block the business action.** A missing actor logs to Pino (via `logError`) and writes the row with a `__missing__` sentinel rather than throwing — a transient session bug must not 500 a legitimate admin operation. Sentinel rows are the alarm channel, not a normal state. They should be alerted on.
2. **Log values, not redactions.** The audience is a small trusted admin team behind GitHub OAuth; the threat model does not justify field-level PII redaction. Pass real before/after values in `details`. Redaction would make the log useless for forensics, GDPR access requests, and undo, all at once.
3. **Always inside a transaction.** The `tx` parameter is required so audit writes are atomic with the business mutation. No orphan rows on rollback, no missing rows on commit.

## What's in the PR

- New `audit_log` table in `app/db/schema.ts` with columns `id`, `created_at`, `actor_username`, `entity_type`, `entity_id`, `action`, `summary`, `details` (jsonb), and three btree indexes on `(entity_type, entity_id)`, `actor_username`, and `created_at`.
- Migration `0058_late_victor_mancha.sql` (single `CREATE TABLE` + three `CREATE INDEX` statements).
- New helper module `app/utils/audit/log.ts` exporting `recordAuditEvent`, the actor sentinels (`SYSTEM_ACTOR`, `MISSING_ACTOR_SENTINEL`), and the `AuditTransaction` type. Includes the philosophy comment block at the top — that file is the source of truth for how audit writes work in this codebase, replacing the standalone `docs/audit-strategy.md` that an earlier draft of the plan called for.
- New integration test at `__tests__/integration/utils/audit-log.integration.test.ts` covering all three actor cases (real session, explicit `null` = system, session-without-username = sentinel + alarm), plus the transaction rollback contract (audit row vanishes when the surrounding transaction throws), plus the optional-fields edges (`null` entity_id, omitted details).
- `__tests__/db/test-db.ts` updated to truncate `audit_log` between tests.

## Notes

- **Migration number conflict with #352.** This PR's migration file is `0058_late_victor_mancha.sql`; Vasteras-Stadsmission/matkassen#352 has `0058_typical_blackheart.sql` on a different branch. Whichever PR lands second will need to bump its migration to `0059` during merge. Drizzle's `_journal.json` will conflict and needs manual resolution.
- The helper's `tx` parameter type matches `app/db/insert-parcels.ts:48` (`Parameters<Parameters<typeof db.transaction>[0]>[0]`). The pglite test db has a structurally identical but nominally different tx type, so the integration test casts via a small `asAuditTx<T>(tx)` helper. The cast lives in the test only — production callers get the strict type.
- This is the third small PR in a series. The first was Vasteras-Stadsmission/matkassen#352 (cascade FK fix). The second was Vasteras-Stadsmission/matkassen#353 (verification notes anonymization + GDPR docs). The next batch wires this helper into the actual gap call sites.