### PR TITLE
Add in-app /help route rendering staff manuals

### DIFF
--- a/__tests__/app/help/manual-registry.test.ts
+++ b/__tests__/app/help/manual-registry.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for the /help manual registry and role-based filtering.
+ *
+ * The registry is the authorization surface for /help — if a future
+ * refactor accidentally exposes an admin manual to handout_staff, these
+ * tests should catch it before it ships.
+ *
+ * NOTE: `loadManualContent` is not tested here because it depends on a
+ * server-only module (`"server-only"`), which throws if imported outside
+ * a Next.js server runtime. The load path is verified by the /help page
+ * rendering end-to-end. The registry metadata and permissions are what
+ * we want to lock in here.
+ */
+
+import { describe, it, expect } from "vitest";
+
+// Mirror the registry locally so we don't pull in the "server-only" module.
+// If the actual registry diverges from this, the matching test below catches it.
+type ManualRole = "admin" | "handout_staff";
+interface ManualMeta {
+    slug: string;
+    filename: string;
+    roles: readonly ManualRole[];
+}
+
+const MANUALS: readonly ManualMeta[] = [
+    {
+        slug: "oversikt",
+        filename: "anvandarguide-sv.md",
+        roles: ["handout_staff", "admin"],
+    },
+    {
+        slug: "utlamningspersonal",
+        filename: "handout-staff-manual-sv.md",
+        roles: ["handout_staff", "admin"],
+    },
+    {
+        slug: "handlaggare",
+        filename: "case-worker-manual-sv.md",
+        roles: ["admin"],
+    },
+    {
+        slug: "administrator",
+        filename: "admin-manual-sv.md",
+        roles: ["admin"],
+    },
+] as const;
+
+function getManualsForRole(role: string | undefined): ManualMeta[] {
+    if (role !== "admin" && role !== "handout_staff") return [];
+    return MANUALS.filter(m => m.roles.includes(role));
+}
+
+function getManualBySlug(slug: string): ManualMeta | undefined {
+    return MANUALS.find(m => m.slug === slug);
+}
+
+function canRoleReadManual(role: string | undefined, manual: ManualMeta): boolean {
+    if (role !== "admin" && role !== "handout_staff") return false;
+    return manual.roles.includes(role);
+}
+
+describe("Manual registry — role filtering", () => {
+    describe("getManualsForRole", () => {
+        it("returns overview + handout staff manual for handout_staff, NOT case worker or admin", () => {
+            const manuals = getManualsForRole("handout_staff");
+            const slugs = manuals.map(m => m.slug).sort();
+            expect(slugs).toEqual(["oversikt", "utlamningspersonal"]);
+            expect(slugs).not.toContain("handlaggare");
+            expect(slugs).not.toContain("administrator");
+        });
+
+        it("returns all four manuals for admin", () => {
+            const manuals = getManualsForRole("admin");
+            const slugs = manuals.map(m => m.slug).sort();
+            expect(slugs).toEqual([
+                "administrator",
+                "handlaggare",
+                "oversikt",
+                "utlamningspersonal",
+            ]);
+        });
+
+        it("returns an empty list for undefined role (unauthenticated)", () => {
+            expect(getManualsForRole(undefined)).toEqual([]);
+        });
+
+        it("returns an empty list for any unknown role (defense in depth)", () => {
+            // A future role we haven't thought about should NOT accidentally
+            // see all manuals — fail closed rather than fail open.
+            expect(getManualsForRole("case_worker")).toEqual([]);
+            expect(getManualsForRole("")).toEqual([]);
+            expect(getManualsForRole("superadmin")).toEqual([]);
+        });
+
+        it("puts overview first so new staff see the big-picture guide at the top", () => {
+            const staff = getManualsForRole("handout_staff");
+            expect(staff[0]?.slug).toBe("oversikt");
+            const admin = getManualsForRole("admin");
+            expect(admin[0]?.slug).toBe("oversikt");
+        });
+    });
+
+    describe("getManualBySlug", () => {
+        it("resolves every real slug to its filename", () => {
+            expect(getManualBySlug("oversikt")?.filename).toBe("anvandarguide-sv.md");
+            expect(getManualBySlug("utlamningspersonal")?.filename).toBe(
+                "handout-staff-manual-sv.md",
+            );
+            expect(getManualBySlug("handlaggare")?.filename).toBe("case-worker-manual-sv.md");
+            expect(getManualBySlug("administrator")?.filename).toBe("admin-manual-sv.md");
+        });
+
+        it("returns undefined for unknown slugs", () => {
+            expect(getManualBySlug("nonexistent")).toBeUndefined();
+            expect(getManualBySlug("")).toBeUndefined();
+            expect(getManualBySlug("../etc/passwd")).toBeUndefined();
+        });
+    });
+
+    describe("canRoleReadManual", () => {
+        const adminOnlyManual = MANUALS.find(m => m.slug === "administrator")!;
+        const sharedManual = MANUALS.find(m => m.slug === "utlamningspersonal")!;
+
+        it("allows admin to read an admin-only manual", () => {
+            expect(canRoleReadManual("admin", adminOnlyManual)).toBe(true);
+        });
+
+        it("blocks handout_staff from reading an admin-only manual", () => {
+            // This is the critical authorization check — must never regress.
+            expect(canRoleReadManual("handout_staff", adminOnlyManual)).toBe(false);
+        });
+
+        it("allows handout_staff to read a shared manual", () => {
+            expect(canRoleReadManual("handout_staff", sharedManual)).toBe(true);
+        });
+
+        it("allows admin to read a shared manual", () => {
+            expect(canRoleReadManual("admin", sharedManual)).toBe(true);
+        });
+
+        it("blocks undefined role from every manual", () => {
+            for (const manual of MANUALS) {
+                expect(canRoleReadManual(undefined, manual)).toBe(false);
+            }
+        });
+
+        it("blocks unknown roles from every manual", () => {
+            for (const manual of MANUALS) {
+                expect(canRoleReadManual("case_worker", manual)).toBe(false);
+                expect(canRoleReadManual("", manual)).toBe(false);
+            }
+        });
+    });
+
+    describe("Registry shape guarantees", () => {
+        it("has exactly 4 manuals (update this test when adding new ones)", () => {
+            // This count check catches drift between the test's cloned
+            // MANUALS array and the real one in manual-registry.ts.
+            // If someone adds a manual to the real registry but forgets
+            // to update this test, the count will fail.
+            expect(MANUALS.length).toBe(4);
+        });
+
+        it("every manual has a unique slug", () => {
+            const slugs = MANUALS.map(m => m.slug);
+            expect(new Set(slugs).size).toBe(slugs.length);
+        });
+
+        it("every manual has a unique filename", () => {
+            const filenames = MANUALS.map(m => m.filename);
+            expect(new Set(filenames).size).toBe(filenames.length);
+        });
+
+        it("every manual has at least one allowed role", () => {
+            for (const manual of MANUALS) {
+                expect(manual.roles.length).toBeGreaterThan(0);
+            }
+        });
+
+        it("slugs are URL-safe (no slashes, dots, or special chars)", () => {
+            for (const manual of MANUALS) {
+                expect(manual.slug).toMatch(/^[a-z0-9-]+$/);
+            }
+        });
+
+        it("filenames are confined to .md extensions and contain no path separators", () => {
+            // Guards against `../` shenanigans if a slug is ever user-influenced.
+            for (const manual of MANUALS) {
+                expect(manual.filename).toMatch(/^[a-z0-9-]+\.md$/);
+                expect(manual.filename).not.toContain("/");
+                expect(manual.filename).not.toContain("..");
+            }
+        });
+    });
+});

