### PR TITLE
Fix welcome banner slug and auth-guide inaccuracies

### DIFF
--- a/app/[locale]/schedule/components/WelcomeBanner.tsx
+++ b/app/[locale]/schedule/components/WelcomeBanner.tsx
@@ -72,7 +72,7 @@ export function WelcomeBanner({ userRole }: WelcomeBannerProps) {
                 <Stack gap={4} style={{ flex: 1 }}>
                     <Text fw={600}>{t("title")}</Text>
                     <Text size="sm">{t("body")}</Text>
-                    <Anchor component={Link} href="/help/utlamningspersonal" size="sm" fw={500}>
+                    <Anchor component={Link} href="/help/handout-staff" size="sm" fw={500}>
                         {t("readManual")}
                     </Anchor>
                 </Stack>

--- a/docs/auth-guide.md
+++ b/docs/auth-guide.md
@@ -2,7 +2,7 @@
 
 ## Authentication Requirements
 
-**EVERY page must be protected except `/auth/*` and `/p/*` (public parcel pages).**
+**EVERY page must be protected except `/auth/*` (sign-in/error screens), `/p/*` (public parcel pages), and `/privacy` (privacy policy).** See `middleware.ts` for the authoritative allow-list.
 
 ## Protection Patterns
 
@@ -145,46 +145,53 @@ This script ensures:
 
 ### Public API Routes (Exceptions)
 
-- `/api/auth/*` - NextAuth routes (public by design)
-- `/api/health` - Health check endpoint
-- `/api/csp-report` - CSP violation reporting (browser-initiated)
+Kept in `middleware.ts` as the `publicApiPatterns` allow-list:
+
+- `/api/auth/*` — NextAuth routes (public by design)
+- `/api/health` — Health check endpoint
+- `/api/csp-report` — CSP violation reporting (browser-initiated)
+- `/api/pickup-locations` — Public pickup locations lookup
+- `/api/webhooks/*` — Webhook endpoints (authenticated via URL secret, not session)
 
 ## GitHub OAuth Configuration
 
-The app uses **NextAuth v5** with:
+The app uses **NextAuth v5** with two separate GitHub integrations:
 
-- **GitHub OAuth** for user authentication
-- **GitHub App** for organization membership verification
+- **GitHub OAuth app** — used at sign-in. The user's OAuth access token is what we call against `GET /user/memberships/orgs/{org}` in `app/utils/auth/org-eligibility.ts` to gate the session. Driven by `AUTH_GITHUB_ID` / `AUTH_GITHUB_SECRET`.
+- **GitHub App** — used by the daily org-sync scheduler (`app/utils/scheduler.ts`), which walks every active user and deactivates anyone who has left the org. The App's installation token lets us read org membership without a specific user's OAuth token. Driven by `AUTH_GITHUB_APP_ID` / `AUTH_GITHUB_APP_INSTALLATION_ID` / `AUTH_GITHUB_APP_PRIVATE_KEY`. The login path does **not** use the GitHub App.
 
-### Required GitHub Permissions
+### Required GitHub permissions
 
-Organization must have the GitHub App installed with:
+- **OAuth app** — scopes `read:user`, `user:email`, `read:org` (declared in `auth.ts`).
+- **GitHub App** — organization permission `Members: Read-only` (used by the scheduler).
 
-- `members:read` - Check organization membership
-- `user:email` - Get user email (for admin audit logs)
+### Session validation flow
 
-### Session Validation Flow
+Sessions are **JWT-based** (`strategy: "jwt"` in `auth.ts`), so validation is stateless — there is no server-side session store to match against.
 
-1. User signs in via GitHub OAuth
-2. NextAuth creates session cookie
-3. `authenticateAdminRequest()` validates:
-    - Session is valid and not expired
-    - User is member of configured GitHub organization
-    - Session token matches server-side state
+1. User signs in via GitHub OAuth.
+2. `signIn` callback in `auth.ts` calls `checkGitHubOrgEligibility()` with the user's OAuth access token; result is cached in the JWT alongside the user's role (refreshed every 10 min for eligibility, every 5 min for role).
+3. On every request, `auth()` decodes the JWT cookie.
+4. `authenticateAdminRequest()` in `app/utils/auth/api-auth.ts` reads `auth()` and asserts: session present, `orgEligibility.ok === true`, and (when `adminOnly`) `user.role === "admin"`.
 
-### Environment Variables
+### Environment variables
+
+The actual variable names — see `.env.example` for the full list:
 
 ```bash
-# .env
-NEXTAUTH_URL=https://your-domain.com
-NEXTAUTH_SECRET=random-string-min-32-chars
+# GitHub OAuth (sign-in path)
+AUTH_GITHUB_ID=your_github_oauth_app_id
+AUTH_GITHUB_SECRET=your_github_oauth_app_secret
+AUTH_SECRET=generate_with_npx_auth_secret
+AUTH_TRUST_HOST=true
 
-GITHUB_ID=your-oauth-app-client-id
-GITHUB_SECRET=your-oauth-app-client-secret
+# GitHub organization access control
+GITHUB_ORG=vasteras-stadsmission
 
-GITHUB_APP_ID=your-github-app-id
-GITHUB_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n..."
-GITHUB_ORG_NAME=your-organization-name
+# GitHub App (scheduled org-sync path)
+AUTH_GITHUB_APP_ID=your_github_app_id
+AUTH_GITHUB_APP_INSTALLATION_ID=your_installation_id
+AUTH_GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
 ```
 
 ## Security Checklist


### PR DESCRIPTION
## Why

Two small problems that surfaced after PR #364 landed:

### 1. Welcome banner link broke after slug rename

PR #363 gave the `/schedule` welcome banner a "Läs handboken för utlämningspersonal →" link pointing at `/help/utlamningspersonal`. PR #364 then renamed that slug to `handout-staff` (and the other Swedish slugs to English equivalents) but missed this reference — the banner now points at a slug that no longer exists. The help detail page redirects unknown slugs back to `/help`, so it's not a crash, but the banner's only CTA dead-ends at the index.

Fix: update the banner href to `/help/handout-staff`.

### 2. `docs/auth-guide.md` has pre-existing inaccuracies

An independent review of PR #363 (via codex) flagged several stale factual claims in `docs/auth-guide.md` that predate the onboarding initiative. None were in PR #363's diff, so they were explicitly out of scope there. This PR cleans them up so the guide matches the code.

| Claim in guide (before) | Reality in code |
| --- | --- |
| Only `/auth/*` and `/p/*` are public pages | `middleware.ts` also exempts `/privacy` |
| Public API list has only 3 exceptions | `middleware.ts` also allows `/api/pickup-locations` and `/api/webhooks/*` |
| "GitHub App for organization membership verification" | Sign-in uses the **user's OAuth token** via `checkGitHubOrgEligibility()` (`auth.ts:77-81`). The GitHub App is only used by the daily org-sync scheduler (`app/utils/scheduler.ts:442`) to deactivate users who have left the org. These are two separate paths. |
| "Session token matches server-side state" | Sessions are **JWT** (`auth.ts:20-23`); `authenticateAdminRequest()` (`app/utils/auth/api-auth.ts`) decodes the JWT and checks `orgEligibility.ok` + role. Nothing is compared to a server-side store. |
| Env vars: `NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `GITHUB_ID`, `GITHUB_SECRET`, `GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`, `GITHUB_ORG_NAME` | Actual names per `.env.example`: `AUTH_GITHUB_ID`, `AUTH_GITHUB_SECRET`, `AUTH_SECRET`, `AUTH_TRUST_HOST`, `GITHUB_ORG`, `AUTH_GITHUB_APP_ID`, `AUTH_GITHUB_APP_INSTALLATION_ID`, `AUTH_GITHUB_APP_PRIVATE_KEY` |

The rewritten GitHub OAuth Configuration section now clearly separates the two GitHub integrations (OAuth for login, GitHub App for the scheduler) and documents the actual scopes/permissions each needs. The Session Validation Flow section now reflects the JWT-based, stateless reality.