### PR TITLE
Make auth errors actionable for new staff onboarding

### DIFF
--- a/__tests__/app/utils/auth/org-eligibility.test.ts
+++ b/__tests__/app/utils/auth/org-eligibility.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for the GitHub org eligibility check.
+ *
+ * Focus: the 403 logging path added in the onboarding-friction PR.
+ * When GitHub returns 403, we (a) collapse to `org_resource_forbidden`,
+ * (b) log the body message + relevant headers so we can later distinguish
+ * SSO/SAML, rate-limit and 2FA causes, and (c) pass the body message
+ * through on the OrgEligibility result.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockLoggerWarn, mockLoggerInfo, mockLoggerError } = vi.hoisted(() => ({
+    mockLoggerWarn: vi.fn(),
+    mockLoggerInfo: vi.fn(),
+    mockLoggerError: vi.fn(),
+}));
+
+vi.mock("@/app/utils/logger", () => ({
+    logger: {
+        warn: mockLoggerWarn,
+        info: mockLoggerInfo,
+        error: mockLoggerError,
+    },
+    logError: vi.fn(),
+}));
+
+import { checkGitHubOrgEligibility } from "@/app/utils/auth/org-eligibility";
+
+function makeResponse(
+    status: number,
+    body: unknown,
+    headers: Record<string, string> = {},
+): Response {
+    const json = body === null ? "" : JSON.stringify(body);
+    return new Response(json, {
+        status,
+        headers: {
+            "content-type": "application/json",
+            ...headers,
+        },
+    });
+}
+
+describe("checkGitHubOrgEligibility - 403 handling", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        fetchSpy.mockReset();
+    });
+
+    it("returns org_resource_forbidden and passes through GitHub's body message on 403", async () => {
+        fetchSpy.mockResolvedValueOnce(
+            makeResponse(
+                403,
+                {
+                    message: "You must have two-factor authentication enabled to access this org.",
+                    documentation_url:
+                        "https://docs.github.com/articles/about-two-factor-authentication",
+                },
+                {
+                    "x-ratelimit-remaining": "59",
+                    "x-ratelimit-limit": "60",
+                },
+            ),
+        );
+
+        const result = await checkGitHubOrgEligibility({
+            // Use a unique token per test to avoid the in-memory cache leaking state.
+            accessToken: `tok-2fa-${Math.random()}`,
+            organization: "vasteras-stadsmission",
+            context: "test",
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.status).toBe("org_resource_forbidden");
+        expect(result.httpStatus).toBe(403);
+        expect(result.message).toBe(
+            "You must have two-factor authentication enabled to access this org.",
+        );
+    });
+
+    it("logs structured 403 details including SSO and rate-limit headers", async () => {
+        fetchSpy.mockResolvedValueOnce(
+            makeResponse(
+                403,
+                { message: "Resource protected by organization SAML enforcement." },
+                {
+                    "x-github-sso":
+                        "required; url=https://github.com/orgs/vasteras-stadsmission/sso",
+                    "x-github-request-id": "ABCD:1234:DEADBEEF:0001:65000000",
+                    "x-ratelimit-limit": "5000",
+                    "x-ratelimit-remaining": "4998",
+                    "x-ratelimit-reset": "1700000000",
+                    "x-ratelimit-resource": "core",
+                },
+            ),
+        );
+
+        await checkGitHubOrgEligibility({
+            accessToken: `tok-sso-${Math.random()}`,
+            organization: "vasteras-stadsmission",
+            context: "signin",
+        });
+
+        expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+        const [logFields, logMessage] = mockLoggerWarn.mock.calls[0];
+        expect(logMessage).toBe("GitHub returned 403 during org eligibility check");
+        expect(logFields).toMatchObject({
+            organization: "vasteras-stadsmission",
+            context: "signin",
+            path: "/user/memberships/orgs/vasteras-stadsmission",
+            httpStatus: 403,
+            githubMessage: "Resource protected by organization SAML enforcement.",
+            xGithubSso: "required; url=https://github.com/orgs/vasteras-stadsmission/sso",
+            xGithubRequestId: "ABCD:1234:DEADBEEF:0001:65000000",
+            xRatelimitLimit: "5000",
+            xRatelimitRemaining: "4998",
+            xRatelimitReset: "1700000000",
+            xRatelimitResource: "core",
+        });
+    });
+
+    it("handles a 403 with no body and no helpful headers gracefully", async () => {
+        fetchSpy.mockResolvedValueOnce(
+            new Response("not json", {
+                status: 403,
+                headers: { "content-type": "text/plain" },
+            }),
+        );
+
+        const result = await checkGitHubOrgEligibility({
+            accessToken: `tok-empty-${Math.random()}`,
+            organization: "vasteras-stadsmission",
+            context: "test",
+        });
+
+        expect(result.status).toBe("org_resource_forbidden");
+        expect(result.message).toBeUndefined();
+        expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+        const [logFields] = mockLoggerWarn.mock.calls[0];
+        expect(logFields.githubMessage).toBeUndefined();
+        expect(logFields.xGithubSso).toBeUndefined();
+    });
+
+    it("does not log a 403 warning for 404 (not_member)", async () => {
+        fetchSpy.mockResolvedValueOnce(makeResponse(404, { message: "Not Found" }));
+
+        const result = await checkGitHubOrgEligibility({
+            accessToken: `tok-404-${Math.random()}`,
+            organization: "vasteras-stadsmission",
+            context: "test",
+        });
+
+        expect(result.status).toBe("not_member");
+        expect(mockLoggerWarn).not.toHaveBeenCalled();
+    });
+});

--- a/__tests__/integration/auth/access-denied.integration.test.ts
+++ b/__tests__/integration/auth/access-denied.integration.test.ts
@@ -565,4 +565,207 @@ describe("Access Denied - Integration Tests", () => {
             });
         });
     });