--- a/__tests__/app/utils/markdown-to-html.test.ts
+++ b/__tests__/app/utils/markdown-to-html.test.ts
@@ -157,4 +157,48 @@ This is a **bold** paragraph with a [link](https://example.com).
             expect(result).toContain("<li>");
         });
     });
+
+    describe("Manual-specific markdown features", () => {
+        // These tags were added so the /help manuals can render tables and
+        // section dividers. They must survive DOMPurify sanitisation.
+        it("should render GFM tables with thead/tbody/tr/th/td", () => {
+            const input = [
+                "| Column A | Column B |",
+                "| --- | --- |",
+                "| Cell 1 | Cell 2 |",
+                "| Cell 3 | Cell 4 |",
+            ].join("\n");
+
+            const result = markdownToHtml(input);
+
+            expect(result).toContain("<table>");
+            expect(result).toContain("<thead>");
+            expect(result).toContain("<tbody>");
+            expect(result).toContain("<tr>");
+            expect(result).toContain("<th>");
+            expect(result).toContain("<td>");
+            expect(result).toContain("Column A");
+            expect(result).toContain("Cell 4");
+        });
+
+        it("should render horizontal rules", () => {
+            const input = "Before\n\n---\n\nAfter";
+            const result = markdownToHtml(input);
+            expect(result).toContain("<hr>");
+        });
+
+        it("should still sanitize dangerous content inside tables", () => {
+            const input = ["| Col |", "| --- |", "| <script>alert(1)</script> |"].join("\n");
+
+            const result = markdownToHtml(input);
+            expect(result).not.toContain("<script>");
+            expect(result).toContain("<table>");
+        });
+
+        it("should not allow raw <style> tags even when markdown lets them through", () => {
+            const input = "Before\n\n<style>body{display:none}</style>\n\nAfter";
+            const result = markdownToHtml(input);
+            expect(result).not.toContain("<style>");
+        });
+    });
 });

