### PR TITLE
Refresh overview guide: surface /help, roles, fix stale nav

### DIFF
--- a/docs/anvandarguide-sv.md
+++ b/docs/anvandarguide-sv.md
@@ -4,19 +4,33 @@ Den här guiden visar hur Matcentralen fungerar för personal och mottagare.
 
 ---
 
+## Fler manualer under Hjälp
+
+Klicka på **Hjälp** i toppmenyn för att se alla manualer. Den här översikten är en av flera.
+
+Vilka manualer som visas beror på din roll:
+
+- **Administratör** – du som planerar utlämningar, registrerar hushåll och ändrar inställningar. Ser alla manualer.
+- **Utlämningspersonal** – du som arbetar med dagens utlämningar vid ett utlämningsställe. Ser översikten och handboken för utlämningspersonal.
+
+Om du tror att du borde se fler manualer än du gör, kontakta en administratör.
+
+---
+
 ## Navigationsöversikt
 
-Så här är webbplatsen uppbyggd:
+Så här är webbplatsen uppbyggd. Diagrammet visar alla sidor. Utlämningspersonal ser endast **Schema** och **Hjälp** i menyn – övriga sidor kräver administratörsbehörighet.
 
 ```mermaid
 flowchart TB
     subgraph Personalens sidor
-        Start["🏠 Startsida<br/>(Uppföljning)"]
+        Start["🏠 Startsida (Uppföljning)<br/>— endast administratörer"]
 
         Schema["📅 Schema"]
-        Hushall["👥 Hushåll"]
-        Statistik["📊 Statistik"]
-        Installningar["⚙️ Inställningar"]
+        Hjalp["❓ Hjälp"]
+        Hushall["👥 Hushåll<br/>— endast administratörer"]
+        Statistik["📊 Statistik<br/>— endast administratörer"]
+        Installningar["⚙️ Inställningar<br/>— endast administratörer"]
 
         Start --> Schema
         Start --> Hushall
@@ -24,16 +38,19 @@ flowchart TB
         Start --> Installningar
 
         Schema --> DagensUtlamningar["Dagens utlämningar"]
-        Schema --> Veckoschema["Veckoschema"]
+        Schema --> Veckoschema["Veckoschema<br/>— endast administratörer"]
 
         Hushall --> NyttHushall["Nytt hushåll"]
         Hushall --> HushallDetalj["Hushållsdetaljer"]
         HushallDetalj --> RedigeraHushall["Redigera hushåll"]
         HushallDetalj --> HanteraMatkassar["Hantera matkassar"]
 
-        Installningar --> AllmannaInst["Allmänna"]
         Installningar --> Platser["Utlämningsställen"]
-        Installningar --> Matkassegranser["Matkassegränser"]
+        Installningar --> Registreringsformular["Registreringsformulär"]
+        Installningar --> Matkassegranser["Varningsgräns för matkassar"]
+        Installningar --> Anvandare["Användare"]
+
+        Hjalp --> Manualer["Manualer för din roll"]
     end
 
     subgraph Mottagarens sida
@@ -130,6 +147,8 @@ flowchart TD
 
 ## Uppgift 3: Hantera problem (Uppföljning)
 
+> Endast administratörer. Utlämningspersonal ser inte startsidan och behöver inte göra uppföljning.
+
 Startsidan visar saker som behöver åtgärdas.
 
 ```mermaid
@@ -223,17 +242,20 @@ Mottagaren kan välja bland många språk: svenska, engelska, arabiska, somalisk
 
 ## Snabbreferens: Alla sidor
 
