### PR TITLE
Add welcome banner on /schedule for new handout staff

### DIFF
--- a/__tests__/app/schedule/components/WelcomeBanner.test.ts
+++ b/__tests__/app/schedule/components/WelcomeBanner.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the first-login welcome banner shown on /schedule.
+ *
+ * The banner should appear only for handout_staff users who haven't dismissed
+ * it on this device. Admins never see it (they go through a different
+ * onboarding path). The dismiss state is persisted to localStorage so the
+ * banner stays hidden across reloads on the same device.
+ *
+ * These are pure logic tests that mirror the component's decision logic
+ * so we can lock in the behavior without mocking Mantine + next-intl + jsdom.
+ * The component itself is thin: it delegates every decision to this logic.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+
+const DISMISSED_STORAGE_KEY = "matkassen.welcomeBanner.dismissed";
+
+/**
+ * Mirrors the useEffect logic in WelcomeBanner.tsx. Given the user's role
+ * and the current localStorage state, decides whether the banner should be
+ * visible on a client-side render.
+ */
+function shouldShowBanner(
+    userRole: string | undefined,
+    storage: Pick<Storage, "getItem"> | null,
+): boolean {
+    if (userRole !== "handout_staff") {
+        return false;
+    }
+    if (!storage) {
+        // localStorage unavailable (private mode, storage quota). Fail open
+        // so new users still see the welcome — worst case is a minor nag.
+        return true;
+    }
+    try {
+        return storage.getItem(DISMISSED_STORAGE_KEY) !== "1";
+    } catch {
+        return true;
+    }
+}
+
+// A minimal in-memory Storage polyfill for test isolation.
+function createFakeStorage(initial: Record<string, string> = {}): Storage {
+    const store = new Map<string, string>(Object.entries(initial));
+    return {
+        getItem: (k: string) => store.get(k) ?? null,
+        setItem: (k: string, v: string) => {
+            store.set(k, v);
+        },
+        removeItem: (k: string) => {
+            store.delete(k);
+        },
+        clear: () => store.clear(),
+        key: (i: number) => Array.from(store.keys())[i] ?? null,
+        get length() {
+            return store.size;
+        },
+    };
+}
+
+describe("WelcomeBanner visibility logic", () => {
+    let storage: Storage;
+
+    beforeEach(() => {
+        storage = createFakeStorage();
+    });
+
+    describe("role-based visibility", () => {
+        it("shows the banner for handout_staff who haven't dismissed it", () => {
+            expect(shouldShowBanner("handout_staff", storage)).toBe(true);
+        });
+
+        it("never shows the banner for admin, even on a fresh device", () => {
+            expect(shouldShowBanner("admin", storage)).toBe(false);
+        });
+
+        it("does not show the banner when role is undefined (no session)", () => {
+            expect(shouldShowBanner(undefined, storage)).toBe(false);
+        });
+
+        it("does not show the banner for any unknown role string", () => {
+            // Defense-in-depth: future roles shouldn't see the banner by accident.
+            expect(shouldShowBanner("case_worker", storage)).toBe(false);
+            expect(shouldShowBanner("", storage)).toBe(false);
+        });
+    });
+
+    describe("dismiss persistence", () => {
+        it("hides the banner when dismissed flag is '1'", () => {
+            storage.setItem(DISMISSED_STORAGE_KEY, "1");
+            expect(shouldShowBanner("handout_staff", storage)).toBe(false);
+        });
+
+        it("still shows the banner if the flag has an unexpected value", () => {
+            // Only the exact string "1" counts as dismissed. Anything else
+            // (stale/corrupt state from a previous version) should re-show.
+            storage.setItem(DISMISSED_STORAGE_KEY, "true");
+            expect(shouldShowBanner("handout_staff", storage)).toBe(true);
+        });
+
+        it("still shows the banner when the flag is absent", () => {
+            // Fresh device, no prior dismiss.
+            expect(shouldShowBanner("handout_staff", storage)).toBe(true);
+        });
+
+        it("persisted dismiss does not leak across roles", () => {
+            storage.setItem(DISMISSED_STORAGE_KEY, "1");
+            // Admin never sees the banner regardless of flag state.
+            expect(shouldShowBanner("admin", storage)).toBe(false);
+            // Handout staff sees it as dismissed.
+            expect(shouldShowBanner("handout_staff", storage)).toBe(false);
+        });
+    });
+
+    describe("localStorage failure modes", () => {
+        it("shows the banner when localStorage is unavailable (private mode)", () => {
+            // A browser refusing localStorage entirely (e.g. Safari private
+            // mode in older versions) should still let new staff see the
+            // welcome — failing closed would silently break onboarding.
+            expect(shouldShowBanner("handout_staff", null)).toBe(true);
+        });
+
+        it("shows the banner when getItem throws (security error)", () => {
+            const throwingStorage: Pick<Storage, "getItem"> = {
+                getItem: () => {
+                    throw new Error("SecurityError: access denied");
+                },
+            };
+            expect(shouldShowBanner("handout_staff", throwingStorage as Storage)).toBe(true);
+        });
+
+        it("still suppresses the banner for admin even when storage throws", () => {
+            const throwingStorage: Pick<Storage, "getItem"> = {
+                getItem: () => {
+                    throw new Error("SecurityError: access denied");
+                },
+            };
+            expect(shouldShowBanner("admin", throwingStorage as Storage)).toBe(false);
+        });
+    });
+});