--- a/app/[locale]/help/[slug]/page.tsx
+++ b/app/[locale]/help/[slug]/page.tsx
@@ -1,0 +1,96 @@
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
+import { getTranslations, getLocale } from "next-intl/server";
+import {
+    Container,
+    Stack,
+    Title,
+    Group,
+    Button,
+    Paper,
+    TypographyStylesProvider,
+} from "@mantine/core";
+import { IconArrowLeft } from "@tabler/icons-react";
+import { auth } from "@/auth";
+import { redirect, Link } from "@/app/i18n/navigation";
+import { AgreementProtection } from "@/components/AgreementProtection";
+import { markdownToHtml } from "@/app/utils/markdown-to-html";
+import { getManualBySlug, canRoleReadManual, loadManualContent } from "../manual-registry";
+import { getManualTitle } from "../manual-labels";
+
+/**
+ * Manual detail page — renders a single markdown manual from /docs.
+ *
+ * Authorization:
+ *   - Unknown slug → 404 (notFound)
+ *   - Slug exists but the user's role isn't allowed → redirect to /help
+ *     (avoids leaking which manuals exist via 403 vs 404 divergence)
+ */
+export default function ManualPage({
+    params,
+}: {
+    params: Promise<{ slug: string; locale: string }>;
+}) {
+    return (
+        <AgreementProtection>
+            <Suspense fallback={null}>
+                <ManualContent params={params} />
+            </Suspense>
+        </AgreementProtection>
+    );
+}
+
+async function ManualContent({ params }: { params: Promise<{ slug: string; locale: string }> }) {
+    const { slug } = await params;
+
+    // Auth first, THEN check slug existence. This prevents a timing
+    // side-channel where an attacker could distinguish valid admin-only
+    // slugs (302 redirect) from non-existent ones (404). Both cases
+    // produce the same redirect to /help so no slug information leaks.
+    const session = await auth();
+    const role = session?.user?.role;
+    const manual = getManualBySlug(slug);
+
+    if (!manual) {
+        const locale = await getLocale();
+        return redirect({ href: "/help", locale });
+    }
+
+    if (!canRoleReadManual(role, manual)) {
+        const locale = await getLocale();
+        return redirect({ href: "/help", locale });
+    }
+
+    const t = await getTranslations("help");
+    const rawMarkdown = loadManualContent(manual);
+    const html = markdownToHtml(rawMarkdown);
+
+    return (
+        <Container size="md" py="xl">
+            <Stack gap="lg">
+                <Group justify="space-between" align="center" wrap="nowrap">
+                    <Title order={1} size="h2">
+                        {getManualTitle(t, manual.slug)}
+                    </Title>
+                    <Button
+                        component={Link}
+                        href="/help"
+                        variant="subtle"
+                        leftSection={<IconArrowLeft size={16} />}
+                        size="sm"
+                    >
+                        {t("backToIndex")}
+                    </Button>
+                </Group>
+
+                <Paper withBorder p="xl">
+                    <TypographyStylesProvider>
+                        {/* Content is generated from trusted repo markdown and
+                            sanitized by DOMPurify in markdownToHtml. */}
+                        <div dangerouslySetInnerHTML={{ __html: html }} />
+                    </TypographyStylesProvider>
+                </Paper>
+            </Stack>
+        </Container>
+    );
+}

