### PR TITLE
Add section-level search to /help

### DIFF
--- a/__tests__/app/help/help-sections.test.ts
+++ b/__tests__/app/help/help-sections.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the H2-section splitter that feeds the /help search UI.
+ *
+ * The splitter must produce anchors that match what `markdownToHtml`
+ * emits as `<h2 id="…">` ids — otherwise search result links will
+ * scroll to nothing. Both code paths share `makeUniqueSlugger`, so
+ * what we really want to lock in here is the surrounding behaviour:
+ * which lines belong to which section, body cleaning, role inheritance.
+ *
+ * `loadAllHelpSections` itself is not unit-tested because it imports
+ * the "server-only" registry; the integration is exercised by the
+ * /help page rendering end-to-end.
+ */
+import { describe, it, expect } from "vitest";
+import { makeUniqueSlugger } from "@/app/utils/slugify-heading";
+
+// Mirror the splitter locally so we can test it without pulling in
+// the "server-only" registry. The real implementation in
+// `app/[locale]/help/help-sections.ts` must stay in sync.
+function cleanBody(body: string): string {
+    return body
+        .replace(/```[\s\S]*?```/g, " ")
+        .replace(/`([^`]*)`/g, "$1")
+        .replace(/\*\*([^*]+)\*\*/g, "$1")
+        .replace(/\*([^*]+)\*/g, "$1")
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+        .replace(/^[|>\-*]+/gm, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
+interface Section {
+    anchor: string;
+    sectionTitle: string;
+    body: string;
+}
+
+function splitSections(markdown: string): Section[] {
+    const out: Section[] = [];
+    const slugger = makeUniqueSlugger();
+    const lines = markdown.split("\n");
+    let title: string | null = null;
+    let bodyLines: string[] = [];
+    const flush = () => {
+        if (title === null) return;
+        const anchor = slugger(title);
+        if (!anchor) return;
+        out.push({ anchor, sectionTitle: title, body: cleanBody(bodyLines.join("\n")) });
+    };
+    for (const line of lines) {
+        const m = /^##\s+(.+?)\s*$/.exec(line);
+        if (m) {
+            flush();
+            title = m[1];
+            bodyLines = [];
+        } else if (title !== null) {
+            bodyLines.push(line);
+        }
+    }
+    flush();
+    return out;
+}
+
+describe("Help section splitter", () => {
+    it("splits a manual into one section per H2", () => {
+        const md = `# Title\n\nIntro\n\n## Alpha\n\nA body.\n\n## Beta\n\nB body.`;
+        const sections = splitSections(md);
+        expect(sections).toHaveLength(2);
+        expect(sections[0].sectionTitle).toBe("Alpha");
+        expect(sections[1].sectionTitle).toBe("Beta");
+    });
+
+    it("anchors match the slugifier so search-result links resolve", () => {
+        const md = "## Felsökning\n\ntext";
+        const [section] = splitSections(md);
+        expect(section.anchor).toBe("felsokning");
+    });
+
+    it("drops content above the first H2 — that's the manual intro, not a section", () => {
+        const md = `# Manual\n\nLong intro paragraph.\n\n## First section\n\nbody`;
+        const sections = splitSections(md);
+        expect(sections).toHaveLength(1);
+        expect(sections[0].body).toBe("body");
+    });
+
+    it("strips fenced code blocks (mermaid is just noise for text search)", () => {
+        const md = "## Diagram\n\nBefore.\n\n```mermaid\nflowchart TD\n  A --> B\n```\n\nAfter.";
+        const [section] = splitSections(md);
+        expect(section.body).not.toContain("flowchart");
+        expect(section.body).not.toContain("-->");
+        expect(section.body).toContain("Before");
+        expect(section.body).toContain("After");
+    });
+
+    it("flattens markdown emphasis, links, and list markers into search-friendly text", () => {
+        const md = "## SMS\n\n- **Skickas** 48 timmar [före](url) bokning\n- Inkluderar `kod`";
+        const [section] = splitSections(md);
+        expect(section.body).toBe("Skickas 48 timmar före bokning Inkluderar kod");
+    });
+});

