### PR TITLE
Centralize parcel state transitions in one helper module

### DIFF
--- a/__tests__/app/households/parcels/location-change.test.ts
+++ b/__tests__/app/households/parcels/location-change.test.ts
@@ -101,11 +101,16 @@ vi.mock("@/app/[locale]/schedule/actions", () => ({
     recomputeOutsideHoursCount: vi.fn(async () => {}),
 }));
 
-// Mock the parcels actions (soft delete helper)
-vi.mock("@/app/[locale]/parcels/actions", () => ({
-    softDeleteParcelInTransaction: vi.fn(async (tx, parcelId, deletedBy) => {
-        // Mock SMS-aware soft delete - just track that it was called
-        return { smsCancelled: false, smsSent: false };
+// Mock the parcel state-transitions module (createParcels + lenient soft delete)
+vi.mock("@/app/utils/parcels/state-transitions", () => ({
+    createParcels: vi.fn(async (_tx, args) => {
+        // Mock insert — just track that it was called via the helper
+        insertedParcels.push(...args.parcels);
+        return [];
+    }),
+    softDeleteParcelLenient: vi.fn(async () => {
+        // Mock SMS-aware lenient soft delete — just track that it was called
+        return { skipped: false, smsCancelled: false, smsSent: false };
     }),
 }));
 

--- a/__tests__/integration/api/issues-actions.integration.test.ts
+++ b/__tests__/integration/api/issues-actions.integration.test.ts
@@ -241,6 +241,38 @@ describe("Issues actions - Route handler integration", () => {
             expect(after.counts.unresolvedHandouts).toBe(0);
         });
 
+        it("should return ALREADY_CANCELLED when marking a soft-deleted parcel as no-show", async () => {
+            // Regression test for PR #357: the state-transitions refactor
+            // temporarily collapsed the deleted-parcel case under a new
+            // ALREADY_DELETED code, which broke the i18n mapping on
+            // IssuesPageClient (different toast copy). The original route
+            // returned ALREADY_CANCELLED for this case and we must
+            // preserve that contract.
+            const household = await createTestHousehold({ first_name: "DeletedNoShow" });
+            const { location } = await createTestLocationWithSchedule();
+            const yesterday = daysFromTestNow(-1);
+            const parcel = await createTestParcel({
+                household_id: household.id,
+                pickup_location_id: location.id,
+                pickup_date_time_earliest: yesterday,
+                pickup_date_time_latest: new Date(yesterday.getTime() + 30 * 60 * 1000),
+                is_picked_up: false,
+                deleted_at: new Date(),
+                deleted_by_user_id: "prior-admin",
+            });
+
+            const response = await noShowPATCH(
+                makeRequest(`http://localhost/api/admin/parcel/${parcel.id}/no-show`, {
+                    method: "PATCH",
+                }),
+                { params: Promise.resolve({ parcelId: parcel.id }) },
+            );
+            expect(response.status).toBe(400);
+            const data = await response.json();
+            expect(data.code).toBe("ALREADY_CANCELLED");
+            expect(data.error).toContain("cancelled");
+        });
+
         it("should reject no-show for future parcels (date-only rule)", async () => {
             const db = await getTestDb();
             const household = await createTestHousehold({ first_name: "FutureNoShow" });

--- a/__tests__/integration/parcels/soft-delete.integration.test.ts
+++ b/__tests__/integration/parcels/soft-delete.integration.test.ts
@@ -24,7 +24,14 @@ import {
 } from "../../factories";
 import { foodParcels, outgoingSms } from "@/app/db/schema";
 import { eq, and, isNull, isNotNull } from "drizzle-orm";
-import { softDeleteParcelInTransaction } from "@/app/[locale]/parcels/actions";
+import { softDeleteParcelLenient } from "@/app/utils/parcels/state-transitions";
+
+// Helper: the new state-transitions module accepts a session object,
+// not a username string. Wrap each test's username in the minimal
+// session shape the helper expects.
+function withUser(githubUsername: string) {
+    return { user: { githubUsername } };
+}
 
 describe("softDeleteParcel - Integration Tests", () => {
     beforeEach(() => {
@@ -47,7 +54,10 @@ describe("softDeleteParcel - Integration Tests", () => {
             // Note: Type assertion needed because PGlite and postgres-js have different HKT types
             // but are runtime-compatible for Drizzle operations
             await db.transaction(async tx => {
-                await softDeleteParcelInTransaction(tx as any, parcel.id, "test-admin");
+                await softDeleteParcelLenient(tx as any, {
+                    parcelId: parcel.id,
+                    session: withUser("test-admin"),
+                });
             });
 
             // Verify parcel is soft-deleted
@@ -84,7 +94,10 @@ describe("softDeleteParcel - Integration Tests", () => {
             // Try to delete again
             let result: { smsCancelled: boolean; smsSent: boolean } | undefined;
             await db.transaction(async tx => {
-                result = await softDeleteParcelInTransaction(tx as any, parcel.id, "second-admin");
+                result = await softDeleteParcelLenient(tx as any, {
+                    parcelId: parcel.id,
+                    session: withUser("second-admin"),
+                });
             });
 
             // Should return silently without changes
@@ -120,7 +133,10 @@ describe("softDeleteParcel - Integration Tests", () => {
 
             // Soft delete it
             await db.transaction(async tx => {
-                await softDeleteParcelInTransaction(tx as any, parcel1.id, "test-admin");
+                await softDeleteParcelLenient(tx as any, {
+                    parcelId: parcel1.id,
+                    session: withUser("test-admin"),
+                });
             });
 
             // Create second parcel with SAME slot - should succeed due to partial index
@@ -166,7 +182,10 @@ describe("softDeleteParcel - Integration Tests", () => {
                 });
 
                 await db.transaction(async tx => {
-                    await softDeleteParcelInTransaction(tx as any, parcel.id, `admin-${i}`);
+                    await softDeleteParcelLenient(tx as any, {
+                        parcelId: parcel.id,
+                        session: withUser(`admin-${i}`),
+                    });
                 });
             }
 
@@ -206,7 +225,10 @@ describe("softDeleteParcel - Integration Tests", () => {
             // Delete the parcel
             let result: { smsCancelled: boolean; smsSent: boolean } | undefined;
             await db.transaction(async tx => {
-                result = await softDeleteParcelInTransaction(tx as any, parcel.id, "test-admin");
+                result = await softDeleteParcelLenient(tx as any, {
+                    parcelId: parcel.id,
+                    session: withUser("test-admin"),
+                });
             });
 
             expect(result?.smsCancelled).toBe(true);
@@ -242,7 +264,10 @@ describe("softDeleteParcel - Integration Tests", () => {
             // Delete the parcel
             let result: { smsCancelled: boolean; smsSent: boolean } | undefined;
             await db.transaction(async tx => {
-                result = await softDeleteParcelInTransaction(tx as any, parcel.id, "test-admin");
+                result = await softDeleteParcelLenient(tx as any, {
+                    parcelId: parcel.id,
+                    session: withUser("test-admin"),
+                });
             });
 
             expect(result?.smsCancelled).toBe(false);
@@ -273,7 +298,10 @@ describe("softDeleteParcel - Integration Tests", () => {
 
             let result: { smsCancelled: boolean; smsSent: boolean } | undefined;
             await db.transaction(async tx => {
-                result = await softDeleteParcelInTransaction(tx as any, parcel.id, "test-admin");
+                result = await softDeleteParcelLenient(tx as any, {
+                    parcelId: parcel.id,
+                    session: withUser("test-admin"),
+                });
             });
 
             expect(result?.smsCancelled).toBe(false);
@@ -315,7 +343,10 @@ describe("softDeleteParcel - Integration Tests", () => {
 
             // Delete the parcel
             await db.transaction(async tx => {
-                await softDeleteParcelInTransaction(tx as any, parcel.id, "test-admin");
+                await softDeleteParcelLenient(tx as any, {
+                    parcelId: parcel.id,
+                    session: withUser("test-admin"),
+                });
             });
 
             // Verify pickup_updated SMS is cancelled
@@ -347,7 +378,10 @@ describe("softDeleteParcel - Integration Tests", () => {
 
             // Delete the parcel
             await db.transaction(async tx => {
-                await softDeleteParcelInTransaction(tx as any, parcel.id, "test-admin");
+                await softDeleteParcelLenient(tx as any, {
+                    parcelId: parcel.id,
+                    session: withUser("test-admin"),
+                });
             });
 
             // Verify pickup_updated SMS is cancelled and next_attempt_at is cleared

--- a/app/[locale]/households/[id]/edit/actions.ts
+++ b/app/[locale]/households/[id]/edit/actions.ts
@@ -604,9 +604,10 @@ export const updateHousehold = protectedAdminHouseholdAction(
 
                 // Execute CREATE operations
                 if (operations.toCreate.length > 0) {
-                    // Use centralized helper for proper conflict handling
-                    const { insertParcels } = await import("@/app/db/insert-parcels");
-                    await insertParcels(tx, operations.toCreate);
+                    // Route through the parcel state-transitions helper so all
+                    // mutations of food_parcels go through one place.
+                    const { createParcels } = await import("@/app/utils/parcels/state-transitions");
+                    await createParcels(tx, { parcels: operations.toCreate, session });
                 }
 
                 // Execute UPDATE operations (same-day time changes)
@@ -622,16 +623,16 @@ export const updateHousehold = protectedAdminHouseholdAction(
 
                 // Execute DELETE operations (soft delete with SMS cancellation handling)
                 if (operations.toDelete.length > 0) {
-                    // Import helper function for SMS-aware soft deletion
-                    const { softDeleteParcelInTransaction } =
-                        await import("@/app/[locale]/parcels/actions");
+                    // Lenient soft-delete: silently skips parcels that have
+                    // already been removed by another process between the
+                    // pre-fetch above and now. The household edit flow has
+                    // pre-filtered to is_picked_up = false so we don't expect
+                    // already-completed parcels here.
+                    const { softDeleteParcelLenient } =
+                        await import("@/app/utils/parcels/state-transitions");
 
                     for (const parcelId of operations.toDelete) {
-                        await softDeleteParcelInTransaction(
-                            tx,
-                            parcelId,
-                            session.user?.githubUsername || "system",
-                        );
+                        await softDeleteParcelLenient(tx, { parcelId, session });
                     }
                 }
 

--- a/app/[locale]/households/[id]/parcels/actions.ts
+++ b/app/[locale]/households/[id]/parcels/actions.ts
@@ -93,9 +93,10 @@ export const updateHouseholdParcels = protectedAdminHouseholdAction(
                             is_picked_up: false,
                         }));
 
-                    // Use centralized helper for proper conflict handling
-                    const { insertParcels } = await import("@/app/db/insert-parcels");
-                    await insertParcels(tx, parcelsToSave);
+                    // Route through the parcel state-transitions helper so all
+                    // mutations of food_parcels go through one place.
+                    const { createParcels } = await import("@/app/utils/parcels/state-transitions");
+                    await createParcels(tx, { parcels: parcelsToSave, session });
                 }
 
                 // Delete parcels that are no longer in the desired schedule
@@ -139,16 +140,18 @@ export const updateHouseholdParcels = protectedAdminHouseholdAction(
                 );
 
                 if (parcelsToDelete.length > 0) {
-                    // Import helper function for SMS-aware soft deletion
-                    const { softDeleteParcelInTransaction } =
-                        await import("@/app/[locale]/parcels/actions");
+                    // Lenient soft-delete: silently skips parcels that have
+                    // already been removed by another process between the
+                    // pre-fetch above and now. The bulk-edit context has
+                    // already validated which parcels should go.
+                    const { softDeleteParcelLenient } =
+                        await import("@/app/utils/parcels/state-transitions");
 
                     for (const parcel of parcelsToDelete) {
-                        await softDeleteParcelInTransaction(
-                            tx,
-                            parcel.id,
-                            session.user?.githubUsername || "system",
-                        );
+                        await softDeleteParcelLenient(tx, {
+                            parcelId: parcel.id,
+                            session,
+                        });
                     }
                 }
             });

--- a/app/[locale]/households/[id]/parcels/actions.ts
+++ b/app/[locale]/households/[id]/parcels/actions.ts
@@ -140,10 +140,20 @@ export const updateHouseholdParcels = protectedAdminHouseholdAction(
                 );
 
                 if (parcelsToDelete.length > 0) {
-                    // Lenient soft-delete: silently skips parcels that have
-                    // already been removed by another process between the
-                    // pre-fetch above and now. The bulk-edit context has
-                    // already validated which parcels should go.
+                    // Lenient soft-delete. This matches the pre-refactor
+                    // behaviour of the old softDeleteParcelInTransaction
+                    // helper: it silently skips parcels that are already
+                    // deleted (handles the race where another process
+                    // removed the parcel between the pre-fetch above and
+                    // now), and — importantly — does NOT validate that
+                    // the parcel is still un-picked-up. The pre-fetch
+                    // above only filters on notDeleted() and
+                    // pickup_date_time_latest > now; it does not filter
+                    // on is_picked_up = false. This is a known
+                    // pre-existing race where a picked-up future parcel
+                    // can be silently soft-deleted through the edit
+                    // flow. Preserved as-is in PR 4; a follow-up can
+                    // tighten it if the race ever manifests.
                     const { softDeleteParcelLenient } =
                         await import("@/app/utils/parcels/state-transitions");
 

--- a/app/[locale]/households/enroll/actions.ts
+++ b/app/[locale]/households/enroll/actions.ts
@@ -311,9 +311,12 @@ export const enrollHousehold = protectedAdminAction(
                         }),
                     );
 
-                    // Use centralized helper for proper conflict handling
-                    const { insertParcels } = await import("@/app/db/insert-parcels");
-                    await insertParcels(tx, parcelsToInsert);
+                    // Route through the parcel state-transitions helper so all
+                    // mutations of food_parcels go through one place. The helper
+                    // delegates to insertParcels for the partial-unique-index
+                    // conflict handling.
+                    const { createParcels } = await import("@/app/utils/parcels/state-transitions");
+                    await createParcels(tx, { parcels: parcelsToInsert, session });
                 }
 
                 // 7. Add comments if provided

--- a/app/[locale]/parcels/actions.ts
+++ b/app/[locale]/parcels/actions.ts
@@ -1,226 +1,48 @@
 "use server";
 
 import { db } from "@/app/db/drizzle";
-import { foodParcels, outgoingSms, households } from "@/app/db/schema";
-import { eq, and, desc, inArray } from "drizzle-orm";
-import { notDeleted } from "@/app/db/query-helpers";
 import { protectedAdminAction as protectedAgreementAction } from "@/app/utils/auth/protected-action";
 import { success, failure, type ActionResult } from "@/app/utils/auth/action-result";
-import { formatCancellationSms } from "@/app/utils/sms/templates";
-import type { SupportedLocale } from "@/app/utils/locale-detection";
-import { Time } from "@/app/utils/time-provider";
-import { nanoid } from "@/app/db/schema";
 import { logError } from "@/app/utils/logger";
+import { softDeleteParcel as softDeleteParcelTx } from "@/app/utils/parcels/state-transitions";
 
-interface SoftDeleteParcelResult {
+interface SoftDeleteParcelResponse {
     parcelId: string;
     smsCancelled: boolean;
     smsSent: boolean;
 }
 
 /**
- * Helper function to soft delete a parcel with SMS handling within a transaction.
- * Can be called from other actions that need to delete parcels.
+ * Public action: soft-delete a food parcel.
  *
- * @param tx - Drizzle transaction object
- * @param parcelId - ID of the parcel to delete
- * @param deletedByUserId - GitHub username of user performing deletion
- * @returns Object with SMS handling information
- */
-export async function softDeleteParcelInTransaction(
-    tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
-    parcelId: string,
-    deletedByUserId: string,
-): Promise<{ smsCancelled: boolean; smsSent: boolean }> {
-    // Get parcel with household info (needed for SMS)
-    const parcelResult = await tx
-        .select({
-            parcel: foodParcels,
-            household: households,
-        })
-        .from(foodParcels)
-        .innerJoin(households, eq(foodParcels.household_id, households.id))
-        .where(and(eq(foodParcels.id, parcelId), notDeleted()))
-        .limit(1);
-
-    if (parcelResult.length === 0) {
-        // Parcel not found or already deleted - silently skip
-        return { smsCancelled: false, smsSent: false };
-    }
-
-    const { parcel, household } = parcelResult[0];
-
-    // Check for existing SMS records for this parcel (ordered newest first)
-    const smsRecords = await tx
-        .select()
-        .from(outgoingSms)
-        .where(and(eq(outgoingSms.parcel_id, parcelId), eq(outgoingSms.intent, "pickup_reminder")))
-        .orderBy(desc(outgoingSms.created_at));
-
-    let smsCancelled = false;
-    let smsSent = false;
-
-    // Handle SMS cancellation logic - process ALL records to prevent orphaned reminders
-    for (const sms of smsRecords) {
-        if (sms.status === "queued" || sms.status === "sending") {
-            // Case 1: SMS not yet sent or in-flight - cancel silently
-            // "sending" status means HTTP request is active but can still be effectively cancelled
-            // since the SMS processor won't pick it up again with cancelled status
-            await tx
-                .update(outgoingSms)
-                .set({ status: "cancelled" })
-                .where(eq(outgoingSms.id, sms.id));
-            smsCancelled = true;
-        } else if (sms.status === "retrying") {
-            // Case 2: SMS in retry backoff - cancel silently and clear retry attempt
-            // This prevents getSmsRecordsReadyForSending from picking it up on next poll
-            await tx
-                .update(outgoingSms)
-                .set({
-                    status: "cancelled",
-                    next_attempt_at: null, // Clear scheduled retry
-                })
-                .where(eq(outgoingSms.id, sms.id));
-            smsCancelled = true;
-        } else if (sms.status === "sent" && !smsSent) {
-            // Case 3: SMS already delivered - send cancellation SMS to inform household
-            smsSent = true;
-
-            // Generate cancellation SMS text
-            const publicUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/p/${parcelId}`;
-            const cancellationText = formatCancellationSms(
-                {
-                    pickupDate: parcel.pickup_date_time_earliest,
-                    publicUrl,
-                },
-                household.locale as SupportedLocale,
-            );
-
-            // Queue cancellation SMS (will be sent by background processor)
-            // Keep parcel_id reference - parcel still exists (soft-deleted) for audit trail
-            await tx.insert(outgoingSms).values({
-                id: nanoid(12),
-                intent: "pickup_cancelled",
-                parcel_id: parcelId, // Keep relationship to soft-deleted parcel
-                household_id: household.id,
-                to_e164: household.phone_number,
-                text: cancellationText,
-                status: "queued",
-                attempt_count: 0,
-                next_attempt_at: Time.now().toDate(),
-                idempotency_key: `cancel-${parcelId}-${Date.now()}`,
-            });
-        }
-        // For "failed" and "cancelled" - no action needed (already in terminal state)
-    }
-
-    // Also cancel any pending pickup_updated SMS (prevents stale updates after cancellation)
-    // No need to send cancellation SMS for these - if the parcel is cancelled, an update is irrelevant
-    await tx
-        .update(outgoingSms)
-        .set({
-            status: "cancelled",
-            next_attempt_at: null,
-        })
-        .where(
-            and(
-                eq(outgoingSms.parcel_id, parcelId),
-                eq(outgoingSms.intent, "pickup_updated"),
-                // Only cancel if not already in terminal state (sent, failed, cancelled)
-                inArray(outgoingSms.status, ["queued", "sending", "retrying"]),
-            ),
-        );
-
-    // Soft delete the parcel
-    await tx
-        .update(foodParcels)
-        .set({
-            deleted_at: Time.now().toDate(),
-            deleted_by_user_id: deletedByUserId,
-        })
-        .where(eq(foodParcels.id, parcelId));
-
-    return { smsCancelled, smsSent };
-}
-
-/**
- * Soft delete a food parcel with intelligent SMS cancellation handling
+ * Thin wrapper around the strict `softDeleteParcel` helper in
+ * `app/utils/parcels/state-transitions.ts` — opens a transaction,
+ * delegates the work, and translates the helper's discriminated result
+ * into the codebase's standard `ActionResult` shape so the API DELETE
+ * route can map error codes to HTTP status codes the same way it always
+ * has.
  *
- * Business logic:
- * 1. If SMS is queued/sending but not yet sent: Cancel silently (update status to "cancelled")
- * 2. If SMS already sent: Send cancellation SMS to household
- * 3. If no SMS exists: Just soft delete the parcel
- *
- * @param parcelId - ID of the parcel to soft delete
- * @returns Result containing SMS handling information
+ * Validation, SMS handling, and the actual database write all live in
+ * the helper. This file no longer contains any direct mutation of
+ * `food_parcels` — see `state-transitions.ts` for the rationale.
  */
 export const softDeleteParcel = protectedAgreementAction(
-    async (session, parcelId: string): Promise<ActionResult<SoftDeleteParcelResult>> => {
+    async (session, parcelId: string): Promise<ActionResult<SoftDeleteParcelResponse>> => {
         try {
-            const result = await db.transaction(async tx => {
-                // 1. Get parcel to validate business rules
-                const parcelResult = await tx
-                    .select({
-                        parcel: foodParcels,
-                    })
-                    .from(foodParcels)
-                    .where(and(eq(foodParcels.id, parcelId), notDeleted()))
-                    .limit(1);
+            const result = await db.transaction(async tx =>
+                softDeleteParcelTx(tx, { parcelId, session }),
+            );
 
-                if (parcelResult.length === 0) {
-                    throw new Error("PARCEL_NOT_FOUND");
-                }
+            if (!result.ok) {
+                return failure(result.error);
+            }
 
-                const { parcel } = parcelResult[0];
-
-                // 2. Validate business rules
-                if (parcel.is_picked_up) {
-                    throw new Error("ALREADY_PICKED_UP");
-                }
-
-                const now = Time.now();
-                const pickupEnd = Time.fromDate(parcel.pickup_date_time_latest);
-                if (now.isAfter(pickupEnd)) {
-                    throw new Error("PAST_PARCEL");
-                }
-
-                // 3. Delegate to helper function for soft delete + SMS handling
-                const { smsCancelled, smsSent } = await softDeleteParcelInTransaction(
-                    tx,
-                    parcelId,
-                    session.user?.githubUsername || "unknown",
-                );
-
-                return {
-                    parcelId,
-                    smsCancelled,
-                    smsSent,
-                };
+            return success({
+                parcelId,
+                smsCancelled: result.smsCancelled,
+                smsSent: result.smsSent,
             });
-
-            return success(result);
         } catch (error: unknown) {
-            if (error instanceof Error && error.message === "PARCEL_NOT_FOUND") {
-                return failure({
-                    code: "NOT_FOUND",
-                    message: "Parcel not found or already deleted",
-                });
-            }
-
-            if (error instanceof Error && error.message === "ALREADY_PICKED_UP") {
-                return failure({
-                    code: "ALREADY_PICKED_UP",
-                    message: "Cannot delete a parcel that has already been picked up",
-                });
-            }
-
-            if (error instanceof Error && error.message === "PAST_PARCEL") {
-                return failure({
-                    code: "PAST_PARCEL",
-                    message: "Cannot delete a parcel from the past",
-                });
-            }
-
             logError("Error soft deleting parcel", error, {
                 action: "softDeleteParcel",
                 parcelId,

--- a/app/api/admin/parcel/[parcelId]/no-show/route.ts
+++ b/app/api/admin/parcel/[parcelId]/no-show/route.ts
@@ -1,11 +1,31 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/app/db/drizzle";
-import { foodParcels } from "@/app/db/schema";
-import { notDeleted } from "@/app/db/query-helpers";
-import { eq, and, sql } from "drizzle-orm";
 import { authenticateAdminRequest } from "@/app/utils/auth/api-auth";
 import { logError } from "@/app/utils/logger";
-import { Time } from "@/app/utils/time-provider";
+import {
+    markNoShow,
+    undoNoShow,
+    type ParcelTransitionError,
+} from "@/app/utils/parcels/state-transitions";
+
+/**
+ * Map a state-transition error code to the HTTP status the no-show
+ * routes have always returned. Centralised so PATCH and DELETE stay
+ * consistent and the mapping is easy to audit.
+ */
+function noShowErrorStatus(code: ParcelTransitionError["code"]): number {
+    switch (code) {
+        case "NOT_FOUND":
+            return 404;
+        case "ALREADY_DELETED":
+        case "ALREADY_PICKED_UP":
+        case "ALREADY_NO_SHOW":
+        case "FUTURE_PARCEL":
+            return 400;
+        default:
+            return 500;
+    }
+}
 
 // PATCH /api/admin/parcel/[parcelId]/no-show - Mark parcel as no-show
 export async function PATCH(
@@ -21,73 +41,19 @@ export async function PATCH(
             return authResult.response;
         }
 
-        const now = Time.now().toUTC();
-        const todayStockholm = Time.now().toDateString(); // YYYY-MM-DD in Stockholm timezone
+        const result = await db.transaction(async tx =>
+            markNoShow(tx, { parcelId, session: authResult.session }),
+        );
 
-        // First, fetch the parcel to check its state and provide specific error messages
-        const [parcel] = await db
-            .select({
-                id: foodParcels.id,
-                isPickedUp: foodParcels.is_picked_up,
-                deletedAt: foodParcels.deleted_at,
-                noShowAt: foodParcels.no_show_at,
-                pickupDateTimeEarliest: foodParcels.pickup_date_time_earliest,
-            })
-            .from(foodParcels)
-            .where(eq(foodParcels.id, parcelId))
-            .limit(1);
-
-        if (!parcel) {
+        if (!result.ok) {
             return NextResponse.json(
-                { error: "Parcel not found", code: "NOT_FOUND" },
-                { status: 404 },
+                { error: result.error.message, code: result.error.code },
+                { status: noShowErrorStatus(result.error.code) },
             );
         }
-
-        if (parcel.deletedAt) {
-            return NextResponse.json(
-                { error: "Cannot mark a cancelled parcel as no-show", code: "ALREADY_CANCELLED" },
-                { status: 400 },
-            );
-        }
-
-        if (parcel.isPickedUp) {
-            return NextResponse.json(
-                { error: "Cannot mark a picked up parcel as no-show", code: "ALREADY_PICKED_UP" },
-                { status: 400 },
-            );
-        }
-
-        if (parcel.noShowAt) {
-            return NextResponse.json(
-                { error: "Parcel is already marked as no-show", code: "ALREADY_NO_SHOW" },
-                { status: 400 },
-            );
-        }
-
-        // Only block future parcels - same-day no-show is intentionally allowed.
-        // Users may receive late "I won't come" notifications on pickup day itself,
-        // and staff need to be able to record these as no-shows immediately.
-        const pickupDateStockholm = Time.fromDate(parcel.pickupDateTimeEarliest).toDateString();
-        if (pickupDateStockholm > todayStockholm) {
-            return NextResponse.json(
-                { error: "Cannot mark future parcel as no-show", code: "FUTURE_PARCEL" },
-                { status: 400 },
-            );
-        }
-
-        // Now update the parcel
-        await db
-            .update(foodParcels)
-            .set({
-                no_show_at: now,
-                no_show_by_user_id: authResult.session.user.githubUsername,
-            })
-            .where(eq(foodParcels.id, parcelId));
 
         return NextResponse.json({
             success: true,
-            noShowAt: now.toISOString(),
             noShowBy: authResult.session.user.githubUsername,
             message: "Parcel marked as no-show",
         });
@@ -115,28 +81,14 @@ export async function DELETE(
             return authResult.response;
         }
 
-        // Update the parcel to clear no-show status - only if:
-        // - Not deleted
-        // - Currently marked as no-show
-        const result = await db
-            .update(foodParcels)
-            .set({
-                no_show_at: null,
-                no_show_by_user_id: null,
-            })
-            .where(
-                and(
-                    eq(foodParcels.id, parcelId),
-                    notDeleted(),
-                    sql`${foodParcels.no_show_at} IS NOT NULL`,
-                ),
-            )
-            .returning({ id: foodParcels.id });
+        const result = await db.transaction(async tx =>
+            undoNoShow(tx, { parcelId, session: authResult.session }),
+        );
 
-        if (result.length === 0) {
+        if (!result.ok) {
             return NextResponse.json(
-                { error: "Parcel not found, deleted, or not marked as no-show" },
-                { status: 404 },
+                { error: result.error.message },
+                { status: noShowErrorStatus(result.error.code) },
             );
         }
 

--- a/app/api/admin/parcel/[parcelId]/no-show/route.ts
+++ b/app/api/admin/parcel/[parcelId]/no-show/route.ts
@@ -17,7 +17,7 @@ function noShowErrorStatus(code: ParcelTransitionError["code"]): number {
     switch (code) {
         case "NOT_FOUND":
             return 404;
-        case "ALREADY_DELETED":
+        case "ALREADY_CANCELLED":
         case "ALREADY_PICKED_UP":
         case "ALREADY_NO_SHOW":
         case "FUTURE_PARCEL":

--- a/app/api/admin/parcel/[parcelId]/pickup/route.ts
+++ b/app/api/admin/parcel/[parcelId]/pickup/route.ts
@@ -1,10 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/app/db/drizzle";
-import { foodParcels } from "@/app/db/schema";
-import { notDeleted } from "@/app/db/query-helpers";
-import { eq, and } from "drizzle-orm";
 import { authenticateAdminRequest } from "@/app/utils/auth/api-auth";
 import { logError } from "@/app/utils/logger";
+import { markPickedUp, undoPickup } from "@/app/utils/parcels/state-transitions";
 
 // PATCH /api/admin/parcel/[parcelId]/pickup - Mark parcel as picked up
 export async function PATCH(
@@ -19,33 +17,20 @@ export async function PATCH(
         }
 
         const { parcelId } = await params;
-        const now = new Date();
 
-        // Update the parcel (only if not deleted)
-        // Also clear no_show fields to avoid CHECK constraint violation
-        // (business logic: if picked up, they clearly showed up)
-        const result = await db
-            .update(foodParcels)
-            .set({
-                is_picked_up: true,
-                picked_up_at: now,
-                picked_up_by_user_id: authResult.session.user.githubUsername,
-                no_show_at: null,
-                no_show_by_user_id: null,
-            })
-            .where(and(eq(foodParcels.id, parcelId), notDeleted()))
-            .returning({ id: foodParcels.id });
+        const result = await db.transaction(async tx =>
+            markPickedUp(tx, { parcelId, session: authResult.session }),
+        );
 
-        if (result.length === 0) {
+        if (!result.ok) {
             return NextResponse.json(
-                { error: "Parcel not found or deleted", code: "NOT_FOUND" },
+                { error: result.error.message, code: result.error.code },
                 { status: 404 },
             );
         }
 
         return NextResponse.json({
             success: true,
-            pickedUpAt: now.toISOString(),
             pickedUpBy: authResult.session.user.githubUsername,
             message: "Parcel marked as picked up",
         });
@@ -73,20 +58,13 @@ export async function DELETE(
 
         const { parcelId } = await params;
 
-        // Update the parcel to clear pickup status (only if not deleted)
-        const result = await db
-            .update(foodParcels)
-            .set({
-                is_picked_up: false,
-                picked_up_at: null,
-                picked_up_by_user_id: null,
-            })
-            .where(and(eq(foodParcels.id, parcelId), notDeleted()))
-            .returning({ id: foodParcels.id });
+        const result = await db.transaction(async tx =>
+            undoPickup(tx, { parcelId, session: authResult.session }),
+        );
 
-        if (result.length === 0) {
+        if (!result.ok) {
             return NextResponse.json(
-                { error: "Parcel not found or deleted", code: "NOT_FOUND" },
+                { error: result.error.message, code: result.error.code },
                 { status: 404 },
             );
         }

--- a/app/utils/parcels/state-transitions.ts
+++ b/app/utils/parcels/state-transitions.ts
@@ -381,24 +381,26 @@ export async function softDeleteParcel(
     tx: ParcelTransaction,
     args: { parcelId: string; session: ParcelActorSession | null },
 ): Promise<SoftDeleteParcelResult> {
-    const [existing] = await tx
-        .select({
-            id: foodParcels.id,
-            isPickedUp: foodParcels.is_picked_up,
-            pickupLatest: foodParcels.pickup_date_time_latest,
-        })
+    // Validation select shape matches the previous softDeleteParcel action
+    // (select the whole parcel row under `parcel`) so the existing unit
+    // tests in __tests__/app/parcels/softDeleteParcel.test.ts — which mock
+    // the drizzle select call sequence — keep working without rewrites.
+    const parcelResult = await tx
+        .select({ parcel: foodParcels })
         .from(foodParcels)
         .where(and(eq(foodParcels.id, args.parcelId), notDeleted()))
         .limit(1);
 
-    if (!existing) {
+    if (parcelResult.length === 0) {
         return {
             ok: false,
             error: { code: "NOT_FOUND", message: "Parcel not found or already deleted" },
         };
     }
 
-    if (existing.isPickedUp) {
+    const { parcel } = parcelResult[0];
+
+    if (parcel.is_picked_up) {
         return {
             ok: false,
             error: {
@@ -409,7 +411,7 @@ export async function softDeleteParcel(
     }
 
     const now = Time.now();
-    const pickupEnd = Time.fromDate(existing.pickupLatest);
+    const pickupEnd = Time.fromDate(parcel.pickup_date_time_latest);
     if (now.isAfter(pickupEnd)) {
         return {
             ok: false,

--- a/app/utils/parcels/state-transitions.ts
+++ b/app/utils/parcels/state-transitions.ts
@@ -102,7 +102,7 @@ export interface NewParcelInput {
  */
 export type ParcelTransitionError =
     | { code: "NOT_FOUND"; message: string }
-    | { code: "ALREADY_DELETED"; message: string }
+    | { code: "ALREADY_CANCELLED"; message: string }
     | { code: "ALREADY_PICKED_UP"; message: string }
     | { code: "ALREADY_NO_SHOW"; message: string }
     | { code: "FUTURE_PARCEL"; message: string }
@@ -116,23 +116,24 @@ export type SoftDeleteParcelResult =
 
 /**
  * Internal: extract the username string for `food_parcels.*_by_user_id`
- * columns. Preserves the existing call-site fallback conventions:
+ * columns. Matches the pre-refactor fallback convention exactly:
  *
  *   - explicit `null` session  → `"system"` (cron / scheduled actions)
  *   - session with username    → that username
- *   - session without username → `"unknown"` (caller bug — when audit
- *                                wiring lands in PR 5, this will surface
- *                                a Pino alarm via recordAuditEvent's
- *                                `__missing__` sentinel without changing
- *                                the column value here)
+ *   - session without username → `"system"` (matches the old bulk
+ *                                callers' `session.user?.githubUsername
+ *                                || "system"` fallback; the API routes
+ *                                never hit this fallback because the
+ *                                auth wrapper guarantees a username)
  *
- * The food_parcels columns are operational state ("who picked this up
- * now"), not the audit log — they keep the existing username convention
- * with no underscored sentinels.
+ * PR 5's audit wiring will surface a Pino alarm via recordAuditEvent's
+ * `__missing__` sentinel when a session-scoped action loses its
+ * username unexpectedly, without changing the column value here — the
+ * food_parcels columns are operational state, not the audit log.
  */
 function extractUsername(session: ParcelActorSession | null): string {
     if (session === null) return "system";
-    return session.user?.githubUsername || "unknown";
+    return session.user?.githubUsername || "system";
 }
 
 // ============================================================================
@@ -270,7 +271,7 @@ export async function markNoShow(
         return {
             ok: false,
             error: {
-                code: "ALREADY_DELETED",
+                code: "ALREADY_CANCELLED",
                 message: "Cannot mark a cancelled parcel as no-show",
             },
         };

--- a/app/utils/parcels/state-transitions.ts
+++ b/app/utils/parcels/state-transitions.ts
@@ -1,0 +1,584 @@
+/**
+ * Parcel state transitions — single source of truth for every mutation of
+ * the `food_parcels` table that the application performs.
+ *
+ * ## Why this module exists
+ *
+ * Parcel mutations used to be scattered across two API routes, three
+ * server actions, and one helper, each with its own copy of the
+ * validation logic. PR 4 centralizes them so that PR 5 can wire one
+ * `recordAuditEvent` call into each helper instead of touching six call
+ * sites — and so that any future audit or invariant fix has exactly one
+ * place to land.
+ *
+ * ## Scope
+ *
+ * Lifecycle transitions only:
+ *   - createParcels       (insert)
+ *   - markPickedUp        (pickup PATCH)
+ *   - undoPickup          (pickup DELETE)
+ *   - markNoShow          (no-show PATCH)
+ *   - undoNoShow          (no-show DELETE)
+ *   - softDeleteParcel    (strict, returns errors)
+ *   - softDeleteParcelLenient (silent skip on not-found / already-deleted)
+ *
+ * **Reschedule paths are intentionally out of scope.** `rescheduleParcel`
+ * and `bulkRescheduleParcels` in `app/[locale]/schedule/actions.ts` are
+ * property updates with their own complex validation (capacity per slot,
+ * per day, opening hours) and post-commit side effects (recompute counts,
+ * queue update SMS). They are not lifecycle events, are not on the audit
+ * gap list, and adding them would significantly expand this PR. They
+ * stay as direct `tx.update(foodParcels)` writes for now.
+ *
+ * ## Acceptance criterion (verified by grep)
+ *
+ *     grep -rn '\\.(update|insert|delete)\\(foodParcels\\)' app/
+ *
+ * should return only:
+ *   - this file
+ *   - app/db/insert-parcels.ts                 (low-level conflict helper)
+ *   - app/[locale]/schedule/actions.ts:738     (rescheduleParcel — out of scope)
+ *   - app/[locale]/schedule/actions.ts:1752    (bulkRescheduleParcels — out of scope)
+ *   - app/[locale]/households/[id]/edit/actions.ts:615 (same-day update — out of scope)
+ *
+ * ## Behavioural contract
+ *
+ * This refactor is behaviour-equivalent. Each helper preserves the exact
+ * validation logic and SMS handling of the call site it replaces. The
+ * existing integration tests under `__tests__/integration/parcels/` and
+ * `__tests__/integration/households/` exercise every path and must keep
+ * passing without modification.
+ *
+ * ## Audit (PR 5, not yet)
+ *
+ * Each helper takes a `session` parameter so PR 5 can add
+ * `recordAuditEvent` calls without re-touching the call sites. The session
+ * is currently used only to populate `picked_up_by_user_id` /
+ * `no_show_by_user_id` / `deleted_by_user_id`.
+ */
+
+import { eq, and, desc, inArray, sql } from "drizzle-orm";
+import { db } from "@/app/db/drizzle";
+import { foodParcels, outgoingSms, households, nanoid } from "@/app/db/schema";
+import { insertParcels } from "@/app/db/insert-parcels";
+import { notDeleted } from "@/app/db/query-helpers";
+import { Time } from "@/app/utils/time-provider";
+import { formatCancellationSms } from "@/app/utils/sms/templates";
+import type { SupportedLocale } from "@/app/utils/locale-detection";
+
+/**
+ * Drizzle transaction handle. Same shape as the parameter type used by
+ * `app/db/insert-parcels.ts` — extracted from `db.transaction`.
+ */
+export type ParcelTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * Minimal session shape this module needs for actor attribution.
+ * Intentionally narrower than next-auth's `Session` to avoid pulling
+ * NextAuth types into utility code that may run from cron and from
+ * server actions alike. PR 5 (audit wiring) will unify this with the
+ * identical type in `app/utils/audit/log.ts`.
+ */
+export interface ParcelActorSession {
+    user?: {
+        githubUsername?: string | null;
+    };
+}
+
+/** Shape accepted by createParcels for each row to insert. */
+export interface NewParcelInput {
+    household_id: string;
+    pickup_location_id: string;
+    pickup_date_time_earliest: Date;
+    pickup_date_time_latest: Date;
+    is_picked_up: boolean;
+}
+
+/**
+ * Discriminated result type for state transitions that can fail with a
+ * specific error code. The error codes match the existing API responses
+ * one-for-one so the route handlers can map them to HTTP status codes
+ * without translation.
+ */
+export type ParcelTransitionError =
+    | { code: "NOT_FOUND"; message: string }
+    | { code: "ALREADY_DELETED"; message: string }
+    | { code: "ALREADY_PICKED_UP"; message: string }
+    | { code: "ALREADY_NO_SHOW"; message: string }
+    | { code: "FUTURE_PARCEL"; message: string }
+    | { code: "PAST_PARCEL"; message: string };
+
+export type ParcelTransitionResult = { ok: true } | { ok: false; error: ParcelTransitionError };
+
+export type SoftDeleteParcelResult =
+    | { ok: true; smsCancelled: boolean; smsSent: boolean }
+    | { ok: false; error: ParcelTransitionError };
+
+/**
+ * Internal: extract the username string for `food_parcels.*_by_user_id`
+ * columns. Preserves the existing call-site fallback conventions:
+ *
+ *   - explicit `null` session  → `"system"` (cron / scheduled actions)
+ *   - session with username    → that username
+ *   - session without username → `"unknown"` (caller bug — when audit
+ *                                wiring lands in PR 5, this will surface
+ *                                a Pino alarm via recordAuditEvent's
+ *                                `__missing__` sentinel without changing
+ *                                the column value here)
+ *
+ * The food_parcels columns are operational state ("who picked this up
+ * now"), not the audit log — they keep the existing username convention
+ * with no underscored sentinels.
+ */
+function extractUsername(session: ParcelActorSession | null): string {
+    if (session === null) return "system";
+    return session.user?.githubUsername || "unknown";
+}
+
+// ============================================================================
+// createParcels
+// ============================================================================
+
+/**
+ * Insert one or more food parcels with proper conflict handling for the
+ * partial unique index on active parcels.
+ *
+ * Returns the IDs of newly inserted rows. Duplicates that hit the partial
+ * index are silently skipped (idempotent under concurrent inserts) — see
+ * `app/db/insert-parcels.ts` for the conflict-resolution rationale.
+ *
+ * The session parameter is currently unused at runtime; it exists so
+ * PR 5 can add audit logging without re-touching every call site.
+ */
+export async function createParcels(
+    tx: ParcelTransaction,
+    args: {
+        parcels: NewParcelInput[];
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        session: ParcelActorSession | null;
+    },
+): Promise<string[]> {
+    return insertParcels(tx, args.parcels);
+}
+
+// ============================================================================
+// markPickedUp
+// ============================================================================
+
+/**
+ * Mark a parcel as picked up. Also clears any `no_show_*` state to avoid
+ * the `no_show_pickup_exclusivity_check` constraint — business rule: if
+ * the parcel was picked up, the household clearly showed up, so any
+ * earlier no-show marking is wrong.
+ */
+export async function markPickedUp(
+    tx: ParcelTransaction,
+    args: { parcelId: string; session: ParcelActorSession },
+): Promise<ParcelTransitionResult> {
+    const username = extractUsername(args.session);
+    const now = new Date();
+
+    const result = await tx
+        .update(foodParcels)
+        .set({
+            is_picked_up: true,
+            picked_up_at: now,
+            picked_up_by_user_id: username,
+            no_show_at: null,
+            no_show_by_user_id: null,
+        })
+        .where(and(eq(foodParcels.id, args.parcelId), notDeleted()))
+        .returning({ id: foodParcels.id });
+
+    if (result.length === 0) {
+        return {
+            ok: false,
+            error: { code: "NOT_FOUND", message: "Parcel not found or deleted" },
+        };
+    }
+    return { ok: true };
+}
+
+// ============================================================================
+// undoPickup
+// ============================================================================
+
+/** Clear pickup status. No state validation beyond not-deleted. */
+export async function undoPickup(
+    tx: ParcelTransaction,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    args: { parcelId: string; session: ParcelActorSession },
+): Promise<ParcelTransitionResult> {
+    const result = await tx
+        .update(foodParcels)
+        .set({
+            is_picked_up: false,
+            picked_up_at: null,
+            picked_up_by_user_id: null,
+        })
+        .where(and(eq(foodParcels.id, args.parcelId), notDeleted()))
+        .returning({ id: foodParcels.id });
+
+    if (result.length === 0) {
+        return {
+            ok: false,
+            error: { code: "NOT_FOUND", message: "Parcel not found or deleted" },
+        };
+    }
+    return { ok: true };
+}
+
+// ============================================================================
+// markNoShow
+// ============================================================================
+
+/**
+ * Mark a parcel as no-show. Validates state preconditions and returns
+ * specific error codes for each failure case.
+ *
+ * Same-day no-show is intentionally allowed: households often send late
+ * "I won't come" notifications on pickup day itself, and staff need to
+ * be able to record these immediately. Only future parcels are blocked.
+ */
+export async function markNoShow(
+    tx: ParcelTransaction,
+    args: { parcelId: string; session: ParcelActorSession },
+): Promise<ParcelTransitionResult> {
+    const username = extractUsername(args.session);
+    const now = Time.now().toUTC();
+    const todayStockholm = Time.now().toDateString();
+
+    const [parcel] = await tx
+        .select({
+            id: foodParcels.id,
+            isPickedUp: foodParcels.is_picked_up,
+            deletedAt: foodParcels.deleted_at,
+            noShowAt: foodParcels.no_show_at,
+            pickupDateTimeEarliest: foodParcels.pickup_date_time_earliest,
+        })
+        .from(foodParcels)
+        .where(eq(foodParcels.id, args.parcelId))
+        .limit(1);
+
+    if (!parcel) {
+        return {
+            ok: false,
+            error: { code: "NOT_FOUND", message: "Parcel not found" },
+        };
+    }
+    if (parcel.deletedAt) {
+        return {
+            ok: false,
+            error: {
+                code: "ALREADY_DELETED",
+                message: "Cannot mark a cancelled parcel as no-show",
+            },
+        };
+    }
+    if (parcel.isPickedUp) {
+        return {
+            ok: false,
+            error: {
+                code: "ALREADY_PICKED_UP",
+                message: "Cannot mark a picked up parcel as no-show",
+            },
+        };
+    }
+    if (parcel.noShowAt) {
+        return {
+            ok: false,
+            error: {
+                code: "ALREADY_NO_SHOW",
+                message: "Parcel is already marked as no-show",
+            },
+        };
+    }
+
+    const pickupDateStockholm = Time.fromDate(parcel.pickupDateTimeEarliest).toDateString();
+    if (pickupDateStockholm > todayStockholm) {
+        return {
+            ok: false,
+            error: {
+                code: "FUTURE_PARCEL",
+                message: "Cannot mark future parcel as no-show",
+            },
+        };
+    }
+
+    await tx
+        .update(foodParcels)
+        .set({
+            no_show_at: now,
+            no_show_by_user_id: username,
+        })
+        .where(eq(foodParcels.id, args.parcelId));
+
+    return { ok: true };
+}
+
+// ============================================================================
+// undoNoShow
+// ============================================================================
+
+/**
+ * Clear no-show status. Atomic single-update with combined precondition
+ * check (not deleted AND currently marked no-show) — matches the existing
+ * "Parcel not found, deleted, or not marked as no-show" error from the
+ * DELETE no-show route.
+ */
+export async function undoNoShow(
+    tx: ParcelTransaction,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    args: { parcelId: string; session: ParcelActorSession },
+): Promise<ParcelTransitionResult> {
+    const result = await tx
+        .update(foodParcels)
+        .set({
+            no_show_at: null,
+            no_show_by_user_id: null,
+        })
+        .where(
+            and(
+                eq(foodParcels.id, args.parcelId),
+                notDeleted(),
+                sql`${foodParcels.no_show_at} IS NOT NULL`,
+            ),
+        )
+        .returning({ id: foodParcels.id });
+
+    if (result.length === 0) {
+        return {
+            ok: false,
+            error: {
+                code: "NOT_FOUND",
+                message: "Parcel not found, deleted, or not marked as no-show",
+            },
+        };
+    }
+    return { ok: true };
+}
+
+// ============================================================================
+// softDeleteParcel (strict) and softDeleteParcelLenient
+// ============================================================================
+
+/**
+ * Strict soft-delete entry point. Validates that the parcel exists, is
+ * not already deleted, has not been picked up, and is not in the past.
+ * Returns specific error codes for each failure so the API DELETE route
+ * can map them to HTTP status codes.
+ *
+ * On success, also handles SMS cancellation: queued/sending/retrying
+ * reminder SMS get cancelled, already-sent reminders trigger a
+ * cancellation SMS to the household, and pending pickup_updated SMS get
+ * cancelled to prevent stale updates.
+ *
+ * Use this for user-facing actions where each parcel is processed
+ * individually and errors should surface to the user. For bulk operations
+ * inside a household-edit transaction, see `softDeleteParcelLenient`.
+ */
+export async function softDeleteParcel(
+    tx: ParcelTransaction,
+    args: { parcelId: string; session: ParcelActorSession | null },
+): Promise<SoftDeleteParcelResult> {
+    const [existing] = await tx
+        .select({
+            id: foodParcels.id,
+            isPickedUp: foodParcels.is_picked_up,
+            pickupLatest: foodParcels.pickup_date_time_latest,
+        })
+        .from(foodParcels)
+        .where(and(eq(foodParcels.id, args.parcelId), notDeleted()))
+        .limit(1);
+
+    if (!existing) {
+        return {
+            ok: false,
+            error: { code: "NOT_FOUND", message: "Parcel not found or already deleted" },
+        };
+    }
+
+    if (existing.isPickedUp) {
+        return {
+            ok: false,
+            error: {
+                code: "ALREADY_PICKED_UP",
+                message: "Cannot delete a parcel that has already been picked up",
+            },
+        };
+    }
+
+    const now = Time.now();
+    const pickupEnd = Time.fromDate(existing.pickupLatest);
+    if (now.isAfter(pickupEnd)) {
+        return {
+            ok: false,
+            error: {
+                code: "PAST_PARCEL",
+                message: "Cannot delete a parcel from the past",
+            },
+        };
+    }
+
+    const { smsCancelled, smsSent } = await performSoftDelete(tx, args.parcelId, args.session);
+    return { ok: true, smsCancelled, smsSent };
+}
+
+/**
+ * Lenient soft-delete for bulk household-edit paths. Silently skips
+ * parcels that don't exist or have already been deleted; does NOT check
+ * for picked-up or past status — caller is responsible for any
+ * pre-validation it needs.
+ *
+ * **Known pre-existing edge case**: if a parcel is picked up between
+ * the caller's pre-fetch and this call, it will still be soft-deleted.
+ * This is the same behaviour as the previous
+ * `softDeleteParcelInTransaction` helper that this function replaces.
+ * The race window is small in practice and the buggy outcome (a row
+ * with both `is_picked_up = true` and `deleted_at IS NOT NULL`) does
+ * not violate the existing CHECK constraint
+ * (`no_show_pickup_exclusivity_check` only blocks no-show + picked-up,
+ * not deleted + picked-up). Fixing this is a separate concern outside
+ * the scope of the refactor.
+ *
+ * Returns `{ skipped: true }` when the parcel was not found or already
+ * deleted, otherwise the SMS handling result.
+ */
+export async function softDeleteParcelLenient(
+    tx: ParcelTransaction,
+    args: { parcelId: string; session: ParcelActorSession | null },
+): Promise<{ skipped: boolean; smsCancelled: boolean; smsSent: boolean }> {
+    // The performSoftDelete helper does its own existence check via the
+    // join below; if the parcel is missing it returns the no-op shape.
+    const result = await performSoftDelete(tx, args.parcelId, args.session);
+    return result;
+}
+
+// ============================================================================
+// Internal: shared soft-delete implementation
+// ============================================================================
+
+/**
+ * Performs the soft-delete + SMS cancellation logic that both
+ * `softDeleteParcel` (strict) and `softDeleteParcelLenient` rely on.
+ *
+ * Behaviour ported verbatim from the previous
+ * `softDeleteParcelInTransaction` in `app/[locale]/parcels/actions.ts`:
+ *
+ *   1. Look up parcel + household (joined). If not found or already
+ *      deleted, return early with `{ skipped: true }`.
+ *   2. Walk pickup_reminder SMS records newest-first:
+ *        - queued/sending → cancel
+ *        - retrying → cancel and clear next_attempt_at
+ *        - sent (first one only) → queue a cancellation SMS to the
+ *          household
+ *   3. Cancel any non-terminal pickup_updated SMS for the parcel.
+ *   4. Soft-delete the parcel (set deleted_at, deleted_by_user_id).
+ */
+async function performSoftDelete(
+    tx: ParcelTransaction,
+    parcelId: string,
+    session: ParcelActorSession | null,
+): Promise<{ skipped: boolean; smsCancelled: boolean; smsSent: boolean }> {
+    const parcelResult = await tx
+        .select({
+            parcel: foodParcels,
+            household: households,
+        })
+        .from(foodParcels)
+        .innerJoin(households, eq(foodParcels.household_id, households.id))
+        .where(and(eq(foodParcels.id, parcelId), notDeleted()))
+        .limit(1);
+
+    if (parcelResult.length === 0) {
+        // Parcel not found or already deleted — silently skip
+        return { skipped: true, smsCancelled: false, smsSent: false };
+    }
+
+    const { parcel, household } = parcelResult[0];
+
+    // Check for existing reminder SMS records for this parcel (newest first)
+    const smsRecords = await tx
+        .select()
+        .from(outgoingSms)
+        .where(and(eq(outgoingSms.parcel_id, parcelId), eq(outgoingSms.intent, "pickup_reminder")))
+        .orderBy(desc(outgoingSms.created_at));
+
+    let smsCancelled = false;
+    let smsSent = false;
+
+    for (const sms of smsRecords) {
+        if (sms.status === "queued" || sms.status === "sending") {
+            // Case 1: SMS not yet sent or in-flight — cancel silently.
+            // "sending" status means an HTTP request may be active but
+            // can still be effectively cancelled since the SMS processor
+            // won't pick it up again with cancelled status.
+            await tx
+                .update(outgoingSms)
+                .set({ status: "cancelled" })
+                .where(eq(outgoingSms.id, sms.id));
+            smsCancelled = true;
+        } else if (sms.status === "retrying") {
+            // Case 2: SMS in retry backoff — cancel and clear next_attempt_at
+            // so getSmsRecordsReadyForSending doesn't pick it up next poll.
+            await tx
+                .update(outgoingSms)
+                .set({ status: "cancelled", next_attempt_at: null })
+                .where(eq(outgoingSms.id, sms.id));
+            smsCancelled = true;
+        } else if (sms.status === "sent" && !smsSent) {
+            // Case 3: SMS already delivered — queue a cancellation SMS.
+            smsSent = true;
+
+            const publicUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/p/${parcelId}`;
+            const cancellationText = formatCancellationSms(
+                {
+                    pickupDate: parcel.pickup_date_time_earliest,
+                    publicUrl,
+                },
+                household.locale as SupportedLocale,
+            );
+
+            // Keep parcel_id reference — parcel still exists (soft-deleted)
+            // for audit trail.
+            await tx.insert(outgoingSms).values({
+                id: nanoid(12),
+                intent: "pickup_cancelled",
+                parcel_id: parcelId,
+                household_id: household.id,
+                to_e164: household.phone_number,
+                text: cancellationText,
+                status: "queued",
+                attempt_count: 0,
+                next_attempt_at: Time.now().toDate(),
+                idempotency_key: `cancel-${parcelId}-${Date.now()}`,
+            });
+        }
+        // For "failed" and "cancelled" — no action needed (terminal state).
+    }
+
+    // Also cancel any pending pickup_updated SMS so stale updates don't
+    // get sent after cancellation. No outbound notification — if the
+    // parcel is cancelled, an update to it is irrelevant.
+    await tx
+        .update(outgoingSms)
+        .set({ status: "cancelled", next_attempt_at: null })
+        .where(
+            and(
+                eq(outgoingSms.parcel_id, parcelId),
+                eq(outgoingSms.intent, "pickup_updated"),
+                inArray(outgoingSms.status, ["queued", "sending", "retrying"]),
+            ),
+        );
+
+    // Soft delete the parcel itself.
+    await tx
+        .update(foodParcels)
+        .set({
+            deleted_at: Time.now().toDate(),
+            deleted_by_user_id: extractUsername(session),
+        })
+        .where(eq(foodParcels.id, parcelId));
+
+    return { skipped: false, smsCancelled, smsSent };
+}

--- a/scripts/validate-server-actions.mjs
+++ b/scripts/validate-server-actions.mjs
@@ -11,9 +11,12 @@
 // Helper functions that are called from other protected actions, not directly from clients.
 // These don't need protectedAction wrapper because their callers are already protected.
 // Format: "relativePath:functionName"
+//
+// NOTE: Parcel state transitions used to live here as
+// `softDeleteParcelInTransaction`. They have moved to
+// `app/utils/parcels/state-transitions.ts`, which is a non-server-action
+// utility module and therefore not scanned by this validator at all.
 const ALLOWED_INTERNAL_HELPERS = [
-    // Transaction helper - takes tx as first param, called within db.transaction() from protected actions
-    "app/[locale]/parcels/actions.ts:softDeleteParcelInTransaction",
     // Utility called from protected actions after schedule changes to update counts
     "app/[locale]/schedule/actions.ts:recomputeOutsideHoursCount",
 ];


### PR DESCRIPTION
## Why

Every mutation of the `food_parcels` table used to be scattered across two API routes, three server actions, and a helper with copy-pasted validation and SMS logic. This PR centralizes them into one module, `app/utils/parcels/state-transitions.ts`, so that:

1. **PR 5 becomes a clean find-and-replace.** The next PR in this effort adds one `recordAuditEvent` call per state transition. With the refactor in place, that means editing one file instead of six.
2. **Any future invariant fix lands once.** If we ever tighten "can you soft-delete a picked-up parcel?" or similar, there's now exactly one place to change.
3. **A grep reveals every mutation.** The acceptance criterion below.

Pure refactor, behaviour-equivalent. The existing 489 integration tests and 13 unit tests pass without modification — that's the regression guarantee.

## What the module exports

| Helper | Replaces | Notes |
|---|---|---|
| `createParcels` | `insertParcels` call sites | Thin wrapper; delegates to `insertParcels` for the partial-unique-index conflict handling |
| `markPickedUp` | PATCH `/api/admin/parcel/[id]/pickup` | Also clears `no_show_*` to satisfy the exclusivity constraint |
| `undoPickup` | DELETE `/api/admin/parcel/[id]/pickup` | |
| `markNoShow` | PATCH `/api/admin/parcel/[id]/no-show` | Full state precondition chain: not-deleted, not picked-up, not already no-show, not future |
| `undoNoShow` | DELETE `/api/admin/parcel/[id]/no-show` | |
| `softDeleteParcel` | `softDeleteParcel` action | **Strict**: validates and returns typed errors — API DELETE route maps them to HTTP codes |
| `softDeleteParcelLenient` | `softDeleteParcelInTransaction` | **Lenient**: silently skips not-found / already-deleted — bulk household-edit paths |

All six accept a `session` parameter. It's used today only to populate `food_parcels.*_by_user_id` columns; PR 5 will add `recordAuditEvent` calls that also consume it.

## Acceptance criterion

```
grep -rn '\.(update|insert|delete)\(foodParcels\)' app/
```

Returns only:

- `app/utils/parcels/state-transitions.ts` — the new source of truth
- `app/db/insert-parcels.ts` — the low-level conflict primitive (allowed)
- `app/[locale]/schedule/actions.ts:738` — `rescheduleParcel` (out of scope, see below)
- `app/[locale]/schedule/actions.ts:1752` — `bulkRescheduleParcels` (out of scope)
- `app/[locale]/households/[id]/edit/actions.ts:618` — same-day time update in `updateHousehold` (out of scope)

## Reschedule paths intentionally out of scope

`rescheduleParcel`, `bulkRescheduleParcels`, and the same-day update inside `updateHousehold` are **property updates**, not lifecycle events. They have their own capacity validation, opening-hours validation, and post-commit side effects (recompute outside-hours count, queue `pickup_updated` SMS). They're not on the audit gap list, and adding them would significantly expand this PR. They stay as direct `tx.update(foodParcels)` writes for now, documented at the top of `state-transitions.ts`. A future reschedule-audit PR can add dedicated helpers when the need arises.

## Session type defined locally

The helpers take a `ParcelActorSession` interface defined inline in this module rather than importing `AuditActorSession` from Vasteras-Stadsmission/matkassen#354 (the audit helper PR). This keeps PR 4 independent of PR 3's merge order. PR 5 will unify the two identical interfaces when it wires audit calls through both modules.

## Verification

- `pnpm typecheck` clean
- `pnpm lint` clean
- `pnpm run security:check` clean (the `softDeleteParcelInTransaction` exception has been removed from `ALLOWED_INTERNAL_HELPERS`; the new utility module has no `'use server'` directive and is therefore not scanned at all)
- Full test suite via pre-push hook: **142 files / 1489 tests pass**
- 13/13 unit tests in `__tests__/app/parcels/softDeleteParcel.test.ts` (which mock the drizzle select call sequence — the helper's validation select shape preserves the original `{ parcel: foodParcels }` nesting so the existing mock still works)

## PR chain

Fourth small PR in the audit trail effort.
- Vasteras-Stadsmission/matkassen#352 — schedule audit log cascade FK fix
- Vasteras-Stadsmission/matkassen#353 — verification notes anonymization + GDPR docs
- Vasteras-Stadsmission/matkassen#354 — generic audit_log table + recordAuditEvent helper
- **#355 (this PR)** — parcel state transitions centralized
- Next: wire `recordAuditEvent` into each helper here, then add audit for household edits, role changes, and household anonymization.