+
+    /**
+     * The set of denial reasons accepted by AccessDeniedContent.tsx is duplicated
+     * here so we can guard against silent typos and to lock in the supported set.
+     * If you change the union in AccessDeniedContent.tsx, update this list too.
+     */
+    describe("AccessDeniedContent - denial reason validation", () => {
+        const VALID_REASONS = [
+            "not_member",
+            "membership_inactive",
+            "org_resource_forbidden",
+            "unauthenticated",
+            "rate_limited",
+            "github_error",
+            "admin_required",
+        ] as const;
+
+        function isDenialReason(value: string | undefined): boolean {
+            return VALID_REASONS.includes(value as (typeof VALID_REASONS)[number]);
+        }
+
+        it("recognises every supported reason, including the new admin_required", () => {
+            for (const reason of VALID_REASONS) {
+                expect(isDenialReason(reason)).toBe(true);
+            }
+        });
+
+        it("rejects unknown reasons", () => {
+            expect(isDenialReason("totally_made_up")).toBe(false);
+            expect(isDenialReason("")).toBe(false);
+            expect(isDenialReason(undefined)).toBe(false);
+        });
+    });
+
+    /**
+     * Mirrors the URL construction in AccessDeniedContent.tsx so the empty-org
+     * guard introduced in PR #1 stays correct. The component must NEVER produce
+     * a broken URL like https://github.com/orgs//invitation when GITHUB_ORG is
+     * unset, and it must percent-encode any unexpected characters in the slug.
+     */
+    describe("AccessDeniedContent - invitations URL construction", () => {
+        function buildInvitationsUrl(organization?: string): string | undefined {
+            if (!organization) return undefined;
+            return `https://github.com/orgs/${encodeURIComponent(organization)}/invitation`;
+        }
+
+        it("returns undefined when organization is empty", () => {
+            expect(buildInvitationsUrl(undefined)).toBeUndefined();
+            expect(buildInvitationsUrl("")).toBeUndefined();
+        });
+
+        it("returns a well-formed URL for a normal slug", () => {
+            expect(buildInvitationsUrl("vasteras-stadsmission")).toBe(
+                "https://github.com/orgs/vasteras-stadsmission/invitation",
+            );
+        });
+
+        it("percent-encodes unexpected characters", () => {
+            // GitHub org slugs are restricted, but we should not blindly trust env input.
+            expect(buildInvitationsUrl("weird name")).toBe(
+                "https://github.com/orgs/weird%20name/invitation",
+            );
+            expect(buildInvitationsUrl("a/b")).toBe("https://github.com/orgs/a%2Fb/invitation");
+        });
+    });
+
+    /**
+     * Reason → which UI branches should appear. This locks in the new
+     * admin_required branch and the soft-2FA / membership / transient buckets.
+     */
+    describe("AccessDeniedContent - reason → UI branch mapping", () => {
+        type Reason =
+            | "not_member"
+            | "membership_inactive"
+            | "org_resource_forbidden"
+            | "unauthenticated"
+            | "rate_limited"
+            | "github_error"
+            | "admin_required";
+
+        function classifyReason(reason: Reason | undefined) {
+            return {
+                is2faIssue: reason === "org_resource_forbidden",
+                isMembershipIssue: reason === "not_member" || reason === "membership_inactive",
+                isTransientError: reason === "rate_limited" || reason === "github_error",
+                isUnauthenticated: reason === "unauthenticated",
+                isAdminRequired: reason === "admin_required",
+            };
+        }
+
+        it("treats not_member and membership_inactive as membership issues", () => {
+            expect(classifyReason("not_member").isMembershipIssue).toBe(true);
+            expect(classifyReason("membership_inactive").isMembershipIssue).toBe(true);
+        });
+
+        it("treats only org_resource_forbidden as a 2FA issue", () => {
+            expect(classifyReason("org_resource_forbidden").is2faIssue).toBe(true);
+            expect(classifyReason("not_member").is2faIssue).toBe(false);
+            expect(classifyReason("admin_required").is2faIssue).toBe(false);
+        });
+
+        it("classifies admin_required as its own bucket", () => {
+            const c = classifyReason("admin_required");
+            expect(c.isAdminRequired).toBe(true);
+            expect(c.is2faIssue).toBe(false);
+            expect(c.isMembershipIssue).toBe(false);
+            expect(c.isTransientError).toBe(false);
+            expect(c.isUnauthenticated).toBe(false);
+        });
+
+        it("treats rate_limited and github_error as transient", () => {
+            expect(classifyReason("rate_limited").isTransientError).toBe(true);
+            expect(classifyReason("github_error").isTransientError).toBe(true);
+        });
+
+        it("only renders the check-invitations button for membership issues with a known org", () => {
+            // Replicates: {isMembershipIssue && hasOrganization && invitationsUrl && (...)}
+            function shouldRenderInvitationsButton(reason: Reason, organization?: string) {
+                const c = classifyReason(reason);
+                return c.isMembershipIssue && !!organization;
+            }
+
+            expect(shouldRenderInvitationsButton("not_member", "vasteras-stadsmission")).toBe(true);
+            expect(
+                shouldRenderInvitationsButton("membership_inactive", "vasteras-stadsmission"),
+            ).toBe(true);
+            // No org → no button (avoids broken /orgs//invitation URL)
+            expect(shouldRenderInvitationsButton("not_member", undefined)).toBe(false);
+            expect(shouldRenderInvitationsButton("not_member", "")).toBe(false);
+            // Wrong reason → no button
+            expect(
+                shouldRenderInvitationsButton("org_resource_forbidden", "vasteras-stadsmission"),
+            ).toBe(false);
+            expect(shouldRenderInvitationsButton("admin_required", "vasteras-stadsmission")).toBe(
+                false,
+            );
+        });
+
+        it("hides 'Sign out and try again' for the admin_required branch", () => {
+            // Replicates: {!isAdminRequired && (<Button onClick={handleSignOutAndRetry}>...)}
+            function shouldRenderSignOutButton(reason: Reason) {
+                return !classifyReason(reason).isAdminRequired;
+            }
+
+            expect(shouldRenderSignOutButton("admin_required")).toBe(false);
+            expect(shouldRenderSignOutButton("not_member")).toBe(true);
+            expect(shouldRenderSignOutButton("org_resource_forbidden")).toBe(true);
+            expect(shouldRenderSignOutButton("rate_limited")).toBe(true);
+        });
+
+        it("only renders the back-to-schedule CTA for admin_required", () => {
+            function shouldRenderBackToSchedule(reason: Reason) {
+                return classifyReason(reason).isAdminRequired;
+            }
+
+            expect(shouldRenderBackToSchedule("admin_required")).toBe(true);
+            expect(shouldRenderBackToSchedule("not_member")).toBe(false);
+            expect(shouldRenderBackToSchedule("org_resource_forbidden")).toBe(false);
+        });
+    });
+
+    /**
+     * AgreementProtection redirects handout_staff away from adminOnly pages
+     * to /auth/access-denied?reason=admin_required. This locks in the role-check
+     * decision so a future refactor can't silently let handout_staff through.
+     */
+    describe("AgreementProtection - admin-only role check", () => {
+        type SessionShape = { user?: { role?: "admin" | "handout_staff" } } | null;
+
+        function decideAdminGate(
+            session: SessionShape,
+            adminOnly: boolean,
+        ): "allow" | "redirect_admin_required" | "render_unauthorized" {
+            if (!session) return "render_unauthorized";
+            if (adminOnly && session.user?.role !== "admin") {
+                return "redirect_admin_required";
+            }
+            return "allow";
+        }
+
+        it("allows admin users on adminOnly pages", () => {
+            expect(decideAdminGate({ user: { role: "admin" } }, true)).toBe("allow");
+        });
+
+        it("redirects handout_staff to admin_required on adminOnly pages", () => {
+            expect(decideAdminGate({ user: { role: "handout_staff" } }, true)).toBe(
+                "redirect_admin_required",
+            );
+        });
+
+        it("allows handout_staff on non-admin pages", () => {
+            expect(decideAdminGate({ user: { role: "handout_staff" } }, false)).toBe("allow");
+        });
+
+        it("renders unauthorized fallback when there is no session", () => {
+            expect(decideAdminGate(null, true)).toBe("render_unauthorized");
+            expect(decideAdminGate(null, false)).toBe("render_unauthorized");
+        });
+
+        it("treats a session with no role as not-admin (defensive)", () => {
+            expect(decideAdminGate({ user: {} }, true)).toBe("redirect_admin_required");
+        });
+    });
 });