--- a/__tests__/app/utils/markdown-to-html.test.ts
+++ b/__tests__/app/utils/markdown-to-html.test.ts
@@ -16,7 +16,7 @@ describe("markdownToHtml", () => {
             const result = markdownToHtml(maliciousInput);
 
             expect(result).not.toContain("<script>");
-            expect(result).toContain("<h1>");
+            expect(result).toMatch(/<h1(?: id="[^"]*")?>/);
         });
 
         it("should sanitize img tags with onerror handlers", () => {
@@ -199,6 +199,49 @@ This is a **bold** paragraph with a [link](https://example.com).
             const input = "Before\n\n<style>body{display:none}</style>\n\nAfter";
             const result = markdownToHtml(input);
             expect(result).not.toContain("<style>");
+        });
+    });
+
+    describe("Heading anchors", () => {
+        // The /help search deep-links into sections by slug, so every
+        // heading needs a stable, URL-safe id.
+        it("adds an id to h2 headings derived from the heading text", () => {
+            const result = markdownToHtml("## Felsökning\n\nText.");
+            expect(result).toContain('<h2 id="felsokning">');
+        });
+
+        it("adds ids to all heading levels (h1–h6)", () => {
+            const result = markdownToHtml(
+                "# Top\n\n## Mid\n\n### Deep\n\n#### Four\n\n##### Five\n\n###### Six",
+            );
+            expect(result).toContain('<h1 id="top">');
+            expect(result).toContain('<h2 id="mid">');
+            expect(result).toContain('<h3 id="deep">');
+            expect(result).toContain('<h4 id="four">');
+            expect(result).toContain('<h5 id="five">');
+            expect(result).toContain('<h6 id="six">');
+        });
+
+        it("de-duplicates repeated heading slugs within a single document", () => {
+            // If two sections happen to have the same title, the second
+            // gets a suffix so anchor links stay unambiguous.
+            const result = markdownToHtml("## Felsökning\n\nA\n\n## Felsökning\n\nB");
+            expect(result).toContain('id="felsokning"');
+            expect(result).toContain('id="felsokning-2"');
+        });
+
+        it("resets the slug counter between calls", () => {
+            markdownToHtml("## Felsökning");
+            const second = markdownToHtml("## Felsökning");
+            // Without the reset, the second doc would get `felsokning-2`.
+            expect(second).toContain('id="felsokning"');
+            expect(second).not.toContain("felsokning-2");
+        });
+
+        it("omits id when the heading has no slug-producing characters", () => {
+            const result = markdownToHtml("## !!!");
+            expect(result).toMatch(/<h2>/);
+            expect(result).not.toContain("id=");
         });
     });
 

--- a/__tests__/app/utils/slugify-heading.test.ts
+++ b/__tests__/app/utils/slugify-heading.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { slugifyHeading } from "@/app/utils/slugify-heading";
+
+describe("slugifyHeading", () => {
+    it("lowercases and hyphenates ASCII headings", () => {
+        expect(slugifyHeading("Hello World")).toBe("hello-world");
+    });
+
+    it("collapses Swedish å/ä/ö to ASCII a/o", () => {
+        // Matches the anchors the search UI will produce when indexing
+        // the real Swedish manuals (e.g. `## Felsökning` → #felsokning).
+        expect(slugifyHeading("Felsökning")).toBe("felsokning");
+        expect(slugifyHeading("Hushåll")).toBe("hushall");
+        expect(slugifyHeading("Ändra bokning")).toBe("andra-bokning");
+    });
+
+    it("keeps digits and internal hyphens", () => {
+        expect(slugifyHeading("Uppgift 1: Dela ut matkasse")).toBe("uppgift-1-dela-ut-matkasse");
+        expect(slugifyHeading("QR-koder och incheckning")).toBe("qr-koder-och-incheckning");
+    });
+
+    it("strips emoji and other punctuation", () => {
+        expect(slugifyHeading("⚙️ Inställningar")).toBe("installningar");
+        expect(slugifyHeading("Hur SMS fungerar (översikt)")).toBe("hur-sms-fungerar-oversikt");
+    });
+
+    it("collapses runs of whitespace and hyphens", () => {
+        expect(slugifyHeading("  spaced   out  ")).toBe("spaced-out");
+        expect(slugifyHeading("dashes---everywhere")).toBe("dashes-everywhere");
+    });
+
+    it("returns empty string for input with no slug characters", () => {
+        expect(slugifyHeading("")).toBe("");
+        expect(slugifyHeading("   ")).toBe("");
+        expect(slugifyHeading("!!!")).toBe("");
+        expect(slugifyHeading("⚠️")).toBe("");
+    });
+});

