### PR TITLE
Scroll /help detail page to the search result's section

### DIFF
--- a/app/[locale]/help/[slug]/HashScroller.tsx
+++ b/app/[locale]/help/[slug]/HashScroller.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Scroll to the URL hash target after client-side navigation.
+ *
+ * App Router's `<Link href="/path#hash">` scrolls to the hash target on
+ * navigation, but programmatic `router.push("/path#hash")` does not —
+ * the /help search UI uses `router.push` (so it can clear the query and
+ * close the results palette on the same click) and needs this helper
+ * to restore the scroll.
+ *
+ * The retry loop is insurance against Suspense streaming: if the heading
+ * isn't in the DOM on the first tick we re-try briefly, then give up.
+ * The URL and content are still correct either way.
+ */
+export function HashScroller() {
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        const hash = window.location.hash;
+        if (!hash) return;
+
+        // Our slugs are ASCII-only (see slugifyHeading), so decoding the
+        // hash isn't needed for links we produce. Skip the decode so a
+        // malformed externally-crafted hash like `#%E0%A4%A` can't throw
+        // a URIError and break the effect.
+        const id = hash.slice(1);
+        if (!id) return;
+
+        let cancelled = false;
+        let attempts = 0;
+
+        const tryScroll = () => {
+            if (cancelled) return;
+            const el = document.getElementById(id);
+            if (el) {
+                el.scrollIntoView({ block: "start", behavior: "smooth" });
+                return;
+            }
+            if (attempts++ < 50) {
+                setTimeout(tryScroll, 20);
+            }
+        };
+
+        tryScroll();
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    return null;
+}

--- a/app/[locale]/help/[slug]/page.tsx
+++ b/app/[locale]/help/[slug]/page.tsx
@@ -17,6 +17,7 @@ import { markdownToHtml } from "@/app/utils/markdown-to-html";
 import { getManualBySlug, canRoleReadManual, loadManualContent } from "../manual-registry";
 import { getManualTitle } from "../manual-labels";
 import { MermaidRenderer } from "./MermaidRenderer";
+import { HashScroller } from "./HashScroller";
 
 /**
  * Manual detail page — renders a single markdown manual from /docs.
@@ -96,6 +97,7 @@ async function ManualContent({ params }: { params: Promise<{ slug: string; local
                     </TypographyStylesProvider>
                 </Paper>
                 <MermaidRenderer />
+                <HashScroller />
             </Stack>
         </Container>
     );


### PR DESCRIPTION
## Why

#366 landed section-level search, but clicking a result opened the correct manual **without scrolling to the matching section** — the reader still had to Ctrl-F the page. This fixes that.

## Root cause

Next.js App Router's `<Link href="/path#hash">` does scroll to the hash on navigation — that path is fine. The bug is that the search UI uses `router.push("/path#hash")` programmatically (so it can clear the query and close the results palette in the same click), and `router.push` deliberately skips the hash scroll. So the hash landed in the URL but the reader stayed at the top of the page.

Switching to `<Link>` would work for mouse clicks, but keyboard `Enter` on a highlighted result still has to navigate programmatically, so we'd end up needing a scroll helper for that case anyway. A small `HashScroller` on the detail page covers both entry points cleanly.

## Fix

`HashScroller` is a tiny client component mounted on the manual detail page. On mount it reads `window.location.hash`, looks up the element by id, and calls `scrollIntoView({ block: "start", behavior: "smooth" })`.

It retries for ~1 s because the heading may not be in the DOM on the first tick if the page is still streaming through the `Suspense` boundary. After the retries exhaust it gives up silently — the URL and content are still correct, the reader just needs to scroll themselves.

No impact when landing without a hash (e.g. browsing into a manual from the card grid): the component early-returns.

The hash isn't `decodeURIComponent`'d — our slugs are ASCII by construction (see `slugifyHeading`), so decoding isn't needed for links the app produces, and skipping it avoids a `URIError` footgun on externally-crafted malformed hashes.

## How to verify

1. Go to `/help`.
2. Search `felsökning` (or any section name).
3. Click a result — or highlight with ↑/↓ and press ↵.
4. Page should open the manual and smoothly scroll to the matching `## Felsökning` heading, not the top of the manual.
5. Direct hits (typing `/help/handout-staff#hur-sms-fungerar` into the address bar and pressing Enter) should still scroll — those were already working via the browser's native anchor scroll and still do.