### PR TITLE
Stop /help nav from wrapping to a second row

### DIFF
--- a/components/HeaderSimple/HeaderSimple.tsx
+++ b/components/HeaderSimple/HeaderSimple.tsx
@@ -251,7 +251,16 @@ export function HeaderSimple() {
     return (
         <>
             <header className={classes.header} data-compact={isCompactDesktop || undefined}>
-                <Container size="md" className={classes.inner}>
+                {/* `md` (960 px) was just barely enough for logo + four admin
+                    nav items + four right-side actions. Adding the help icon
+                    pushed the row past 960 px — Mantine's Group defaults to
+                    `wrap="wrap"`, so the last nav item ("Statistik" for
+                    admins) dropped to a second row instead of overflowing.
+                    Bumping to `lg` (1140 px) gives the row the ~180 px of
+                    slack it needs without making the header feel detached
+                    from the `md`-sized content containers on the pages
+                    below. */}
+                <Container size="lg" className={classes.inner}>
                     <Box className={classes.logoContainer}>
                         <TransitionLink
                             href={HOME_LINK}


### PR DESCRIPTION
## The bug

Once the help \`?\` icon landed in the header (#360), the admin nav started wrapping to a second row on normal desktop widths — the last item (\"Statistik\") dropped below \"Behöver uppföljning / Hushåll / Schema\" instead of staying inline. Reported with a screenshot in prod.

## Why

Two things combined:

1. The header's inner \`<Container>\` was \`size=\"md\"\` (960 px).
2. Mantine's \`<Group>\` defaults to \`wrap=\"wrap\"\`, so when content exceeds the row width the nav (the flex-growing group) wraps rather than overflowing.

Content needs on an admin session:

| Element | ~px |
| --- | --- |
| Logo + \"Matcentralen\" | 180 |
| Four admin nav items | 480 |
| Language switcher + help icon + avatar + gear + \"Skanna QR-kod\" button | 360 |
| Gaps between groups | 60 |
| **Total** | **~1 080** |

Adding the help icon in #360 pushed the total past the 960 px budget, and the nav wrapped.

## Fix

Bump the header's Container from \`size=\"md\"\` (960 px) to \`size=\"lg\"\` (1 140 px).

**Why specifically \`lg\` and not \`xl\`.** The header \"should be as wide as the content below it\" feels right intuitively, but the app doesn't have a single content width. A quick survey of \`Container size=\` across the authenticated routes:

| Page | Container |
| --- | --- |
| Home / follow-up (\`/\`) | \`lg\` (1 140 px) |
| Schedule | \`xl\` (1 320 px) |
| Statistics | \`xl\` (1 320 px) |
| Settings shell | \`xl\` (1 320 px) |
| Settings sub-panels | \`md\` (960 px) |
| Help | \`md\` (960 px) |

\`lg\` is a good compromise: it matches the home page's content width exactly (no visible misalignment on the page most admins land on), stays reasonably close to the \`xl\` pages, and is only modestly wider than the \`md\` settings panels. \`xl\` would over-correct — fine for the three \`xl\` pages, visibly detached from everything else.

## Out of scope

An adjacent improvement worth a separate PR: the \"Skanna QR-kod\" button currently only drops its text label below the \`md\` breakpoint (viewport width). Making it icon-only at the \`isCompactDesktop\` breakpoint too would reduce the width pressure more surgically and let the header stay even narrower — but that's a UX choice worth making intentionally rather than folding into a bug-fix PR.

## How to verify

1. Open any admin page on a desktop viewport.
2. Header should render on a single row: logo, nav, right-side actions.
3. The nav \"Statistik\" label should not drop below the other nav items.
4. Resize the window: at the \`md\` breakpoint and below, the mobile burger takes over as before — that path is unchanged.