### PR TITLE
Update staff documentation and fix stale content

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "extends": ["next/core-web-vitals", "next/typescript"],
     "rules": {
         "react/no-unescaped-entities": "off",

--- a/README.md
+++ b/README.md
@@ -456,6 +456,17 @@ Continuous deployment is configured for staging with manual promotion to product
 
 ## Documentation
 
-- `docs/user-manual.md` – operator guide for the admin portal
-- `docs/user-flows.md` – key workflows for volunteers and staff
+Staff-facing manuals (Swedish):
+
+- `docs/anvandarguide-sv.md` – overall user guide with diagrams
+- `docs/handout-staff-manual-sv.md` – daily handout operations for utlämningspersonal
+- `docs/case-worker-manual-sv.md` – household intake and scheduling for handläggare
+- `docs/admin-manual-sv.md` – settings, configuration, and staff onboarding for administrators
+
+Developer-facing documentation:
+
+- `docs/user-flows.md` – key workflows for volunteers and staff (diagrams)
+- `docs/auth-guide.md` – authentication and authorization patterns
+- `docs/business-logic.md` – domain concepts and rules
+- `docs/i18n-guide.md` – internationalization conventions
 - `AGENTS.md` – contribution guidance for AI assistants

--- a/docs/admin-manual-sv.md
+++ b/docs/admin-manual-sv.md
@@ -2,11 +2,40 @@
 
 Kort översikt av kugghjulsmenyn. Avsedd för administratörer och koordinatorer.
 
+## Lägga till ny personal
+
+Nya personer som ska börja arbeta i Matcentralen behöver gå igenom ett antal steg innan de kan logga in. Som administratör hjälper du dem genom processen.
+
+**Förutsättningar som personen själv måste ordna:**
+
+1. **GitHub-konto** – skapas kostnadsfritt på [github.com](https://github.com/join). Användarnamnet behöver inte vara ett riktigt namn; välj gärna något neutralt (t.ex. `förnamn-vs`).
+2. **Säker tvåfaktorsautentisering på GitHub** – organisationen godkänner endast säkra metoder:
+    - **GitHub Mobile-appen** (enklaste alternativet – bara en notis att godkänna)
+    - **Passkey** (Face ID, Touch ID, Windows Hello)
+    - **Autentiseringsapp** (Google Authenticator, Authy, Microsoft Authenticator)
+    - **SMS godkänns inte** – det räknas inte som säker tvåfaktorsautentisering. Om personen bara har SMS aktiverat kommer inloggningen att misslyckas.
+    - Stegvisa instruktioner visas automatiskt på inloggningssidan om något är fel.
+
+**Steg som du som admin gör:**
+
+3. **Bjud in personen till GitHub-organisationen `vasteras-stadsmission`**:
+    - Gå till [github.com/orgs/vasteras-stadsmission/people](https://github.com/orgs/vasteras-stadsmission/people) → `Invite member`.
+    - Ange personens GitHub-användarnamn eller e-postadress. Skicka inbjudan.
+    - Personen får ett mejl från GitHub och behöver klicka på länken för att acceptera inbjudan. Om personen inte ser inbjudan kan de kontrollera [github.com/orgs/vasteras-stadsmission/invitation](https://github.com/orgs/vasteras-stadsmission/invitation) direkt.
+4. **Första inloggningen**: När personen loggar in första gången skapas deras konto automatiskt med rollen **Utlämningspersonal**. Be dem fylla i sitt riktiga namn (för- och efternamn) när de blir ombedda – det visas i gränssnittet.
+5. **Om personen ska bli administratör**: Gå till `Inställningar` → `Användare`, hitta personen i listan och ändra rollen till `Administratör`. Ändringen syns inom fem minuter (eller direkt om personen loggar ut och in). Administratörer har åtkomst till alla delar av systemet (hushåll, inställningar, statistik och användarhantering).
+
+**Vanliga fel vid inloggning:**
+
+- **"GitHub nekade åtkomst"** – Personen behöver aktivera en säker tvåfaktormetod (se ovan). Stegvisa instruktioner visas på sidan.
+- **"Du har en väntande inbjudan"** – Personen har fått inbjudan men har inte accepterat den än. Använd knappen "Kontrollera väntande inbjudningar på GitHub" på felsidan.
+- **"Inte medlem i organisationen"** – Personen har inget GitHub-konto i organisationen. Antingen har du inte skickat inbjudan än, eller så har personen loggat in med fel GitHub-konto.
+
 ## Verifieringschecklista
 
 Kontrollpunkter som personal måste bekräfta vid inskrivning av nya hushåll.
 
-- Gå till `Inställningar` → `Allmänna inställningar`.
+- Gå till `Inställningar` → `Registreringsformulär`.
 - Checklistan visas för personalen i inskrivningsflödet som "Jag har säkerställt att...".
 - Lägg till punkt: fyll i text på svenska och engelska, markera om den är obligatorisk och lägg till ev. hjälptext.
 - Ändra ordning genom att dra punkterna; sparas direkt.
@@ -34,11 +63,11 @@ Styr vilka dagar och tider bokningar kan göras på varje utlämningsställe.
 - Vid ändring eller borttagning visar systemet hur många bokningar som påverkas; flytta dem först vid behov.
 - Slot-längden för nya tider styrs av värdet från platsens grundflik.
 
-## Matkassegränser
+## Varningsgräns för matkassar
 
 Varningssystem för att identifiera hushåll med högt antal matkassar.
 
-- Gå till `Inställningar` → `Matkassegränser`.
+- Gå till `Inställningar` → `Varningsgräns för matkassar`.
 - Ange en gräns för antal kassar varefter systemet visar en varning.
 - När ett hushåll överskrider gränsen visas varning på hushållskortet och vid bokningar.
 - Hjälper till att identifiera hushåll som kan behöva extra stöd eller genomgång.

--- a/docs/anvandarguide-sv.md
+++ b/docs/anvandarguide-sv.md
@@ -109,17 +109,14 @@ flowchart TD
     subgraph Steg för steg
         S1["Steg 1: Grunduppgifter<br/>Namn, telefon, språk"]
         S2["Steg 2: Medlemmar<br/>Ålder och kön för alla i hushållet"]
-        S3["Steg 3: Matrestriktioner<br/>Halal, vegetariskt, allergier..."]
-        S4["Steg 4: Husdjur<br/>Hund, katt, annat"]
-        S5["Steg 5: Ytterligare behov<br/>Hygienartiklar, barnartiklar..."]
-        S6["Steg 6: Verifiering<br/>Bekräfta checklista"]
-        S7["Steg 7: Matkassar<br/>Välj datum och tider"]
-        S8["Steg 8: Sammanfattning<br/>Granska och bekräfta"]
+        S3["Steg 3: Preferenser<br/>Matrestriktioner, husdjur, övriga behov"]
+        S4["Steg 4: Verifiering<br/>Bekräfta checklista (om admin konfigurerat)"]
+        S5["Steg 5: Sammanfattning<br/>Granska och bekräfta"]
     end
 
-    H1 --> H2 --> S1 --> S2 --> S3 --> S4 --> S5 --> S6 --> S7 --> S8
+    H1 --> H2 --> S1 --> S2 --> S3 --> S4 --> S5
 
-    S8 --> Klar["✅ Hushållet är registrerat!<br/>SMS skickas automatiskt"]
+    S5 --> Klar["✅ Hushållet är registrerat!<br/>SMS skickas automatiskt<br/>Schemalägg matkassar efter att ha sparat"]
 ```
 
 ### Tips vid registrering

--- a/docs/case-worker-manual-sv.md
+++ b/docs/case-worker-manual-sv.md
@@ -19,11 +19,12 @@ Gå till `Hushåll` → `Nytt hushåll`. Guiden har följande steg:
     - SMS-samtycke (obligatoriskt för att kunna skicka påminnelser)
     - Språk (standard: svenska)
 2. **Medlemmar** – Lägg till hushållsmedlemmar med ålder och kön.
-3. **Matrestriktioner** – Välj från lista eller lägg till egna.
-4. **Husdjur** – Välj från lista eller lägg till egna.
-5. **Ytterligare behov** – Rullstolsanpassning, tolk, etc.
-6. **Verifiering** – Bekräfta obligatoriska kontroller (visas endast om admin har konfigurerat frågor).
-7. **Sammanfattning** – Granska och spara.
+3. **Preferenser** – Kost, husdjur och övriga behov i ett och samma steg:
+    - Matrestriktioner (t.ex. halal, vegetariskt, allergier) – välj från lista eller lägg till egna.
+    - Husdjur – välj från lista eller lägg till egna.
+    - Ytterligare behov – rullstolsanpassning, tolk, hygienartiklar, barnartiklar, etc.
+4. **Verifiering** – Bekräfta obligatoriska kontroller (visas endast om admin har konfigurerat frågor).
+5. **Sammanfattning** – Granska och spara.
 
 Innan hushållet sparas visas en bekräftelsedialog om att du har informerat hushållet om hur deras personuppgifter behandlas.
 
@@ -97,4 +98,4 @@ Startsidan visar ärenden som behöver åtgärdas:
 
 **Kan inte boka på viss tid** – Kontrollera att utlämningsstället har öppet den dagen/tiden i `Schema`.
 
-**SMS skickades inte** – Kontrollera att SMS-samtycke är markerat. Kolla `Behöver uppföljning` på startsidan.
+**SMS skickades inte** – Kontrollera att SMS-samtycke är markerat. Kontakta din administratör om felet kvarstår.

--- a/docs/handout-staff-manual-sv.md
+++ b/docs/handout-staff-manual-sv.md
@@ -37,17 +37,6 @@ Registrera när mottagaren inte hämtar sin matkasse.
 - Kan endast göras för dagens eller tidigare bokningar.
 - Hjälper till att hålla statistiken korrekt och rensa olösta utlämningar.
 
-## Behöver uppföljning
-
-Ärenden som kräver åtgärd visas på startsidan.
-
-- Röd siffra i navigationen visar antalet olösta ärenden.
-- Tre kategorier:
-    1. **Olösta utlämningar** – tidigare bokningar utan utfall (markera som hämtad eller ej hämtad)
-    2. **Utanför öppettiderna** – kommande bokningar utanför platsens öppettider (omboka)
-    3. **Misslyckade SMS** – sändningsfel att hantera
-- När alla ärenden är åtgärdade försvinner länken från navigationen.
-
 ## Hitta hushåll och boka
 
 Sök upp hushåll och hantera deras bokningar.
@@ -99,6 +88,6 @@ Snabb identifiering av mottagare vid utlämning.
 
 **Kan inte markera hämtad** – Kontrollera att bokningen inte redan är markerad eller borttagen.
 
-**Mottagaren fick inget SMS** – Kolla `Behöver uppföljning` eller hushållets SMS-historik. Dela annars länken direkt.
+**Mottagaren fick inget SMS** – Kontrollera hushållets SMS-historik via hushållskortet, eller be en administratör titta i uppföljningsvyn. Dela annars länken direkt.
 
 **QR-kod skannar inte** – Höj skärmljusstyrkan, testa annan vinkel, eller sök fram bokningen manuellt i `Dagens utlämningar`.

--- a/docs/user-flows.md
+++ b/docs/user-flows.md
@@ -18,8 +18,8 @@ flowchart LR
     subgraph Staff Team
         MW["Middleware<br/>- locale detection & CSP<br/>- redirects unauthenticated -> signin"]
         SignIn["Sign-in /auth/signin<br/>- GitHub OAuth + org membership check<br/>- redirects to callback"]
-        Home["Home /<br/>- AuthProtection ensures session<br/>- shows welcome copy + status"]
-        Header["Header + layout<br/>- nav: Schedule / Households / Locations<br/>- LanguageSwitcher + Auth menu + Scan QR link"]
+        Home["Home /<br/>- admin only (handout staff redirected to /schedule)<br/>- shows Issues Dashboard"]
+        Header["Header + layout<br/>- nav: Schedule (all) + Households / Statistics / Issues (admin only)<br/>- Settings dropdown (admin only) contains Locations, Users, etc.<br/>- LanguageSwitcher + Auth menu + Scan QR link"]
         ScanQR["Scan QR<br/>- Mobile: Use native Camera app (fastest)<br/>- Laptop: Use scanapp.org<br/>- Opens schedule with parcel dialog"]
         MW -- no session --> SignIn
         MW -- session --> Home
@@ -54,19 +54,19 @@ flowchart LR
         HouseholdsList --> HouseholdDetailModal
         HouseholdDetailModal["Household detail modal<br/>- members, needs, parcel history<br/>- comment thread add/delete via API"]
         HouseholdsList --> EnrollWizard
-        EnrollWizard["Household wizard create<br/>- steps: basics → members → needs → review<br/>- submit calls enrollHousehold action<br/>- redirects to schedule page after save"]
+        EnrollWizard["Household wizard create<br/>- steps: basics → members → preferences → verification (conditional) → review<br/>- submit calls enrollHousehold action<br/>- redirects to schedule page after save"]
         HouseholdsList --> EditWizard
         EditWizard["Household wizard edit<br/>- prefilled data & comment hooks<br/>- updateHousehold + add/delete comments"]
 
-        Header --> HandoutLocationsPage
-        HandoutLocationsPage["Handout locations admin<br/>- tab per location with form<br/>- notifications on create/update/delete"]
+        Header -- Settings dropdown, admin only --> HandoutLocationsPage
+        HandoutLocationsPage["Handout locations admin /settings/locations<br/>- tab per location with form<br/>- notifications on create/update/delete"]
         HandoutLocationsPage --> LocationModal
         LocationModal["Add location modal<br/>- LocationForm create mode<br/>- resets after save"]
         HandoutLocationsPage --> SchedulesTab
         SchedulesTab["Schedules tab<br/>- configure opening hours & slot duration<br/>- week picker + validation helpers"]
 
-        Header --> Issues
-        Issues["Issues Dashboard /<br/>- shows unresolved handouts (past parcels)<br/>- shows parcels outside opening hours<br/>- shows failed SMS requiring attention<br/>- navigation badge shows total issue count<br/>- dismiss or resolve issues inline"]
+        Header -- admin only --> Issues
+        Issues["Issues Dashboard / (home page)<br/>- shows unresolved handouts (past parcels)<br/>- shows parcels outside opening hours<br/>- shows failed SMS requiring attention<br/>- navigation badge shows total issue count<br/>- dismiss or resolve issues inline<br/>- handout staff are redirected to /schedule instead"]
         Issues -- view household --> HouseholdDetailModal
     end
 ```


### PR DESCRIPTION
## Why

The Swedish staff manuals in `/docs` had accumulated stale content — wizard step counts that no longer matched the code, references to removed Settings pages, mentions of admin-only features in handout-staff docs, and a broken link in the README. This was flagged during the onboarding-friction audit (four independent subagent reviews across the codebase).

Meanwhile, the onboarding process for new staff (GitHub account, 2FA, org invite, first login, role promotion) was not documented anywhere. Admins had to explain it verbally each time.

## What changed

**New content** — `docs/admin-manual-sv.md` gains a "Lägga till ny personal" section covering the full onboarding flow: GitHub account creation, secure 2FA requirements (authenticator/passkey/GitHub Mobile, SMS not accepted), org invite to `vasteras-stadsmission`, first login as Utlämningspersonal, and how to promote via Inställningar → Användare (with the concrete "five minutes or sign out/in" timing from `auth.ts:229`).

**Stale content fixes:**

| File | What was wrong | What's fixed |
|---|---|---|
| `admin-manual-sv.md` | Referenced "Allmänna inställningar" (removed route) | Changed to "Registreringsformulär" (actual settings label) |
| `admin-manual-sv.md` | "Matkassegränser" heading | Changed to "Varningsgräns för matkassar" (actual label) |
| `handout-staff-manual-sv.md` | "Behöver uppföljning" section described the start page + issues badge — both admin-only since handout_staff redirect to /schedule | Entire section removed; troubleshooting SMS entry updated |
| `case-worker-manual-sv.md` | 7 wizard steps (3 separate preference pages + a "Matkassar" step) | 5 steps: basics → members → preferences (combined) → verification (conditional) → review. Parcels added after save. |
| `case-worker-manual-sv.md` | Troubleshooting entry referenced "Behöver uppföljning" on the start page | Replaced with "Kontakta din administratör" |
| `anvandarguide-sv.md` | 8-step Mermaid diagram for household wizard | 5-step diagram matching current wizard |
| `user-flows.md` | Header nav listed "Schedule / Households / Locations" | Updated to "Schedule (all) + Households / Statistics / Issues (admin only), Settings dropdown (admin only)" |
| `user-flows.md` | Wizard listed "basics → members → needs → review" | Updated to include preferences + conditional verification |
| `README.md` | Linked to non-existent `docs/user-manual.md` | Replaced with full list of actual Swedish + dev docs |

**ESLint ergonomics** — Added `"root": true` to `.eslintrc.json`. This is the standard setting for project-root ESLint configs and prevents ESLint v9 from walking up the directory tree and finding parent configs (which breaks `next lint` in nested git worktrees). No behavioral change for normal checkouts.