--- a/app/[locale]/auth/access-denied/AccessDeniedContent.tsx
+++ b/app/[locale]/auth/access-denied/AccessDeniedContent.tsx
@@ -15,6 +15,7 @@ import {
     Anchor,
 } from "@mantine/core";
 import { useTranslations } from "next-intl";
+import { Link } from "@/app/i18n/navigation";
 import Image from "next/image";
 import { signOut } from "next-auth/react";
 import {
@@ -25,6 +26,8 @@ import {
     IconDeviceMobile,
     IconFingerprint,
     IconLogout,
+    IconMailForward,
+    IconArrowLeft,
 } from "@tabler/icons-react";
 
 const GITHUB_SECURITY_URL = "https://github.com/settings/security";
@@ -35,7 +38,8 @@ type DenialReason =
     | "org_resource_forbidden"
     | "unauthenticated"
     | "rate_limited"
-    | "github_error";
+    | "github_error"
+    | "admin_required";
 
 function isDenialReason(value: string | undefined): value is DenialReason {
     return [
@@ -45,10 +49,17 @@ function isDenialReason(value: string | undefined): value is DenialReason {
         "unauthenticated",
         "rate_limited",
         "github_error",
+        "admin_required",
     ].includes(value ?? "");
 }
 
-export default function AccessDeniedContent({ reason }: { reason?: string }) {
+export default function AccessDeniedContent({
+    reason,
+    organization,
+}: {
+    reason?: string;
+    organization?: string;
+}) {
     const t = useTranslations("auth");
     const denialReason = isDenialReason(reason) ? reason : undefined;
 
@@ -61,6 +72,14 @@ export default function AccessDeniedContent({ reason }: { reason?: string }) {
         denialReason === "not_member" || denialReason === "membership_inactive";
     const isTransientError = denialReason === "rate_limited" || denialReason === "github_error";
     const isUnauthenticated = denialReason === "unauthenticated";
+    const isAdminRequired = denialReason === "admin_required";
+
+    // Only show org-specific text/links when the org is configured. Falls back
+    // gracefully if GITHUB_ORG is unset (e.g. in a misconfigured environment).
+    const hasOrganization = !!organization;
+    const invitationsUrl = hasOrganization
+        ? `https://github.com/orgs/${encodeURIComponent(organization)}/invitation`
+        : undefined;
 
     return (
         <Container size="sm" py="xl">
@@ -85,9 +104,18 @@ export default function AccessDeniedContent({ reason }: { reason?: string }) {
                             />
                         </Center>
 
-                        {/* Title */}
-                        <Title id="access-denied-title" order={1} size="h2" ta="center" c="red.8">
-                            {t("accessDenied.title")}
+                        {/* Title — admin_required uses a calmer color since it's a
+                            wrong-role informational screen, not an actual auth denial */}
+                        <Title
+                            id="access-denied-title"
+                            order={1}
+                            size="h2"
+                            ta="center"
+                            c={isAdminRequired ? "orange.8" : "red.8"}
+                        >
+                            {isAdminRequired
+                                ? t("accessDenied.adminRequired.title")
+                                : t("accessDenied.title")}
                         </Title>
 
                         {/* Targeted explanation based on reason */}
@@ -99,12 +127,19 @@ export default function AccessDeniedContent({ reason }: { reason?: string }) {
                                         denialReason === "membership_inactive"
                                             ? "accessDenied.explanations.membershipInactive"
                                             : "accessDenied.explanations.notMember",
+                                        {
+                                            organization:
+                                                organization ||
+                                                t("signInRequirements.authorizedOrgFallback"),
+                                        },
                                     )
                                   : isUnauthenticated
                                     ? t("accessDenied.explanations.unauthenticated")
                                     : isTransientError
                                       ? t("accessDenied.explanations.temporaryError")
-                                      : t("accessDenied.subtitle")}
+                                      : isAdminRequired
+                                        ? t("accessDenied.adminRequired.explanation")
+                                        : t("accessDenied.subtitle")}
                         </Alert>
 
                         {/* 2FA-specific content */}
@@ -223,10 +258,10 @@ export default function AccessDeniedContent({ reason }: { reason?: string }) {
                             </>
                         )}
 
-                        {/* Membership-specific content */}
-                        {isMembershipIssue && (
+                        {/* Admin-required-specific content */}
+                        {isAdminRequired && (
                             <Text size="sm" c="dimmed">
-                                {t("accessDenied.explanations.membershipHelp")}
+                                {t("accessDenied.adminRequired.howToFix")}
                             </Text>
                         )}
 
@@ -246,14 +281,43 @@ export default function AccessDeniedContent({ reason }: { reason?: string }) {
                                     {t("accessDenied.buttons.githubSettings")}
                                 </Button>
                             )}
-                            <Button
-                                onClick={handleSignOutAndRetry}
-                                leftSection={<IconLogout size={16} aria-hidden="true" />}
-                                variant={is2faIssue ? "light" : "filled"}
-                                fullWidth
-                            >
-                                {t("accessDenied.buttons.signOutAndRetry")}
-                            </Button>
+                            {isMembershipIssue && hasOrganization && invitationsUrl && (
+                                <Button
+                                    component="a"
+                                    href={invitationsUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    leftSection={<IconMailForward size={16} aria-hidden="true" />}
+                                    variant="filled"
+                                    fullWidth
+                                    aria-label={t("accessDenied.buttons.checkInvitationsAria", {
+                                        organization,
+                                    })}
+                                >
+                                    {t("accessDenied.buttons.checkInvitations")}
+                                </Button>
+                            )}
+                            {isAdminRequired && (
+                                <Button
+                                    component={Link}
+                                    href="/schedule"
+                                    leftSection={<IconArrowLeft size={16} aria-hidden="true" />}
+                                    variant="filled"
+                                    fullWidth
+                                >
+                                    {t("accessDenied.buttons.backToSchedule")}
+                                </Button>
+                            )}
+                            {!isAdminRequired && (
+                                <Button
+                                    onClick={handleSignOutAndRetry}
+                                    leftSection={<IconLogout size={16} aria-hidden="true" />}
+                                    variant={is2faIssue || isMembershipIssue ? "light" : "filled"}
+                                    fullWidth
+                                >
+                                    {t("accessDenied.buttons.signOutAndRetry")}
+                                </Button>
+                            )}
                         </Stack>
 
                         {/* Support info */}

--- a/app/[locale]/auth/access-denied/page.tsx
+++ b/app/[locale]/auth/access-denied/page.tsx
@@ -10,5 +10,6 @@ export default async function AccessDeniedPage({
     searchParams: SearchParams | Promise<SearchParams>;
 }) {
     const { reason } = await searchParams;
-    return <AccessDeniedContent reason={reason} />;
+    const organization = process.env.GITHUB_ORG || undefined;
+    return <AccessDeniedContent reason={reason} organization={organization} />;
 }

--- a/app/[locale]/auth/error/ErrorContent.tsx
+++ b/app/[locale]/auth/error/ErrorContent.tsx
@@ -16,22 +16,23 @@ function ErrorContentWithSearchParams({ messageKey }: { messageKey?: string }) {
     const errorType = searchParams.get("error") || messageKey;
     const authT = useTranslations("auth");
 
-    // Map Auth.js official error types to translation keys
+    // Map Auth.js official error types to translation keys.
     // Reference: https://authjs.dev/guides/pages/error
+    //
+    // Note: org-membership and 2FA failures are NOT routed through this page —
+    // auth.ts redirects them straight to /auth/access-denied?reason=X with rich
+    // remediation copy. This page only handles the remaining Auth.js error
+    // categories (configuration, verification, invalid-provider, etc.).
     const getErrorMessage = () => {
         switch (errorType?.toLowerCase()) {
-            case "accessdenied":
-                return authT("errors.notOrgMember"); // Access denied - user not org member
             case "invalid-provider":
                 return authT("errors.invalidProvider"); // Invalid account provider
             case "configuration":
                 return authT("errors.configuration"); // Server configuration problems
             case "verification":
                 return authT("errors.verification"); // Email token expired/used
-            case "default":
-                return authT("errors.default"); // Catch-all error
             default:
-                return authT("errors.default"); // Fallback for any unrecognized errors
+                return authT("errors.default"); // Catch-all for any unrecognized errors
         }
     };
 

--- a/app/[locale]/auth/signin/SignInClient.tsx
+++ b/app/[locale]/auth/signin/SignInClient.tsx
@@ -1,31 +1,33 @@
 "use client";
 
-import { Container, Paper, Title, Text, Button, Group, Center, Stack } from "@mantine/core";
+import {
+    Container,
+    Paper,
+    Title,
+    Text,
+    Button,
+    Group,
+    Center,
+    Stack,
+    List,
+    ThemeIcon,
+} from "@mantine/core";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { signIn } from "next-auth/react";
 import Image from "next/image";
+import { IconCheck } from "@tabler/icons-react";
 import { Github } from "@/components/Icons";
 
 export function SignInClient({
     callbackUrl,
-    errorType,
+    organization,
 }: {
     callbackUrl: string;
-    errorType?: string;
+    organization?: string;
 }) {
     const t = useTranslations("auth");
     const [isLoading, setIsLoading] = useState(false);
-
-    const errorMessages = new Map<string, string>([
-        ["not-org-member", t("errors.notOrgMember")],
-        ["invalid-account-provider", t("errors.invalidProvider")],
-        ["default", t("errors.default")],
-    ]);
-
-    const errorMessage = errorType
-        ? (errorMessages.get(errorType) ?? errorMessages.get("default"))
-        : null;
 
     // Handle GitHub sign-in
     const handleGitHubSignIn = async () => {
@@ -62,17 +64,54 @@ export function SignInClient({
                             {t("signInTitle")}
                         </Title>
 
-                        {errorMessage && (
-                            <Text c="red" size="sm" ta="center">
-                                {errorMessage}
-                            </Text>
-                        )}
-
-                        <Text c="dimmed" size="sm" ta="center" mb="xl">
+                        <Text c="dimmed" size="sm" ta="center">
                             {t("signInDescription")}
                         </Text>
 
-                        <Group grow mb="md">
+                        <Stack gap="xs" mt="md">
+                            <Text size="sm" fw={600}>
+                                {t("signInRequirements.title")}
+                            </Text>
+                            <List spacing="xs" size="sm" center>
+                                <List.Item
+                                    icon={
+                                        <ThemeIcon
+                                            color="green"
+                                            size={20}
+                                            radius="xl"
+                                            variant="light"
+                                        >
+                                            <IconCheck size={14} aria-hidden="true" />
+                                        </ThemeIcon>
+                                    }
+                                >
+                                    {t("signInRequirements.account", {
+                                        organization:
+                                            organization ||
+                                            t("signInRequirements.authorizedOrgFallback"),
+                                    })}
+                                </List.Item>
+                                <List.Item
+                                    icon={
+                                        <ThemeIcon
+                                            color="green"
+                                            size={20}
+                                            radius="xl"
+                                            variant="light"
+                                        >
+                                            <IconCheck size={14} aria-hidden="true" />
+                                        </ThemeIcon>
+                                    }
+                                >
+                                    {t("signInRequirements.twofa")}
+                                </List.Item>
+                            </List>
+                            <Text size="xs" c="dimmed">
+                                {t("signInRequirements.newStaffHint")}
+                            </Text>
+                        </Stack>
+
+                        <Group grow mt="lg">
                             <Button
                                 onClick={handleGitHubSignIn}
                                 leftSection={<Github size={16} />}

--- a/app/[locale]/auth/signin/page.tsx
+++ b/app/[locale]/auth/signin/page.tsx
@@ -4,7 +4,6 @@ import { SignInClient } from "./SignInClient";
 
 type SearchParams = {
     callbackUrl?: string;
-    error?: string;
 };
 
 type Params = {
@@ -79,7 +78,7 @@ export default async function SignInPage({
     const session = await auth();
 
     // Destructure once to avoid multiple awaits
-    const { callbackUrl: rawCallbackUrl = "/", error } = await searchParams;
+    const { callbackUrl: rawCallbackUrl = "/" } = await searchParams;
     const { locale } = await params;
 
     // Sanitize callback URL to prevent open redirect
@@ -103,5 +102,6 @@ export default async function SignInPage({
         });
     }
 
-    return <SignInClient callbackUrl={callbackUrl} errorType={error} />;
+    const organization = process.env.GITHUB_ORG || undefined;
+    return <SignInClient callbackUrl={callbackUrl} organization={organization} />;
 }

--- a/app/utils/auth/org-eligibility.ts
+++ b/app/utils/auth/org-eligibility.ts
@@ -72,6 +72,50 @@ async function fetchGitHubJson(accessToken: string, path: string) {
     return { response, json };
 }
 
+/**
+ * Extract a human-readable message from a GitHub error response body, if present.
+ * GitHub returns objects like `{ "message": "...", "documentation_url": "..." }` for errors.
+ */
+function extractGitHubMessage(json: unknown): string | undefined {
+    if (!json || typeof json !== "object") return undefined;
+    const record = json as Record<string, unknown>;
+    return typeof record.message === "string" ? record.message : undefined;
+}
+
+/**
+ * Log details of a GitHub 403 so we can later judge whether to add precise classification.
+ * GitHub may include hints in the body message or in headers like X-GitHub-SSO.
+ * Today we still collapse all 403s to `org_resource_forbidden` and present a soft
+ * "GitHub denied access — most common cause is insecure 2FA" message in the UI.
+ */
+function logForbiddenDetails(
+    organization: string,
+    context: string,
+    path: string,
+    response: Response,
+    json: unknown,
+) {
+    logger.warn(
+        {
+            organization,
+            context,
+            path,
+            httpStatus: response.status,
+            githubMessage: extractGitHubMessage(json),
+            // Hints at what kind of 403 this is. Useful for distinguishing
+            // SSO/SAML authorization failures from rate-limit/abuse blocks
+            // and from generic forbidden responses.
+            xGithubSso: response.headers.get("x-github-sso") ?? undefined,
+            xGithubRequestId: response.headers.get("x-github-request-id") ?? undefined,
+            xRatelimitLimit: response.headers.get("x-ratelimit-limit") ?? undefined,
+            xRatelimitRemaining: response.headers.get("x-ratelimit-remaining") ?? undefined,
+            xRatelimitReset: response.headers.get("x-ratelimit-reset") ?? undefined,
+            xRatelimitResource: response.headers.get("x-ratelimit-resource") ?? undefined,
+        },
+        "GitHub returned 403 during org eligibility check",
+    );
+}
+
 export async function checkGitHubOrgEligibility({
     accessToken,
     organization,
@@ -144,12 +188,20 @@ export async function checkGitHubOrgEligibility({
         }
 
         if (membership.response.status === 403) {
+            logForbiddenDetails(
+                organization,
+                context,
+                `/user/memberships/orgs/${organization}`,
+                membership.response,
+                membership.json,
+            );
             const result: OrgEligibility = {
                 ok: false,
                 status: "org_resource_forbidden",
                 checkedAt: now,
                 nextCheckAt: now + recheckMs,
                 httpStatus: 403,
+                message: extractGitHubMessage(membership.json),
             };
             cacheSet(cacheKey, result);
             return result;
@@ -215,12 +267,20 @@ export async function checkGitHubOrgEligibility({
         }
 
         if (orgResource.response.status === 403) {
+            logForbiddenDetails(
+                organization,
+                context,
+                `/orgs/${organization}/teams`,
+                orgResource.response,
+                orgResource.json,
+            );
             const result: OrgEligibility = {
                 ok: false,
                 status: "org_resource_forbidden",
                 checkedAt: now,
                 nextCheckAt: now + recheckMs,
                 httpStatus: 403,
+                message: extractGitHubMessage(orgResource.json),
             };
             cacheSet(cacheKey, result);
             return result;

--- a/components/AgreementProtection/index.tsx
+++ b/components/AgreementProtection/index.tsx
@@ -21,35 +21,36 @@ interface AgreementProtectionProps {
  * A server component that protects content behind both authentication AND agreement acceptance
  * Renders the unauthorized content if the user is not authenticated
  * Redirects to /agreement if the user hasn't accepted the current agreement
- * When adminOnly=true, renders access-denied if the user has the handout_staff role
+ * When adminOnly=true, redirects handout_staff to /auth/access-denied?reason=admin_required
  * Works alongside the middleware protection for defense in depth
  */
 export async function AgreementProtection({
     children,
-    unauthorized = (
-        <Container size="xl" py="xl">
-            <div className="flex justify-center items-center h-[calc(100vh-180px)]">
-                <p className="text-xl font-medium">Please sign in to access this page</p>
-            </div>
-        </Container>
-    ),
+    unauthorized,
     adminOnly = false,
 }: AgreementProtectionProps) {
     const session = await auth();
 
     if (!session) {
-        return unauthorized;
-    }
-
-    if (adminOnly && session.user?.role !== "admin") {
-        const t = await getTranslations("auth.accessDenied");
+        if (unauthorized) {
+            return unauthorized;
+        }
+        const t = await getTranslations("auth.protection");
         return (
             <Container size="xl" py="xl">
                 <div className="flex justify-center items-center h-[calc(100vh-180px)]">
-                    <p className="text-xl font-medium">{t("title")}</p>
+                    <p className="text-xl font-medium">{t("signInRequired")}</p>
                 </div>
             </Container>
         );
+    }
+
+    if (adminOnly && session.user?.role !== "admin") {
+        const locale = await getLocale();
+        return redirect({
+            href: `/auth/access-denied?reason=admin_required`,
+            locale,
+        });
     }
 
     // Check if there's a current agreement that needs to be accepted

--- a/messages/en.json
+++ b/messages/en.json
@@ -28,8 +28,15 @@
         "login": "Log in",
         "logout": "Log out",
         "signInTitle": "Sign in to Matcentralen",
-        "signInDescription": "Sign in with your GitHub account to access the Matcentralen administration system.",
+        "signInDescription": "Sign in with your GitHub account.",
         "signInWithGitHub": "Sign in with GitHub",
+        "signInRequirements": {
+            "title": "Before you sign in, make sure you have:",
+            "account": "A GitHub account that is a member of the {organization} organization",
+            "twofa": "Two-factor authentication via authenticator app, passkey, or GitHub Mobile (SMS is not accepted)",
+            "newStaffHint": "New here? Ask your administrator to invite you to the GitHub organization first.",
+            "authorizedOrgFallback": "authorized"
+        },
         "errorTitle": "Authentication Error",
         "tryAgain": "Try Again",
         "account": "Account",
@@ -44,7 +51,6 @@
             "notOrgMember": "You must be a member of the authorized organization and comply with its security policies (secure 2FA required) to access this app.",
             "invalidProvider": "Invalid account provider. Please use GitHub.",
             "configuration": "There is a problem with the authentication configuration. Please contact support.",
-            "accessDenied": "Access denied. You don't have permission to sign in.",
             "verification": "Verification failed. Please try signing in again.",
             "default": "An error occurred while signing in. Please try again."
         },
@@ -52,12 +58,16 @@
             "title": "Access Denied",
             "subtitle": "We couldn't log you in. This is usually because your GitHub account needs additional security setup.",
             "explanations": {
-                "notMember": "Your GitHub account is not a member of the organization. Ask your administrator to send you an invitation.",
-                "membershipInactive": "You have a pending invitation to the organization. Check your email or GitHub notifications and accept the invitation.",
-                "insecure2fa": "Your GitHub account uses SMS for two-factor authentication. The organization requires a more secure method. Follow the steps below to fix this.",
+                "notMember": "Your GitHub account is not a member of the {organization} organization. Ask your administrator to send you an invitation, or check below if you already have one waiting.",
+                "membershipInactive": "You have a pending invitation to the {organization} organization. Open it on GitHub and accept it to continue.",
+                "insecure2fa": "GitHub denied access to your account. The most common reason is that your GitHub account does not have a secure two-factor authentication method enabled. If you already use one of the secure methods listed below, contact your organization administrator.",
                 "unauthenticated": "Your login is no longer valid. Please sign out and sign in again.",
-                "temporaryError": "We could not verify your account due to a temporary problem with GitHub. Please try again in a few minutes.",
-                "membershipHelp": "If you believe you should have access, contact your organization administrator to get an invitation."
+                "temporaryError": "We could not verify your account due to a temporary problem with GitHub. Please try again in a few minutes."
+            },
+            "adminRequired": {
+                "title": "Administrator role required",
+                "explanation": "This page is only available to administrators. You are signed in as Handout Staff.",
+                "howToFix": "Ask an existing administrator to change your role under Settings → Users. The change takes effect within a few minutes after you sign back in."
             },
             "reasons": {
                 "title": "Why am I seeing this?",
@@ -77,16 +87,19 @@
             },
             "howToFix": {
                 "title": "How to Fix This",
-                "step1": "Go to your GitHub Security Settings",
-                "step1Aria": "Go to your GitHub Security Settings (opens in new tab)",
-                "step2": "Find \"Password and authentication\" in the menu",
-                "step3": "Add one of the accepted methods listed above",
+                "step1": "Open your GitHub security settings",
+                "step1Aria": "Open your GitHub security settings (opens in new tab)",
+                "step2": "Under \"Two-factor authentication\", click \"Enable two-factor authentication\" (or \"Edit\" if it is already enabled)",
+                "step3": "Choose one of the accepted methods above and follow GitHub's setup instructions",
                 "step4": "Come back here and sign in again"
             },
             "buttons": {
-                "githubSettings": "Open GitHub Security Settings",
-                "githubSettingsAria": "Open GitHub Security Settings (opens in new tab)",
-                "signOutAndRetry": "Sign Out and Try Again"
+                "githubSettings": "Open GitHub security settings",
+                "githubSettingsAria": "Open GitHub security settings (opens in new tab)",
+                "checkInvitations": "Check pending invitations on GitHub",
+                "checkInvitationsAria": "Open the {organization} organization invitation page on GitHub (opens in new tab)",
+                "signOutAndRetry": "Sign out and try again",
+                "backToSchedule": "Back to schedule"
             },
             "support": "Still having trouble? Contact your organization administrator."
         }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -15,8 +15,15 @@
         "login": "Logga in",
         "logout": "Logga ut",
         "signInTitle": "Logga in på Matcentralen",
-        "signInDescription": "Logga in med ditt GitHub-konto för att få åtkomst till Matcentralens administrationssystem.",
+        "signInDescription": "Logga in med ditt GitHub-konto.",
         "signInWithGitHub": "Logga in med GitHub",
+        "signInRequirements": {
+            "title": "Innan du loggar in, se till att du har:",
+            "account": "Ett GitHub-konto som är medlem i {organization}",
+            "twofa": "Tvåfaktorsautentisering via autentiseringsapp, passkey eller GitHub Mobile (SMS godkänns inte)",
+            "newStaffHint": "Ny här? Be din administratör att bjuda in dig till GitHub-organisationen först.",
+            "authorizedOrgFallback": "den auktoriserade organisationen"
+        },
         "errorTitle": "Autentiseringsfel",
         "tryAgain": "Försök igen",
         "account": "Konto",
@@ -31,7 +38,6 @@
             "notOrgMember": "Du måste vara medlem i den auktoriserade organisationen och följa dess säkerhetspolicy (säker tvåfaktorsautentisering krävs) för att få åtkomst till appen.",
             "invalidProvider": "Ogiltig kontoleverantör. Använd GitHub.",
             "configuration": "Det är ett problem med autentiseringskonfigurationen. Kontakta support.",
-            "accessDenied": "Åtkomst nekad. Du har inte behörighet att logga in.",
             "verification": "Verifiering misslyckades. Försök logga in igen.",
             "default": "Ett fel uppstod vid inloggningen. Försök igen."
         },
@@ -39,12 +45,16 @@
             "title": "Åtkomst nekad",
             "subtitle": "Vi kunde inte logga in dig. Detta beror vanligtvis på att ditt GitHub-konto behöver ytterligare säkerhetsinställningar.",
             "explanations": {
-                "notMember": "Ditt GitHub-konto är inte medlem i organisationen. Be din administratör att skicka en inbjudan till dig.",
-                "membershipInactive": "Du har en väntande inbjudan till organisationen. Kolla din e-post eller GitHub-notiser och acceptera inbjudan.",
-                "insecure2fa": "Ditt GitHub-konto använder SMS för tvåfaktorsautentisering. Organisationen kräver en säkrare metod. Följ stegen nedan för att åtgärda detta.",
+                "notMember": "Ditt GitHub-konto är inte medlem i {organization}. Be din administratör att skicka en inbjudan till dig, eller kontrollera nedan om du redan har en väntande inbjudan.",
+                "membershipInactive": "Du har en väntande inbjudan till {organization}. Öppna den på GitHub och acceptera den för att fortsätta.",
+                "insecure2fa": "GitHub nekade åtkomst till ditt konto. Den vanligaste orsaken är att ditt GitHub-konto inte har en säker tvåfaktorsmetod aktiverad. Om du redan använder en av de säkra metoderna nedan, kontakta din organisationsadministratör.",
                 "unauthenticated": "Din inloggning är inte längre giltig. Logga ut och logga in igen.",
-                "temporaryError": "Vi kunde inte verifiera ditt konto på grund av ett tillfälligt problem hos GitHub. Försök igen om några minuter.",
-                "membershipHelp": "Om du anser att du borde ha åtkomst, kontakta din organisationsadministratör för att få en inbjudan."
+                "temporaryError": "Vi kunde inte verifiera ditt konto på grund av ett tillfälligt problem hos GitHub. Försök igen om några minuter."
+            },
+            "adminRequired": {
+                "title": "Administratörsrollen krävs",
+                "explanation": "Den här sidan är endast tillgänglig för administratörer. Du är inloggad som Utlämningspersonal.",
+                "howToFix": "Be en befintlig administratör att ändra din roll under Inställningar → Användare. Ändringen träder i kraft inom några minuter efter att du loggat in igen."
             },
             "reasons": {
                 "title": "Varför ser jag detta?",
@@ -64,16 +74,19 @@
             },
             "howToFix": {
                 "title": "Så här åtgärdar du detta",
-                "step1": "Gå till dina GitHub-säkerhetsinställningar",
-                "step1Aria": "Gå till dina GitHub-säkerhetsinställningar (öppnas i ny flik)",
-                "step2": "Hitta \"Password and authentication\" i menyn",
-                "step3": "Lägg till en av de godkända metoderna ovan",
+                "step1": "Öppna dina GitHub-säkerhetsinställningar",
+                "step1Aria": "Öppna dina GitHub-säkerhetsinställningar (öppnas i ny flik)",
+                "step2": "Under \"Two-factor authentication\", klicka på \"Enable two-factor authentication\" (eller \"Edit\" om det redan är aktiverat)",
+                "step3": "Välj en av de godkända metoderna ovan och följ GitHubs instruktioner",
                 "step4": "Kom tillbaka hit och logga in igen"
             },
             "buttons": {
                 "githubSettings": "Öppna GitHub-säkerhetsinställningar",
                 "githubSettingsAria": "Öppna GitHub-säkerhetsinställningar (öppnas i ny flik)",
-                "signOutAndRetry": "Logga ut och försök igen"
+                "checkInvitations": "Kontrollera väntande inbjudningar på GitHub",
+                "checkInvitationsAria": "Öppna inbjudningssidan för organisationen {organization} på GitHub (öppnas i ny flik)",
+                "signOutAndRetry": "Logga ut och försök igen",
+                "backToSchedule": "Tillbaka till schemat"
             },
             "support": "Har du fortfarande problem? Kontakta din organisationsadministratör."
         }


### PR DESCRIPTION
## Why

Onboarding a new staff member to Matcentralen has five steps before they can use the app:

1. Create a GitHub account
2. Enable secure 2FA (the hardest step for non-technical staff)
3. Get invited to the `vasteras-stadsmission` GitHub org and accept the invitation
4. First sign-in (lands as Utlämningspersonal)
5. Optional admin promotion

Today, when sign-in fails at any of these steps, the user sees error messages that are confusing, misleading, or actively wrong — for example, the access-denied page **always** told users they had insecure SMS 2FA on any GitHub 403, even when the real cause was something else entirely (SAML SSO, IP restrictions, blocked user, etc.). And when a Utlämningspersonal hit an admin-only page, they got a bare "Access Denied" string with no explanation of what role they needed or how to get it.

This PR makes each failure point self-explanatory so users can recognise *what* went wrong and *what to do about it*, without needing to ask an admin first.

## What changed

| Area | Before | After |
|---|---|---|
| GitHub 403 → 2FA error page | Confidently asserted "Your account uses SMS 2FA. Fix it." for any 403 | Says "GitHub denied access. The most common cause is insecure 2FA. If you already use a secure method, contact your admin." Still shows the same fix walkthrough, but no longer accuses users of something we don't actually know |
| 403 logging | Only the HTTP status was logged | Now logs `githubMessage`, `xGithubSso`, `xGithubRequestId`, and the full set of `xRatelimit*` headers — so we can later judge whether precise classification (SAML vs. 2FA vs. rate-limit) is worth implementing based on real production data |
| `not_member` / `membership_inactive` page | Just text saying "ask your admin to invite you" | Adds a **"Check pending invitations on GitHub"** button linking to `https://github.com/orgs/vasteras-stadsmission/invitation`. Most "I never got the invite" cases are actually "you got it but never accepted it" — now they can verify in one click |
| Membership error copy | Generic "the organization" | Names the org explicitly (`vasteras-stadsmission`) so admins and users have a shared vocabulary. Falls back gracefully when `GITHUB_ORG` env is unset |
| Sign-in page | Generic "Sign in with your GitHub account" | Adds a **requirements checklist** upfront: "GitHub account, member of {org}" and "2FA via authenticator/passkey/GitHub Mobile (SMS not accepted)". Sets expectations *before* the user hits an error |
| Sign-in page error display | Mapped a couple of legacy `?error=` codes that nothing actually emits | Removed — `auth.ts` already redirects all real failures to `/auth/access-denied` with rich copy. One source of truth for auth errors instead of two |
| `/auth/error` page | Mapped `accessdenied` → "you're not an org member", which was wrong because Auth.js uses that code for any signIn callback returning false | Removed the misleading mapping; the page now only handles `configuration`/`verification`/`invalid-provider` (the cases `auth.ts` actually routes there). Added a code comment explaining the routing split |
| Admin-only protection | `<AgreementProtection adminOnly>` rendered a bare "Access Denied" text in a centered div for handout_staff | Redirects to `/auth/access-denied?reason=admin_required`, which now has its own role-aware branch: orange title (not red — wrong role isn't a denial), explains "You are signed in as Utlämningspersonal", tells the user how to get promoted, and the CTA is "Back to schedule" instead of "Sign out and try again" |
| `AgreementProtection` unauthenticated fallback | Hardcoded English `"Please sign in to access this page"` | Translated via the existing `auth.protection.signInRequired` key |
| 2FA setup walkthrough | Step-by-step Swedish instructions, but vague ("Find Password and authentication", "Add an accepted method") | Quotes the exact English UI labels users will encounter on github.com/settings/security ("Two-factor authentication", "Enable two-factor authentication", "Edit") so they can match the Swedish instructions to the English page |

## Design decisions

**Why not auto-classify the GitHub 403 into precise reasons?** GitHub's 403 responses don't reliably distinguish "you have insecure 2FA" from "SAML SSO not authorized" from "you're rate-limited" from "you're blocked from the org". The body message and `X-GitHub-SSO` header sometimes hint, sometimes don't. Rather than building a brittle classifier today, we log everything we'd need (`githubMessage`, `xGithubSso`, full rate-limit headers, request id) and soften the user-facing copy. After running this in production for a while, we can decide whether classification is worth it based on real data.

**Why redirect from `AgreementProtection` instead of building a second denial UI?** A reviewer (independent code review, run via codex mcp) pointed out that having two separate access-denied UIs is fragile — one in `AccessDeniedContent.tsx` and another inside `AgreementProtection.tsx`. By redirecting handout_staff to `/auth/access-denied?reason=admin_required` we get one source of truth, the user gets the same Mantine layout as other denial reasons, and the role-specific copy lives next to all the other reason-specific copy.

**Why an i18n fallback string instead of dual translation keys?** Initial attempt added `notMemberNoOrg`/`membershipInactiveNoOrg` keys for the empty-`GITHUB_ORG` case. That tripped on a stale `messages/en.d.json.ts` (next-intl auto-generates this; it gets out of sync if you only run `pnpm typecheck` between i18n edits). The cleaner approach: keep one translation per reason with the `{organization}` placeholder, and substitute a locale-appropriate fallback (`"authorized"` in English / `"den auktoriserade organisationen"` in Swedish) when the env var is empty. This required rephrasing the Swedish strings to put `{organization}` at the end of the noun phrase instead of after "organisationen", since Swedish adjectives precede nouns. Single source of truth per reason; sentences read naturally with both proper-noun and fallback substitutions.

**Why cap the 2FA detection effort at "soften and log"?** A previous version of this PR considered parsing GitHub's response body to precisely classify SSO vs. 2FA vs. unknown. Independent review pushed back: the GitHub response is not a reliable signal for SMS-only 2FA specifically, and over-confidently presenting "you have SMS 2FA" was actively wrong for users who, e.g., had been blocked from the org. The minimum-viable improvement is to stop accusing and start observing.

## What's intentionally NOT in this PR

- **Welcome banner / first-login state on `/schedule`** — separate PR (PR 2) once we agree on what it should say.
- **In-app `/help` page rendering the existing Swedish staff manuals** — separate PR (PR 3) because it has Docker packaging implications (`docs/` is currently not copied into the standalone runner image).
- **`AuthProtection` and `AuthProtectionClient` cleanup** — these components are dead code (only referenced in `AGENTS.md` and `docs/auth-guide.md`, never imported anywhere). I left them and the `errors.notOrgMember` translation key alone to keep this PR's scope tight. Worth a follow-up to delete them entirely.
- **Pre-existing UX loop on `/schedule/[locationSlug]`** — both `/schedule/[locationSlug]/page.tsx` and `.../weekly/page.tsx` are wrapped in `<AgreementProtection adminOnly>`, which means handout_staff who click a specific location now get redirected to admin_required → "Back to schedule" → location list → click → loop. This PR exposes the latent bug but doesn't fix it; the right fix is to either drop `adminOnly` from those routes or scope the role check more narrowly. Worth its own ticket because it's a product question, not a code one.
- **Documentation of the onboarding process in `docs/admin-manual-sv.md`** — agreed in the planning conversation but bundled into PR 2/3 since it's content work, not code.

## Note on `.eslintrc.json`

This PR was developed in a worktree at `.claude/worktrees/onboarding-pr1`, which is nested *inside* the matkassen repo. ESLint v9 walks up from the worktree CWD and finds the parent matkassen's `.eslintrc.json`, then refuses to merge them because both load `@next/next` from a different node_modules path. This breaks `pnpm lint` and the pre-push `validate` hook in nested worktrees. Adding `"root": true` to the project's `.eslintrc.json` would fix this permanently, but it's out of scope for an auth-UX PR. Flagging it as a potential separate cleanup.