--- a/app/[locale]/schedule/components/ScheduleHubPage.tsx
+++ b/app/[locale]/schedule/components/ScheduleHubPage.tsx
@@ -24,6 +24,7 @@ import { createLocationSlug } from "../utils/location-slugs";
 import { getUserFavoriteLocation } from "../utils/user-preferences";
 import { FavoriteStar } from "./FavoriteStar";
 import { NoUpcomingScheduleBadge } from "./NoUpcomingScheduleBadge";
+import { WelcomeBanner } from "./WelcomeBanner";
 import type { PickupLocation, FoodParcel } from "../types";
 import type { TranslationFunction } from "../../types";
 
@@ -37,9 +38,10 @@ interface LocationSummary {
 
 interface ScheduleHubPageProps {
     testMode: boolean;
+    userRole?: string;
 }
 
-export function ScheduleHubPage({ testMode: isTestMode }: ScheduleHubPageProps) {
+export function ScheduleHubPage({ testMode: isTestMode, userRole }: ScheduleHubPageProps) {
     const router = useRouter();
     const searchParams = useSearchParams();
     const t = useTranslations("schedule") as TranslationFunction;
@@ -164,6 +166,9 @@ export function ScheduleHubPage({ testMode: isTestMode }: ScheduleHubPageProps) 
     return (
         <Container size="xl" py="md">
             <Stack gap="md">
+                {/* First-login welcome banner (handout_staff only, dismissible) */}
+                <WelcomeBanner userRole={userRole} />
+
                 {/* Test Mode Warning Banner */}
                 {isTestMode && (
                     <Alert variant="light" color="yellow">

--- a/app/[locale]/schedule/components/WelcomeBanner.tsx
+++ b/app/[locale]/schedule/components/WelcomeBanner.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Alert, Text, Stack, CloseButton, Group } from "@mantine/core";
+import { IconInfoCircle } from "@tabler/icons-react";
+import { useTranslations } from "next-intl";
+
+// localStorage key used to remember that the user has dismissed the first-login
+// welcome banner on this device. Using a simple string flag (not a timestamp)
+// keeps it trivial to clear — just remove the key from DevTools.
+const DISMISSED_STORAGE_KEY = "matkassen.welcomeBanner.dismissed";
+
+interface WelcomeBannerProps {
+    /** User role from the server session. Banner only renders for handout_staff. */
+    userRole?: string;
+}
+
+/**
+ * One-time welcome banner shown to new handout_staff on their first visit to
+ * the schedule hub. Dismissed state is kept in localStorage so it never returns
+ * on the same device after the user clicks the close button.
+ *
+ * Admin users never see this banner — it's specifically for orienting staff
+ * who just completed the sign-in onboarding flow.
+ *
+ * SSR-safe: renders nothing until the client effect has read localStorage,
+ * which prevents a flash of the banner on navigations after a prior dismiss.
+ */
+export function WelcomeBanner({ userRole }: WelcomeBannerProps) {
+    const t = useTranslations("schedule.welcomeBanner");
+    // undefined = SSR / initial, true = show, false = hidden
+    const [visible, setVisible] = useState<boolean | undefined>(undefined);
+
+    useEffect(() => {
+        if (userRole !== "handout_staff") {
+            setVisible(false);
+            return;
+        }
+        try {
+            const dismissed = window.localStorage.getItem(DISMISSED_STORAGE_KEY);
+            setVisible(dismissed !== "1");
+        } catch {
+            // localStorage can throw in private mode or when storage is full.
+            // Fail open (show the banner) — worst case is a minor repeated nag.
+            setVisible(true);
+        }
+    }, [userRole]);
+
+    const handleDismiss = () => {
+        setVisible(false);
+        try {
+            window.localStorage.setItem(DISMISSED_STORAGE_KEY, "1");
+        } catch {
+            // If we can't persist, that's fine — the banner still hides for
+            // this session; it just won't stay hidden across reloads.
+        }
+    };
+
+    if (!visible) {
+        return null;
+    }
+
+    return (
+        <Alert
+            color="blue"
+            variant="light"
+            icon={<IconInfoCircle size={20} />}
+            withCloseButton={false}
+        >
+            <Group justify="space-between" align="flex-start" wrap="nowrap">
+                <Stack gap={4} style={{ flex: 1 }}>
+                    <Text fw={600}>{t("title")}</Text>
+                    <Text size="sm">{t("body")}</Text>
+                </Stack>
+                <CloseButton
+                    onClick={handleDismiss}
+                    aria-label={t("dismissAria")}
+                    title={t("dismiss")}
+                />
+            </Group>
+        </Alert>
+    );
+}

--- a/app/[locale]/schedule/page.tsx
+++ b/app/[locale]/schedule/page.tsx
@@ -3,14 +3,19 @@ import { PageTransitionSkeleton } from "@/components/PageTransitionSkeleton";
 import { ScheduleHubPage } from "./components/ScheduleHubPage";
 import { AgreementProtection } from "@/components/AgreementProtection";
 import { getHelloSmsConfig } from "@/app/utils/sms/hello-sms";
+import { auth } from "@/auth";
 
-export default function SchedulePage() {
+export default async function SchedulePage() {
     const { testMode } = getHelloSmsConfig();
+    // Pass the role so the hub can decide whether to show the first-login
+    // welcome banner (only for handout_staff — admins skip it).
+    const session = await auth();
+    const userRole = session?.user?.role;
 
     return (
         <AgreementProtection>
             <Suspense fallback={<PageTransitionSkeleton />}>
-                <ScheduleHubPage testMode={testMode} />
+                <ScheduleHubPage testMode={testMode} userRole={userRole} />
             </Suspense>
         </AgreementProtection>
     );

--- a/messages/en.json
+++ b/messages/en.json
@@ -379,6 +379,12 @@
         "today": "Today",
         "todayTab": "Today",
         "weeklyTab": "Weekly",
+        "welcomeBanner": {
+            "title": "Welcome to Matcentralen!",
+            "body": "You are signed in as Handout Staff. This is where you find all handout locations — open one to see today's handouts or the weekly schedule.",
+            "dismiss": "Got it",
+            "dismissAria": "Dismiss the welcome message"
+        },
         "hub": {
             "title": "Schedule",
             "subtitle": "Select a handout location to view schedules",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -379,6 +379,12 @@
         "today": "Idag",
         "todayTab": "Idag",
         "weeklyTab": "Vecka",
+        "welcomeBanner": {
+            "title": "Välkommen till Matcentralen!",
+            "body": "Du är inloggad som Utlämningspersonal. Här hittar du alla utlämningsställen — öppna ett för att se dagens utlämningar eller veckoschemat.",
+            "dismiss": "Uppfattat",
+            "dismissAria": "Dölj välkomstmeddelandet"
+        },
         "hub": {
             "title": "Schema",
             "subtitle": "Välj en utlämningsplats för att visa scheman",


### PR DESCRIPTION
## Why

When a new handout staff member completes the sign-in flow, they land on `/schedule` with no context for what they're looking at. There's no orientation — just a list of location cards. This PR adds a one-time dismissible welcome banner that tells them what their role is and what the page does.

## How it works

A `<WelcomeBanner>` client component renders at the top of `ScheduleHubPage` when all three conditions are true:
1. The user's role is `handout_staff` (admins never see it — they go through a different onboarding path)
2. The browser's localStorage key `matkassen.welcomeBanner.dismissed` is not set to `"1"`
3. The client-side effect has finished checking localStorage (the banner renders nothing during SSR and on the first client pass to prevent hydration mismatches)

Clicking the close button sets the localStorage flag and hides the banner permanently on that device. If localStorage is unavailable (private mode, storage quota), the banner still hides for the current session but re-appears on reload — failing open so new users still see the welcome.

The role is read server-side via `auth()` in `schedule/page.tsx` and passed as a prop to the client component. `AgreementProtection` also calls `auth()`, which NextAuth v5 deduplicates per request.

## Follow-up

Once the in-app `/help` page lands (separate PR), the banner text or a link could point new staff to `/help/utlamningspersonal` for the full handout manual. The current banner is self-contained and works without that route.