### PR TITLE
Fix /help server-side crash from non-serializable component prop

### DIFF
--- a/app/[locale]/help/[slug]/page.tsx
+++ b/app/[locale]/help/[slug]/page.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from "react";
-import { notFound } from "next/navigation";
 import { getTranslations, getLocale } from "next-intl/server";
 import {
     Container,
@@ -12,7 +11,7 @@ import {
 } from "@mantine/core";
 import { IconArrowLeft } from "@tabler/icons-react";
 import { auth } from "@/auth";
-import { redirect, Link } from "@/app/i18n/navigation";
+import { redirect } from "@/app/i18n/navigation";
 import { AgreementProtection } from "@/components/AgreementProtection";
 import { markdownToHtml } from "@/app/utils/markdown-to-html";
 import { getManualBySlug, canRoleReadManual, loadManualContent } from "../manual-registry";
@@ -62,6 +61,7 @@ async function ManualContent({ params }: { params: Promise<{ slug: string; local
     }
 
     const t = await getTranslations("help");
+    const locale = await getLocale();
     const rawMarkdown = loadManualContent(manual);
     const html = markdownToHtml(rawMarkdown);
 
@@ -72,9 +72,13 @@ async function ManualContent({ params }: { params: Promise<{ slug: string; local
                     <Title order={1} size="h2">
                         {getManualTitle(t, manual.slug)}
                     </Title>
+                    {/* Plain <a> with a locale-prefixed href — server components
+                        cannot pass the next-intl Link component through as a
+                        prop (React serialization across server/client boundary
+                        rejects component references). */}
                     <Button
-                        component={Link}
-                        href="/help"
+                        component="a"
+                        href={`/${locale}/help`}
                         variant="subtle"
                         leftSection={<IconArrowLeft size={16} />}
                         size="sm"

--- a/app/[locale]/help/page.tsx
+++ b/app/[locale]/help/page.tsx
@@ -74,25 +74,25 @@ function ManualCard({
     manual: ManualMeta;
     t: Awaited<ReturnType<typeof getTranslations<"help">>>;
 }) {
+    // We wrap Card in Link rather than using `component={Link}` because
+    // this file is a server component and passing a component reference
+    // as a prop to a Mantine client component fails serialization
+    // ("Only plain objects can be passed to Client Components").
     return (
-        <Card
-            withBorder
-            shadow="sm"
-            component={Link}
-            href={`/help/${manual.slug}`}
-            style={{ textDecoration: "none" }}
-        >
-            <Group align="flex-start" wrap="nowrap" gap="md">
-                <IconBook2 size={28} color="var(--mantine-color-blue-6)" />
-                <Stack gap={4} style={{ flex: 1 }}>
-                    <Title order={3} size="h4">
-                        {getManualTitle(t, manual.slug)}
-                    </Title>
-                    <Text size="sm" c="dimmed">
-                        {getManualDescription(t, manual.slug)}
-                    </Text>
-                </Stack>
-            </Group>
-        </Card>
+        <Link href={`/help/${manual.slug}`} style={{ textDecoration: "none", display: "block" }}>
+            <Card withBorder shadow="sm">
+                <Group align="flex-start" wrap="nowrap" gap="md">
+                    <IconBook2 size={28} color="var(--mantine-color-blue-6)" />
+                    <Stack gap={4} style={{ flex: 1 }}>
+                        <Title order={3} size="h4">
+                            {getManualTitle(t, manual.slug)}
+                        </Title>
+                        <Text size="sm" c="dimmed">
+                            {getManualDescription(t, manual.slug)}
+                        </Text>
+                    </Stack>
+                </Group>
+            </Card>
+        </Link>
     );
 }


### PR DESCRIPTION
## Why

Production users hitting `/sv/help` (or `/en/help`) saw "Application error: a server-side exception has occurred" with `Digest: 605873561`. The page crashed for every authenticated user. Reproduced locally — Next.js dev overlay surfaced the actual error:

> Only plain objects can be passed to Client Components from Server Components. Classes or other objects with methods are not supported.
> `<... withBorder={true} shadow="sm" component={{\$\$typeof: ..., render: ...}} href=... style=... children=...>`
> `app/[locale]/help/page.tsx (78:9) @ ManualCard`

## Root cause

The `/help` index page (`app/[locale]/help/page.tsx`) and the detail page (`app/[locale]/help/[slug]/page.tsx`) are server components. Both passed `component={Link}` as a prop to Mantine components (Card and Button respectively). Mantine components are client components, so React tries to serialize the props across the server→client boundary — and component references aren't serializable (they have a `\$\$typeof` symbol and a `render` function).

The other `Card component={Link}` usages in the codebase work fine because they live in `"use client"` files (`IssuesPageClient.tsx`, `HouseholdOptionsManager.tsx`). I missed that `/help` was server-side and would hit this restriction.

## Fix

| File | Before | After |
|---|---|---|
| `help/page.tsx` | `<Card component={Link} href={...}>...</Card>` | `<Link href={...}><Card>...</Card></Link>` — wrap, don't pass |
| `help/[slug]/page.tsx` | `<Button component={Link} href="/help">` | `<Button component="a" href={\`/\${locale}/help\`}>` — plain anchor with explicit locale |

For the index, wrapping the Card in a Link is the natural pattern for a "whole card is a link" UI. For the detail page's back-button, a plain `<a>` works because we already know the locale on the server side and can construct the full path.

## Verification

Reproduced the crash locally on `pnpm dev`, confirmed the fix renders both pages correctly for an authenticated handout_staff user. Role-based filtering on the index still works (handout_staff sees 2 manuals, admins would see 4). Detail page shows the markdown content rendered through the existing `markdownToHtml` pipeline.

The unused `notFound` import (left over from before the auth-ordering refactor) was also removed in passing — it was already a build warning.