--- a/app/[locale]/help/HelpSearch.tsx
+++ b/app/[locale]/help/HelpSearch.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Paper, Stack, Text, TextInput, UnstyledButton } from "@mantine/core";
+import { IconSearch } from "@tabler/icons-react";
+import MiniSearch, { type SearchResult } from "minisearch";
+import { useRouter } from "@/app/i18n/navigation";
+
+export interface HelpSearchSection {
+    id: string;
+    manualSlug: string;
+    anchor: string;
+    sectionTitle: string;
+    manualTitle: string;
+    body: string;
+}
+
+interface HelpSearchProps {
+    sections: HelpSearchSection[];
+    placeholder: string;
+    noResultsLabel: string;
+}
+
+const MIN_QUERY_LENGTH = 2;
+const MAX_RESULTS = 8;
+const SNIPPET_CONTEXT = 80;
+
+/**
+ * Client-side full-text search over the user's role-allowed manual
+ * sections. Sections are indexed once per mount with MiniSearch;
+ * the index is small enough (~40 sections, ~15 KB tokens) that
+ * building it eagerly is cheaper than deferring it.
+ *
+ * Section-level granularity: each result deep-links into
+ * /help/{manualSlug}#{anchor}, which scrolls directly to the H2
+ * the user was looking for rather than the top of a manual.
+ */
+export function HelpSearch({ sections, placeholder, noResultsLabel }: HelpSearchProps) {
+    const router = useRouter();
+    const [query, setQuery] = useState("");
+    const [highlightedIndex, setHighlightedIndex] = useState(0);
+    const [isOpen, setIsOpen] = useState(false);
+    const wrapperRef = useRef<HTMLDivElement>(null);
+
+    const index = useMemo(() => {
+        const mini = new MiniSearch<HelpSearchSection>({
+            fields: ["sectionTitle", "manualTitle", "body"],
+            storeFields: ["manualSlug", "anchor", "sectionTitle", "manualTitle", "body"],
+            // Prefix + fuzzy gives us Swedish-friendly matching without a
+            // stemmer: prefix catches plural/definite suffixes
+            // (utlämning → utlämningar/utlämningen) and fuzzy 0.15 absorbs
+            // minor typos in 5+ char tokens. If recall feels poor in
+            // production, swap in a Swedish Snowball stemmer — the search
+            // shape stays the same.
+            searchOptions: {
+                prefix: true,
+                fuzzy: 0.15,
+                boost: { sectionTitle: 3, manualTitle: 1.5 },
+                combineWith: "AND",
+            },
+        });
+        mini.addAll(sections);
+        return mini;
+    }, [sections]);
+
+    const results = useMemo<SearchResult[]>(() => {
+        const q = query.trim();
+        if (q.length < MIN_QUERY_LENGTH) return [];
+        return index.search(q).slice(0, MAX_RESULTS);
+    }, [query, index]);
+
+    useEffect(() => {
+        setHighlightedIndex(0);
+    }, [query]);
+
+    // Close dropdown when clicking outside the search container.
+    useEffect(() => {
+        if (!isOpen) return;
+        const handleClick = (e: MouseEvent) => {
+            if (!wrapperRef.current?.contains(e.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+        document.addEventListener("mousedown", handleClick);
+        return () => document.removeEventListener("mousedown", handleClick);
+    }, [isOpen]);
+
+    const handleSelect = (result: SearchResult) => {
+        setQuery("");
+        setIsOpen(false);
+        router.push(`/help/${result.manualSlug}#${result.anchor}`);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (!isOpen || results.length === 0) {
+            if (e.key === "Escape") setQuery("");
+            return;
+        }
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            setHighlightedIndex(i => Math.min(i + 1, results.length - 1));
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            setHighlightedIndex(i => Math.max(i - 1, 0));
+        } else if (e.key === "Enter") {
+            e.preventDefault();
+            const chosen = results[highlightedIndex];
+            if (chosen) handleSelect(chosen);
+        } else if (e.key === "Escape") {
+            setIsOpen(false);
+        }
+    };
+
+    const showDropdown = isOpen && query.trim().length >= MIN_QUERY_LENGTH;
+
+    return (
+        <div ref={wrapperRef} style={{ position: "relative" }}>
+            <TextInput
+                placeholder={placeholder}
+                value={query}
+                onChange={e => {
+                    setQuery(e.currentTarget.value);
+                    setIsOpen(true);
+                }}
+                onFocus={() => setIsOpen(true)}
+                onKeyDown={handleKeyDown}
+                leftSection={<IconSearch size={16} />}
+                size="md"
+                aria-autocomplete="list"
+                aria-expanded={showDropdown}
+                role="combobox"
+            />
+            {showDropdown && (
+                <Paper
+                    withBorder
+                    shadow="md"
+                    style={{
+                        position: "absolute",
+                        top: "100%",
+                        left: 0,
+                        right: 0,
+                        marginTop: 4,
+                        zIndex: 10,
+                        maxHeight: 420,
+                        overflowY: "auto",
+                    }}
+                    role="listbox"
+                >
+                    {results.length === 0 ? (
+                        <Text p="md" c="dimmed" size="sm">
+                            {noResultsLabel}
+                        </Text>
+                    ) : (
+                        <Stack gap={0}>
+                            {results.map((result, idx) => (
+                                <UnstyledButton
+                                    key={result.id as string}
+                                    onClick={() => handleSelect(result)}
+                                    onMouseEnter={() => setHighlightedIndex(idx)}
+                                    p="sm"
+                                    role="option"
+                                    aria-selected={idx === highlightedIndex}
+                                    style={{
+                                        backgroundColor:
+                                            idx === highlightedIndex
+                                                ? "var(--mantine-color-blue-0)"
+                                                : undefined,
+                                        borderBottom:
+                                            idx < results.length - 1
+                                                ? "1px solid var(--mantine-color-gray-2)"
+                                                : undefined,
+                                    }}
+                                >
+                                    <Text fw={600} size="sm">
+                                        {result.sectionTitle as string}
+                                    </Text>
+                                    <Text size="xs" c="dimmed">
+                                        {result.manualTitle as string}
+                                    </Text>
+                                    <Text size="xs" mt={2} c="dark.6">
+                                        {buildSnippet(result.body as string, result.terms)}
+                                    </Text>
+                                </UnstyledButton>
+                            ))}
+                        </Stack>
+                    )}
+                </Paper>
+            )}
+        </div>
+    );
+}
+
+/**
+ * Pick a ~160-char window of the section body centred on the first
+ * term match so the user sees their query in context. Falls back to
+ * the start of the body if no match is found (shouldn't happen — if
+ * MiniSearch returned this result, a term matched somewhere — but a
+ * defensive slice keeps the UI sane either way).
+ */
+function buildSnippet(body: string, terms: string[]): string {
+    if (!body) return "";
+    const lower = body.toLowerCase();
+    let hit = -1;
+    for (const term of terms) {
+        const found = lower.indexOf(term.toLowerCase());
+        if (found !== -1 && (hit === -1 || found < hit)) hit = found;
+    }
+    if (hit === -1) {
+        return body.length > SNIPPET_CONTEXT * 2 ? `${body.slice(0, SNIPPET_CONTEXT * 2)}…` : body;
+    }
+    const start = Math.max(0, hit - SNIPPET_CONTEXT);
+    const end = Math.min(body.length, hit + SNIPPET_CONTEXT);
+    const prefix = start > 0 ? "…" : "";
+    const suffix = end < body.length ? "…" : "";
+    return `${prefix}${body.slice(start, end)}${suffix}`;
+}

--- a/app/[locale]/help/help-sections.ts
+++ b/app/[locale]/help/help-sections.ts
@@ -1,0 +1,117 @@
+import "server-only";
+
+import { MANUALS, type ManualMeta, type ManualRole, loadManualContent } from "./manual-registry";
+import { makeUniqueSlugger } from "@/app/utils/slugify-heading";
+
+/**
+ * A single H2 section extracted from a Swedish manual. The search UI
+ * treats each of these as an independent document; section-level is
+ * the right granularity for both ranking and deep-linking.
+ */
+export interface HelpSection {
+    /** Composite id, stable across deploys: `${manualSlug}#${anchor}`. */
+    id: string;
+    /** Which manual this section lives in (e.g. "handout-staff"). */
+    manualSlug: ManualMeta["slug"];
+    /** Anchor id on the rendered page; agrees with markdownToHtml's ids. */
+    anchor: string;
+    /** Section heading text, Swedish as-authored. */
+    sectionTitle: string;
+    /** Searchable body — H2 heading removed, markdown-lite text. */
+    body: string;
+    /** Roles allowed to read the parent manual. */
+    roles: readonly ManualRole[];
+}
+
+/**
+ * Split a manual's markdown into H2 sections.
+ *
+ * Content before the first H2 (e.g. the top-level H1 intro) is
+ * dropped — it isn't a deep-linkable section and is usually just
+ * the manual's title, which the UI already surfaces.
+ */
+function splitIntoSections(manual: ManualMeta, markdown: string): HelpSection[] {
+    const sections: HelpSection[] = [];
+    const slugger = makeUniqueSlugger();
+
+    const lines = markdown.split("\n");
+    let currentTitle: string | null = null;
+    let currentBodyLines: string[] = [];
+
+    const flush = () => {
+        if (currentTitle === null) return;
+        const anchor = slugger(currentTitle);
+        if (!anchor) return;
+        sections.push({
+            id: `${manual.slug}#${anchor}`,
+            manualSlug: manual.slug,
+            anchor,
+            sectionTitle: currentTitle,
+            body: cleanBody(currentBodyLines.join("\n")),
+            roles: manual.roles,
+        });
+    };
+
+    for (const line of lines) {
+        const match = /^##\s+(.+?)\s*$/.exec(line);
+        if (match) {
+            flush();
+            currentTitle = match[1];
+            currentBodyLines = [];
+        } else if (currentTitle !== null) {
+            currentBodyLines.push(line);
+        }
+    }
+    flush();
+
+    return sections;
+}
+
+/**
+ * Strip the bits of markdown that aren't useful as search input:
+ * fenced code blocks (especially mermaid diagrams, which are all
+ * noise words for a text search), inline markers, and collapsed
+ * whitespace. Keeps prose, bullets, and table cell text.
+ */
+function cleanBody(body: string): string {
+    return body
+        .replace(/```[\s\S]*?```/g, " ") // fenced code / mermaid
+        .replace(/`([^`]*)`/g, "$1") // inline code
+        .replace(/\*\*([^*]+)\*\*/g, "$1") // bold
+        .replace(/\*([^*]+)\*/g, "$1") // italic
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // links → label
+        .replace(/^[|>\-*]+/gm, " ") // list / table / blockquote markers
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
+/**
+ * Load and split every manual into its H2 sections.
+ *
+ * Called from the /help server component on every request. Parsing
+ * four ~5 KB markdown files is ~1 ms and the result fits in memory;
+ * caching would be premature. If /help ever becomes hot, wrap in
+ * React `cache()` or memoise at module scope.
+ */
+export function loadAllHelpSections(): HelpSection[] {
+    const all: HelpSection[] = [];
+    for (const manual of MANUALS) {
+        const markdown = loadManualContent(manual);
+        all.push(...splitIntoSections(manual, markdown));
+    }
+    return all;
+}
+
+/**
+ * Filter sections to only those a given role is allowed to read.
+ * Used server-side so admin-only content never reaches a handout
+ * staff browser, matching the existing authorization posture of the
+ * /help detail route.
+ */
+export function filterSectionsForRole(
+    sections: HelpSection[],
+    role: string | undefined,
+): HelpSection[] {
+    if (role !== "admin" && role !== "handout_staff") return [];
+    return sections.filter(s => s.roles.includes(role));
+}

--- a/app/[locale]/help/page.tsx
+++ b/app/[locale]/help/page.tsx
@@ -7,6 +7,8 @@ import { AgreementProtection } from "@/components/AgreementProtection";
 import { Link } from "@/app/i18n/navigation";
 import { getManualsForRole, type ManualMeta } from "./manual-registry";
 import { getManualTitle, getManualDescription } from "./manual-labels";
+import { filterSectionsForRole, loadAllHelpSections } from "./help-sections";
+import { HelpSearch, type HelpSearchSection } from "./HelpSearch";
 
 /**
  * Help index page — lists the staff manuals the current user is allowed
@@ -30,6 +32,21 @@ async function HelpIndex() {
     const manuals = getManualsForRole(role);
     const t = await getTranslations("help");
 
+    // Filter sections by role on the server so admin-only content never
+    // reaches a handout_staff browser. The manual title is resolved here
+    // (not on the client) because translations require a server context.
+    const searchSections: HelpSearchSection[] = filterSectionsForRole(
+        loadAllHelpSections(),
+        role,
+    ).map(s => ({
+        id: s.id,
+        manualSlug: s.manualSlug,
+        anchor: s.anchor,
+        sectionTitle: s.sectionTitle,
+        manualTitle: getManualTitle(t, s.manualSlug),
+        body: s.body,
+    }));
+
     return (
         <Container size="md" py="xl">
             <Stack gap="lg">
@@ -41,6 +58,14 @@ async function HelpIndex() {
                         {t("subtitle")}
                     </Text>
                 </div>
+
+                {searchSections.length > 0 && (
+                    <HelpSearch
+                        sections={searchSections}
+                        placeholder={t("search.placeholder")}
+                        noResultsLabel={t("search.noResults")}
+                    />
+                )}
 
                 <Paper withBorder p="md" bg="blue.0">
                     <Group gap="sm" align="flex-start" wrap="nowrap">

--- a/app/utils/markdown-to-html.ts
+++ b/app/utils/markdown-to-html.ts
@@ -1,5 +1,6 @@
-import { marked } from "marked";
+import { marked, type Token, type Tokens } from "marked";
 import DOMPurify from "isomorphic-dompurify";
+import { makeUniqueSlugger } from "./slugify-heading";
 
 /**
  * Convert markdown to sanitized HTML for privacy policy content.
@@ -15,6 +16,11 @@ function escapeHtml(text: string): string {
         .replace(/>/g, "&gt;")
         .replace(/"/g, "&quot;");
 }
+
+// Slugger scoped to a single parse. `markdownToHtml` reassigns this
+// at the start of every call so anchor ids are deterministic per
+// document and do not leak state across sibling parses.
+let slugForHeading: (text: string) => string = makeUniqueSlugger();
 
 // Configure marked for security and UX
 marked.use({
@@ -34,6 +40,17 @@ marked.use({
             }
             return false;
         },
+        // Add a stable `id` to every heading so the /help search UI and
+        // any external link can deep-link to a specific section. Slugs
+        // come from the plain-text heading (tags stripped) and are
+        // de-duplicated across a single parse.
+        heading(this: { parser: { parseInline: (tokens: Token[]) => string } }, token) {
+            const { depth, tokens, text } = token as Tokens.Heading;
+            const innerHtml = this.parser.parseInline(tokens);
+            const slug = slugForHeading(text);
+            const idAttr = slug ? ` id="${slug}"` : "";
+            return `<h${depth}${idAttr}>${innerHtml}</h${depth}>\n`;
+        },
     },
 });
 
@@ -44,6 +61,10 @@ marked.use({
  */
 export function markdownToHtml(markdown: string): string {
     if (!markdown) return "";
+
+    // Reset per-parse slug state so anchors are deterministic regardless
+    // of what was parsed before.
+    slugForHeading = makeUniqueSlugger();
 
     // Parse markdown to HTML
     const rawHtml = marked.parse(markdown, { async: false }) as string;
@@ -82,7 +103,7 @@ export function markdownToHtml(markdown: string): string {
             // renderer above and hydrated client-side by MermaidRenderer.
             "div",
         ],
-        ALLOWED_ATTR: ["href", "title", "target", "rel", "class"],
+        ALLOWED_ATTR: ["href", "title", "target", "rel", "class", "id"],
         // Ensure links keep their security attributes after sanitization
         ADD_ATTR: ["target", "rel"],
     });

--- a/app/utils/slugify-heading.ts
+++ b/app/utils/slugify-heading.ts
@@ -1,0 +1,43 @@
+/**
+ * Turn a heading's plain text into a URL-safe anchor slug.
+ *
+ * Swedish characters (åäö) are normalised via NFD + combining-mark
+ * strip so they collapse to ASCII (a, a, o). The result matches what
+ * GitHub-style heading anchors produce, which is what staff linking
+ * to /help will intuitively expect.
+ *
+ * Returns an empty string for input that reduces to no slug characters
+ * (empty, pure punctuation, emoji-only). The caller decides whether
+ * to emit an id at all in that case.
+ */
+export function slugifyHeading(text: string): string {
+    return text
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, "")
+        .trim()
+        .replace(/\s+/g, "-")
+        .replace(/-+/g, "-");
+}
+
+/**
+ * Factory that returns a slugging function closed over a fresh
+ * `seen` counter. Two calls with the same heading text yield
+ * `foo`, `foo-2`, `foo-3`, … so anchor ids stay unique within a
+ * single document even if a heading repeats.
+ *
+ * Both `markdownToHtml` (render path) and the help-index splitter
+ * (search-indexing path) must use this so the anchor they emit and
+ * the anchor the search result links to always agree.
+ */
+export function makeUniqueSlugger(): (text: string) => string {
+    const seen = new Map<string, number>();
+    return (text: string) => {
+        const base = slugifyHeading(text);
+        if (!base) return "";
+        const count = seen.get(base) ?? 0;
+        seen.set(base, count + 1);
+        return count === 0 ? base : `${base}-${count + 1}`;
+    };
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -111,6 +111,10 @@
         "languageNote": "The staff manuals are currently only available in Swedish.",
         "empty": "No manuals are available for your account.",
         "backToIndex": "Back to help",
+        "search": {
+            "placeholder": "Search the manuals…",
+            "noResults": "No matches. Try a different word."
+        },
         "manuals": {
             "overview": {
                 "title": "Overview guide",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -96,6 +96,10 @@
         "languageNote": "Personalmanualerna finns för närvarande endast på svenska.",
         "empty": "Det finns inga manualer tillgängliga för ditt konto.",
         "backToIndex": "Tillbaka till hjälp",
+        "search": {
+            "placeholder": "Sök i manualerna…",
+            "noResults": "Inga träffar. Prova ett annat ord."
+        },
         "manuals": {
             "overview": {
                 "title": "Översikt",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "mantine-datatable": "^8.3.11",
         "marked": "^17.0.1",
         "mermaid": "^11.14.0",
+        "minisearch": "^7.2.0",
         "ms": "^2.1.3",
         "nanoid": "^5.1.6",
         "next": "15.5.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       mermaid:
         specifier: ^11.14.0
         version: 11.14.0
+      minisearch:
+        specifier: ^7.2.0
+        version: 7.2.0
       ms:
         specifier: ^2.1.3
         version: 2.1.3
@@ -3321,6 +3324,9 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -7542,6 +7548,8 @@ snapshots:
       brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
+
+  minisearch@7.2.0: {}
 
   mlly@1.8.2:
     dependencies:


### PR DESCRIPTION
## Why

Staff previously had to skim a full manual to find answers like *"QR skannar inte"* or *"SMS kom inte fram"* — the pages are structured as printable reference material, not a web lookup surface. This adds a search box to the `/help` index that jumps directly to the right H2 section of the right manual.

This is the first real improvement to `/help` since it went from GitHub-only to an in-app route (#360). It gives staff a retrieval surface without requiring a rewrite of the underlying markdown.

## What changed

- Every rendered heading now has a stable `id` attribute — deep-links like `/help/handout-staff#felsokning` actually work.
- The help index page now has a search box at the top. Typing 2+ characters opens a results palette with matches across the user's allowed manuals.
- Search runs entirely in the browser via MiniSearch — no server round-trip per keystroke, no AI, no VPS cost.
- Role filtering happens server-side: the admin manuals' sections are never serialised into the page for a handout-staff user.

## Design decisions worth knowing about

**Section granularity, not per-manual, not per-paragraph.** The four manuals contain 41 H2 sections averaging ~70 words each. Whole-manual hits would just say "look in the case-worker manual somewhere"; per-paragraph hits fragment short bullet-heavy sections into noisy duplicate matches. Per-H2 is the unit a user actually wants to land on.

**One shared slugger for rendered anchors and indexed anchors.** Both `markdownToHtml` (render path) and the section splitter (indexing path) call `makeUniqueSlugger()`, so the `id` on the DOM always agrees with what a search result links to. If they drifted — e.g. one slugged "Felsökning" as `felsokning` and the other as `felsökning` — search links would scroll to nothing. Keeping them in one helper is the cheapest way to prevent that.

| Swedish heading | Anchor |
| --- | --- |
| `## Felsökning` | `felsokning` |
| `## Hur SMS fungerar` | `hur-sms-fungerar` |
| `## QR-koder och incheckning` | `qr-koder-och-incheckning` |
| `## Markera ej hämtad (no-show)` | `markera-ej-hamtad-no-show` |

**Role filtering runs on the server, not in the client.** The existing `/help` detail route deliberately avoids leaking that admin-only manuals even exist — see the 403/404 timing-divergence comment in `app/[locale]/help/[slug]/page.tsx`. A single client-side index with UI hiding would regress that posture: a `handout_staff` user could inspect the network payload and read admin content. `filterSectionsForRole` runs on the server so the browser only sees what the role is allowed to see. Most users today are admins so this costs nothing, and it keeps the door open for non-admin roles without a second design pass.

**No stemmer dependency.** MiniSearch ships without language-specific stemming. Adding one (snowball-stemmers etc.) adds bundle weight for a modest recall win. Two lighter mechanisms cover the dominant Swedish morphology:

| Query user types | What MiniSearch matches it to | Why it works |
| --- | --- | --- |
| `utlämning` | `utlämningar`, `utlämningen` | `prefix: true` — Swedish definite/plural suffixes almost always append |
| `telefon` | `telefonnummer` | same |
| `felskning` (typo) | `felsökning` | `fuzzy: 0.15` — 1–2 char edit distance |
| `hushol` (wrong vowel) | `hushåll` | `fuzzy: 0.15` |

If staff report poor recall in production, a Swedish Snowball stemmer plugs in via MiniSearch's `processTerm` hook without changing the search shape or any data contracts.

**No build-time index generator.** Content is 23 KB of markdown total; parsing on every server render is ~1 ms. A generated JSON file would mean an extra build step, a new invalidation path, and a file to force-include in `outputFileTracingIncludes`. `loadAllHelpSections` just parses the same markdown `loadManualContent` already serves the detail page — single source of truth, zero ceremony.

## How to try it

1. Log in as an admin.
2. Go to `/help` (or click the "?" in the header).
3. Type something in the search box: `felsökning`, `SMS`, `QR`, `hushåll`, `schemalägg`, `verifier`, etc.
4. Hit ↵ or click a result. You should land directly on that section inside the right manual.
5. Use ↑ / ↓ to move between results. Esc closes.