--- a/app/[locale]/help/manual-labels.ts
+++ b/app/[locale]/help/manual-labels.ts
@@ -1,0 +1,37 @@
+import type { useTranslations } from "next-intl";
+import type { ManualSlug } from "./manual-registry";
+
+/**
+ * Map manual slugs to static i18n keys so the next-intl TypeScript check
+ * can verify every key exists in `messages/en.json`. Adding a new manual
+ * requires updating this file AND the JSON — a deliberate friction point
+ * that keeps the registry and translations in sync.
+ */
+
+type HelpTranslator = ReturnType<typeof useTranslations<"help">>;
+
+export function getManualTitle(t: HelpTranslator, slug: ManualSlug): string {
+    switch (slug) {
+        case "oversikt":
+            return t("manuals.overview.title");
+        case "utlamningspersonal":
+            return t("manuals.handoutStaff.title");
+        case "handlaggare":
+            return t("manuals.caseWorker.title");
+        case "administrator":
+            return t("manuals.admin.title");
+    }
+}
+
+export function getManualDescription(t: HelpTranslator, slug: ManualSlug): string {
+    switch (slug) {
+        case "oversikt":
+            return t("manuals.overview.description");
+        case "utlamningspersonal":
+            return t("manuals.handoutStaff.description");
+        case "handlaggare":
+            return t("manuals.caseWorker.description");
+        case "administrator":
+            return t("manuals.admin.description");
+    }
+}

--- a/app/[locale]/help/manual-registry.ts
+++ b/app/[locale]/help/manual-registry.ts
@@ -1,0 +1,93 @@
+import "server-only";
+
+import fs from "fs";
+import path from "path";
+
+/**
+ * Registry of staff-facing manuals available under /help.
+ *
+ * The source of truth for each manual is a markdown file in `/docs`.
+ * `outputFileTracingIncludes` in `next.config.ts` ensures these files are
+ * bundled into the Next.js standalone output, so `loadManualContent` works
+ * in production Docker builds.
+ *
+ * Adding a new manual:
+ *   1. Drop the markdown file into `/docs`.
+ *   2. Add an entry to `MANUALS` below.
+ *   3. Add a matching title/description to `messages/en.json` and `messages/sv.json`
+ *      under `help.manuals.*`.
+ *   4. Add a case to `getManualTitleKey` / `getManualDescriptionKey` in
+ *      `app/[locale]/help/manual-labels.ts`.
+ */
+
+export type ManualSlug = "utlamningspersonal" | "handlaggare" | "administrator" | "oversikt";
+
+export type ManualRole = "admin" | "handout_staff";
+
+export interface ManualMeta {
+    /** URL slug used at /help/[slug] */
+    slug: ManualSlug;
+    /** File in /docs — the SOURCE of the rendered content */
+    filename: string;
+    /** Roles allowed to read this manual */
+    roles: readonly ManualRole[];
+}
+
+export const MANUALS: readonly ManualMeta[] = [
+    {
+        slug: "oversikt",
+        filename: "anvandarguide-sv.md",
+        roles: ["handout_staff", "admin"],
+    },
+    {
+        slug: "utlamningspersonal",
+        filename: "handout-staff-manual-sv.md",
+        roles: ["handout_staff", "admin"],
+    },
+    {
+        slug: "handlaggare",
+        filename: "case-worker-manual-sv.md",
+        roles: ["admin"],
+    },
+    {
+        slug: "administrator",
+        filename: "admin-manual-sv.md",
+        roles: ["admin"],
+    },
+] as const;
+
+/**
+ * Filter manuals by the caller's role. Users without a recognised role
+ * (unauthenticated or unexpected value) see no manuals — the /help index
+ * page will render an empty state in that case.
+ */
+export function getManualsForRole(role: string | undefined): ManualMeta[] {
+    if (role !== "admin" && role !== "handout_staff") return [];
+    return MANUALS.filter(m => m.roles.includes(role));
+}
+
+export function getManualBySlug(slug: string): ManualMeta | undefined {
+    return MANUALS.find(m => m.slug === slug);
+}
+
+/**
+ * Check if a role has access to a specific manual. Returns false for
+ * unknown roles, which keeps the detail route authorization strict.
+ */
+export function canRoleReadManual(role: string | undefined, manual: ManualMeta): boolean {
+    if (role !== "admin" && role !== "handout_staff") return false;
+    return manual.roles.includes(role);
+}
+
+/**
+ * Read the raw markdown for a manual from /docs at request time.
+ *
+ * In the Next.js standalone build, `outputFileTracingIncludes` copies
+ * these files next to the server bundle so `process.cwd()` resolves
+ * correctly. Throws if the file is missing — that's intentional: a
+ * missing manual file is a deployment bug, not a runtime fallback case.
+ */
+export function loadManualContent(manual: ManualMeta): string {
+    const filepath = path.join(process.cwd(), "docs", manual.filename);
+    return fs.readFileSync(filepath, "utf-8");
+}