-| Sida                        | Vad du gör där                    |
-| --------------------------- | --------------------------------- |
-| **Uppföljning** (Startsida) | Se och åtgärda problem            |
-| **Schema**                  | Välj utlämningsställe             |
-| **Dagens utlämningar**      | Lämna ut matkassar, skanna QR     |
-| **Veckoschema**             | Se hela veckans bokningar, omboka |
-| **Hushåll**                 | Sök och visa alla hushåll         |
-| **Nytt hushåll**            | Registrera nytt hushåll           |
-| **Hushållsdetaljer**        | Se all info om ett hushåll        |
-| **Statistik**               | Se diagram och siffror            |
-| **Inställningar**           | Ändra systemkonfiguration         |
+Sidor markerade med _(admin)_ visas endast för administratörer.
+
+| Sida                                  | Vad du gör där                    |
+| ------------------------------------- | --------------------------------- |
+| **Uppföljning** (Startsida) _(admin)_ | Se och åtgärda problem            |
+| **Schema**                            | Välj utlämningsställe             |
+| **Dagens utlämningar**                | Lämna ut matkassar, skanna QR     |
+| **Veckoschema** _(admin)_             | Se hela veckans bokningar, omboka |
+| **Hushåll** _(admin)_                 | Sök och visa alla hushåll         |
+| **Nytt hushåll** _(admin)_            | Registrera nytt hushåll           |
+| **Hushållsdetaljer** _(admin)_        | Se all info om ett hushåll        |
+| **Statistik** _(admin)_               | Se diagram och siffror            |
+| **Inställningar** _(admin)_           | Ändra systemkonfiguration         |
+| **Hjälp**                             | Läs manualer för din roll         |
 
 ---
 
@@ -257,4 +279,4 @@ Mottagaren kan välja bland många språk: svenska, engelska, arabiska, somalisk
 
 ---
 
-_Dokumentet uppdaterat: 2025_
+_Dokumentet uppdaterat: 2026_


### PR DESCRIPTION
## Why

You reported that `/en/help/overview` (the overview guide rendered at `/help/overview`) doesn't show that there is a help page, and asked for a general readability / freshness pass. Two analysts (one local, one via codex) proposed elaborate role-education sections; a third pass as devil's advocate pushed back and said most of that is over-engineering for a 20-user charity app. This PR ships the minimal version that actually solves the reported problem.

## What changed

1. **New intro section "Fler manualer under Hjälp"** (added right after the title, before the nav diagram). Four short items: the `Hjälp` menu exists, this overview is one of several manuals, which manuals you see depends on your role (`Administratör` vs `Utlämningspersonal` — described in work-language, not RBAC jargon), and contact an administrator if you think something's missing. This is the direct answer to "the overview doesn't mention the help page."

2. **Stale nav diagram fixed.** The old diagram implied every staff user could navigate from `Startsida → Schema / Hushåll / Statistik / Inställningar`. Reality: handout staff are redirected away from `Startsida` to `/schedule` and don't see `Hushåll`, `Statistik`, or `Inställningar` at all. The diagram now labels admin-only nodes inline ("— endast administratörer") and one sentence above the diagram makes that plain. Also:
   - Removed the `Inställningar → Allmänna` branch (that route redirects to `/settings/locations` now)
   - Renamed `Matkassegränser` → `Varningsgräns för matkassar` (actual label)
   - Added `Registreringsformulär` and `Användare` under `Inställningar`
   - Added a `Hjälp` node to the diagram so it's visible in the structure
   - Labelled `Veckoschema` as admin-only (handout staff only have `Dagens utlämningar`)

3. **"Uppgift 3: Hantera problem (Uppföljning)" now opens with a blockquote noting it's admin-only.** Handout staff reading this section previously got misleading instructions for a page they can't access.

4. **"Snabbreferens: Alla sidor" table** now has an *(admin)* marker next to admin-only rows and includes the `Hjälp` entry. Kept it as a single table rather than splitting into two — simpler and doesn't duplicate maintenance.

5. **Date footer**: `2025` → `2026`.

## What's NOT in here (explicit scope decisions)

- **No big "role-based access control" explainer**, no pair-of-comparison-tables ("what you can do / what admin does"). Devil's advocate review argued these are over-engineering and risk being patronizing for adult volunteers.
- **No "who this is for" banner** at the top of every other manual. The `/help` index already filters manuals by role, so handout staff never see the admin manual in the first place.
- **No role label in the header UI.** Scope creep for a documentation fix, and the access-denied page + redirect behavior already handle the "why can't I see this?" case with explicit, role-specific copy.
- **No screenshots.** The overview is rendered through `app/utils/markdown-to-html.ts` which uses DOMPurify with `<img>` tags stripped — images wouldn't render anyway.

## Known follow-ups that are out of scope for this PR

- Similar stale content likely exists in `docs/handout-staff-manual-sv.md` and `docs/case-worker-manual-sv.md` (both still describe the `Hushåll` route without noting it's admin-only, the case-worker manual describes wizard steps that handout staff can't access). Could be a follow-up pass if you want.
- The `docs/user-flows.md` nav claims are partly stale too but that's a developer-facing doc.