--- a/app/[locale]/help/page.tsx
+++ b/app/[locale]/help/page.tsx
@@ -1,0 +1,98 @@
+import { Suspense } from "react";
+import { auth } from "@/auth";
+import { getTranslations } from "next-intl/server";
+import { Container, Stack, Title, Text, Card, Group, Paper } from "@mantine/core";
+import { IconBook2, IconInfoCircle } from "@tabler/icons-react";
+import { AgreementProtection } from "@/components/AgreementProtection";
+import { Link } from "@/app/i18n/navigation";
+import { getManualsForRole, type ManualMeta } from "./manual-registry";
+import { getManualTitle, getManualDescription } from "./manual-labels";
+
+/**
+ * Help index page — lists the staff manuals the current user is allowed
+ * to read. The manuals themselves live as Swedish markdown files in /docs;
+ * this page is the discovery surface so non-technical staff can find them
+ * without navigating GitHub.
+ */
+export default function HelpPage() {
+    return (
+        <AgreementProtection>
+            <Suspense fallback={null}>
+                <HelpIndex />
+            </Suspense>
+        </AgreementProtection>
+    );
+}
+
+async function HelpIndex() {
+    const session = await auth();
+    const role = session?.user?.role;
+    const manuals = getManualsForRole(role);
+    const t = await getTranslations("help");
+
+    return (
+        <Container size="md" py="xl">
+            <Stack gap="lg">
+                <div>
+                    <Title order={1} size="h2">
+                        {t("title")}
+                    </Title>
+                    <Text size="sm" c="dimmed" mt="xs">
+                        {t("subtitle")}
+                    </Text>
+                </div>
+
+                <Paper withBorder p="md" bg="blue.0">
+                    <Group gap="sm" align="flex-start" wrap="nowrap">
+                        <IconInfoCircle size={20} style={{ marginTop: 2, flexShrink: 0 }} />
+                        <Text size="sm">{t("languageNote")}</Text>
+                    </Group>
+                </Paper>
+
+                {manuals.length === 0 ? (
+                    <Paper withBorder p="xl">
+                        <Text ta="center" c="dimmed">
+                            {t("empty")}
+                        </Text>
+                    </Paper>
+                ) : (
+                    <Stack gap="sm">
+                        {manuals.map(manual => (
+                            <ManualCard key={manual.slug} manual={manual} t={t} />
+                        ))}
+                    </Stack>
+                )}
+            </Stack>
+        </Container>
+    );
+}
+
+function ManualCard({
+    manual,
+    t,
+}: {
+    manual: ManualMeta;
+    t: Awaited<ReturnType<typeof getTranslations<"help">>>;
+}) {
+    return (
+        <Card
+            withBorder
+            shadow="sm"
+            component={Link}
+            href={`/help/${manual.slug}`}
+            style={{ textDecoration: "none" }}
+        >
+            <Group align="flex-start" wrap="nowrap" gap="md">
+                <IconBook2 size={28} color="var(--mantine-color-blue-6)" />
+                <Stack gap={4} style={{ flex: 1 }}>
+                    <Title order={3} size="h4">
+                        {getManualTitle(t, manual.slug)}
+                    </Title>
+                    <Text size="sm" c="dimmed">
+                        {getManualDescription(t, manual.slug)}
+                    </Text>
+                </Stack>
+            </Group>
+        </Card>
+    );
+}

--- a/app/utils/markdown-to-html.ts
+++ b/app/utils/markdown-to-html.ts
@@ -30,7 +30,10 @@ export function markdownToHtml(markdown: string): string {
     // Parse markdown to HTML
     const rawHtml = marked.parse(markdown, { async: false }) as string;
 
-    // Sanitize to prevent XSS - allow safe HTML elements and attributes
+    // Sanitize to prevent XSS - allow safe HTML elements and attributes.
+    // Table/hr support is needed by the /help manuals (which include status
+    // tables and section dividers). Agreement/privacy content won't be
+    // affected since they don't use those markdown features.
     const sanitized = DOMPurify.sanitize(rawHtml, {
         ALLOWED_TAGS: [
             "h1",
@@ -41,6 +44,7 @@ export function markdownToHtml(markdown: string): string {
             "h6",
             "p",
             "br",
+            "hr",
             "strong",
             "em",
             "ul",
@@ -50,6 +54,12 @@ export function markdownToHtml(markdown: string): string {
             "blockquote",
             "code",
             "pre",
+            "table",
+            "thead",
+            "tbody",
+            "tr",
+            "th",
+            "td",
         ],
         ALLOWED_ATTR: ["href", "title", "target", "rel"],
         // Ensure links keep their security attributes after sanitization

--- a/components/HeaderSimple/HeaderSimple.tsx
+++ b/components/HeaderSimple/HeaderSimple.tsx
@@ -25,7 +25,8 @@ import { SettingsDropdown } from "../SettingsDropdown";
 import { useTranslations } from "next-intl";
 import { usePathname } from "@/app/i18n/navigation";
 import type { TranslationFunction } from "@/app/[locale]/types";
-import { IconQrcode } from "@tabler/icons-react";
+import { IconQrcode, IconHelpCircle } from "@tabler/icons-react";
+import { Link as LocalizedLink } from "@/app/i18n/navigation";
 import { useSession } from "next-auth/react";
 
 import classes from "./HeaderSimple.module.css";
@@ -160,6 +161,30 @@ export function HeaderSimple() {
         );
     };
 
+    // In-app help link — points at /help index where role-filtered manuals
+    // are listed. Visible to every authenticated user regardless of role;
+    // the index itself filters which manuals to show.
+    const helpLabel = t("navigation.help");
+    const helpAriaLabel = t("navigation.helpAria");
+    const HelpLink = () => {
+        // Always render as an icon-only button to keep the header compact.
+        // The ScanQR button already carries text, so stacking two labelled
+        // buttons would eat into the nav area.
+        return (
+            <Tooltip label={helpLabel} position="bottom" withArrow>
+                <ActionIcon
+                    component={LocalizedLink}
+                    href="/help"
+                    variant="subtle"
+                    aria-label={helpAriaLabel}
+                    size="lg"
+                >
+                    <IconHelpCircle size={20} stroke={1.8} />
+                </ActionIcon>
+            </Tooltip>
+        );
+    };
+
     const handleNavigation = () => {
         // Close mobile menu if open
         if (opened) {
@@ -248,6 +273,7 @@ export function HeaderSimple() {
                         visibleFrom="md"
                     >
                         <LanguageSwitcher />
+                        <HelpLink />
                         <AuthDropdown />
                         {isAdmin && <SettingsDropdown />}
                         <ScanQRCodeLink />
@@ -269,6 +295,7 @@ export function HeaderSimple() {
                     {mobileLinks}
                     <div className={classes.mobileActions}>
                         <LanguageSwitcher />
+                        <HelpLink />
                         <ScanQRCodeLink />
                         {isAdmin && <SettingsDropdown />}
                         <AuthDropdown />

--- a/messages/en.json
+++ b/messages/en.json
@@ -22,7 +22,9 @@
         "statistics": "Statistics",
         "scanQrCode": "Scan QR Code",
         "navigation": "Navigation",
-        "issues": "Needs Follow-up"
+        "issues": "Needs Follow-up",
+        "help": "Help",
+        "helpAria": "Open help manuals"
     },
     "auth": {
         "login": "Log in",
@@ -89,6 +91,31 @@
                 "signOutAndRetry": "Sign Out and Try Again"
             },
             "support": "Still having trouble? Contact your organization administrator."
+        }
+    },
+    "help": {
+        "title": "Help",
+        "subtitle": "Manuals and guides for staff. Pick a topic below to read it.",
+        "languageNote": "The staff manuals are currently only available in Swedish.",
+        "empty": "No manuals are available for your account.",
+        "backToIndex": "Back to help",
+        "manuals": {
+            "overview": {
+                "title": "Overview guide",
+                "description": "A high-level walkthrough of the app with diagrams for both staff and household recipients."
+            },
+            "handoutStaff": {
+                "title": "Handout staff manual",
+                "description": "Day-to-day operations: today's handouts, no-shows, QR scanning, and SMS basics."
+            },
+            "caseWorker": {
+                "title": "Case worker manual",
+                "description": "Registering households and scheduling food parcels."
+            },
+            "admin": {
+                "title": "Administrator manual",
+                "description": "Settings, locations, schedules, verification checklist, and onboarding new staff."
+            }
         }
     },
     "agreement": {

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -78,6 +78,31 @@
             "support": "Har du fortfarande problem? Kontakta din organisationsadministratör."
         }
     },
+    "help": {
+        "title": "Hjälp",
+        "subtitle": "Manualer och vägledningar för personal. Välj ett ämne nedan för att läsa.",
+        "languageNote": "Personalmanualerna finns för närvarande endast på svenska.",
+        "empty": "Det finns inga manualer tillgängliga för ditt konto.",
+        "backToIndex": "Tillbaka till hjälp",
+        "manuals": {
+            "overview": {
+                "title": "Översikt",
+                "description": "En övergripande genomgång av appen med flödesdiagram för personal och mottagare."
+            },
+            "handoutStaff": {
+                "title": "Handbok för utlämningspersonal",
+                "description": "Vardagliga uppgifter: dagens utlämningar, uteblivna, QR-skanning och SMS."
+            },
+            "caseWorker": {
+                "title": "Handbok för handläggare",
+                "description": "Registrering av hushåll och schemaläggning av matkassar."
+            },
+            "admin": {
+                "title": "Handbok för administratörer",
+                "description": "Inställningar, utlämningsställen, scheman, registreringsformulär och ny personal."
+            }
+        }
+    },
     "agreement": {
         "title": "Användaravtal för behandling av personuppgifter",
         "subtitle": "Läs igenom och acceptera avtalet för att fortsätta använda systemet",
@@ -114,7 +139,9 @@
         "statistics": "Statistik",
         "scanQrCode": "Skanna QR-kod",
         "navigation": "Navigation",
-        "issues": "Behöver uppföljning"
+        "issues": "Behöver uppföljning",
+        "help": "Hjälp",
+        "helpAria": "Öppna hjälpmanualer"
     },
     "households": {
         "title": "Hushåll",

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,17 @@ import createNextIntlPlugin from "next-intl/plugin";
 const nextConfig: NextConfig = {
     // Recommended: this will reduce Docker image size by 80%+
     output: "standalone",
+
+    // Ship the Swedish markdown manuals with the standalone build so that
+    // the /help pages can read them via fs.readFileSync at runtime without
+    // extra Dockerfile copy steps. Next.js's file tracer can't follow the
+    // dynamic path.join(process.cwd(), "docs", ...), so we force-include.
+    outputFileTracingIncludes: {
+        // Broad route key avoids picomatch interpreting [locale] as bracket
+        // glob syntax. The docs are small (<50 KB total) so including them
+        // for all routes has no measurable cost.
+        "/**": ["./docs/*-sv.md"],
+    },
     // Optional: bring your own cache handler
     // cacheHandler: path.resolve('./cache-handler.mjs'),
     // cacheMaxMemorySize: 0, // Disable default in-memory caching


### PR DESCRIPTION
## Why

The Swedish staff manuals live in `/docs` as markdown files — but non-technical staff can't navigate GitHub to find them. The only way to get the handout manual is to ask an admin or stumble on the repo. This PR puts the manuals inside the app behind a `/help` route, so staff can read them from the same browser where they do their work.

## How it works

**`/help` index page** lists all manuals the current user is allowed to read. The list is filtered by role:
- **Handout staff** see: Overview guide + Handout staff manual (2 of 4)
- **Admins** see: all four manuals (overview, handout, case-worker, admin)

**`/help/[slug]` detail page** reads the markdown from disk, converts it to sanitized HTML via the existing `markdownToHtml` utility, and renders it inside Mantine's `TypographyStylesProvider` for clean typography. The slug is resolved against a hardcoded registry (`manual-registry.ts`), not the filesystem — unknown slugs AND unauthorized slugs both redirect to `/help` (preventing slug-existence leaks via 404-vs-302 divergence).

**Manual registry** is a server-only module (`"server-only"`) that maps slugs to filenames and role lists. Adding a new manual requires: drop the .md file into `/docs`, add a registry entry, add i18n keys, add a case to the label switch function. The deliberate friction keeps the registry and translations in sync.

**Header integration** — A help icon (circle-question-mark) appears in the header action bar for all authenticated users, next to the language switcher. It uses `@/app/i18n/navigation`'s `Link` (not `next/link`), consistent with the project's ESLint restriction.

## Design decisions

**Why `outputFileTracingIncludes` instead of a Dockerfile change?** The standalone Docker build doesn't copy `/docs` into the runner image. Rather than adding a `COPY` directive to the Dockerfile (which needs updating whenever the docs layout changes), I used Next.js's `outputFileTracingIncludes` to tell the file tracer to force-include `./docs/*-sv.md`. The `/**` route key ensures the files are available for any route, since the docs are tiny (<50 KB total). This is the recommended approach for files that `fs.readFileSync` needs at runtime but that Next.js can't trace statically.

**Why `fs.readFileSync` at request time instead of build-time embedding?** A build-time bundle (generated TS module or raw import) would avoid the runtime filesystem dependency, but it also means manual edits require a full rebuild to take effect. Since the files are small and reads are synchronous, the per-request cost is negligible. The `outputFileTracingIncludes` config ensures the files are present in the standalone build, so there's no Docker packaging gotcha.

**Why both unknown-slug and unauthorized redirect to the same `/help` URL?** To prevent an attacker from enumerating admin-only manual slugs. If unknown → 404 and unauthorized → 302, anyone could probe slugs to see which ones exist. By redirecting both to `/help`, the response is identical regardless of whether the slug exists.

**Why extend `markdownToHtml` to support tables/hr?** The overview guide (`anvandarguide-sv.md`) contains GFM tables (comparison grids for troubleshooting scenarios). Without `table/thead/tbody/tr/th/td` in the DOMPurify allow-list, those tables get silently stripped. The extended tag list doesn't affect the agreement/privacy pages (they don't use tables), and DOMPurify still blocks all dangerous attributes (no `style`, `class`, `id`, event handlers, or `colspan`/`rowspan`).