### PR TITLE
Reserve AppShell header height when scrolling to /help anchors

### DIFF
--- a/app/[locale]/help/[slug]/ManualContent.module.css
+++ b/app/[locale]/help/[slug]/ManualContent.module.css
@@ -1,0 +1,13 @@
+/*
+ * Reserve space at the top of the viewport when scrolling to an
+ * anchor inside a manual. Mantine's AppShell renders a fixed 60 px
+ * header that would otherwise cover the target heading; without
+ * this, deep-links land with the heading text clipped.
+ *
+ * Applied to every heading that has an id (i.e. every heading the
+ * search UI can link to) so both JS scrollIntoView and native
+ * browser hash-scroll on refresh behave the same way.
+ */
+.content :is(h1, h2, h3, h4, h5, h6)[id] {
+    scroll-margin-top: 80px;
+}

--- a/app/[locale]/help/[slug]/page.tsx
+++ b/app/[locale]/help/[slug]/page.tsx
@@ -18,6 +18,7 @@ import { getManualBySlug, canRoleReadManual, loadManualContent } from "../manual
 import { getManualTitle } from "../manual-labels";
 import { MermaidRenderer } from "./MermaidRenderer";
 import { HashScroller } from "./HashScroller";
+import classes from "./ManualContent.module.css";
 
 /**
  * Manual detail page — renders a single markdown manual from /docs.
@@ -93,7 +94,10 @@ async function ManualContent({ params }: { params: Promise<{ slug: string; local
                     <TypographyStylesProvider>
                         {/* Content is generated from trusted repo markdown and
                             sanitized by DOMPurify in markdownToHtml. */}
-                        <div dangerouslySetInnerHTML={{ __html: html }} />
+                        <div
+                            className={classes.content}
+                            dangerouslySetInnerHTML={{ __html: html }}
+                        />
                     </TypographyStylesProvider>
                 </Paper>
                 <MermaidRenderer />


### PR DESCRIPTION
## The bug

Clicking a \`/help\` search result (wired up in #368) opened the correct manual and scrolled to the matching section, but the section **title** sat ~50 px above the viewport top — readers had to manually scroll up to see the heading they'd just searched for.

## Root cause

Mantine's \`AppShell\` in \`app/client-providers.tsx\` uses \`header={{ height: 60 }}\`, which renders \`AppShell.Header\` as **fixed-positioned** over \`AppShell.Main\`.

\`HeaderSimple\`'s own CSS is \`position: relative\`, which is easy to misread as \"the header scrolls with the page\" — but the fixed behaviour comes from the AppShell wrapper, not from HeaderSimple itself. Took a moment to spot.

\`scrollIntoView({ block: \"start\" })\` aligns the target element's top with y=0 of the viewport — right underneath the 60 px fixed header bar — so the heading text is clipped.

The sticky-looking \`SmsBalanceBanner\` was also a suspect but it turned out to be normal-flow content inside \`AppShell.Main\`, not fixed — it isn't contributing to the clip.

## Fix

The CSS property that exists precisely for this case: \`scroll-margin-top\` on every heading with an \`id\` inside the manual body.

\`\`\`css
.content :is(h1, h2, h3, h4, h5, h6)[id] {
    scroll-margin-top: 80px;
}
\`\`\`

**About the 80 px value.** This is *not* the exact AppShell header height (60 px) — it's \"60 px to clear the bar + 20 px of comfort buffer\" so the heading doesn't sit flush against the bottom of the fixed header. Treat it as a deliberate spacing token, not a layout-derived number. If the AppShell header height changes later, this value should be revisited explicitly. Not worth threading a theme token for a single use site today.

## Why CSS instead of a JS offset in HashScroller

\`scroll-margin-top\` is also honoured by the browser's **native** hash-scroll, so this also fixes:

- Bookmarking \`/help/handout-staff#felsokning\` and opening the bookmark later.
- Reloading a manual page with a hash in the URL.
- Clicking an external link with a hash (e.g. from Slack).

A JS-side offset in \`HashScroller\` would only fix programmatic navigations from our own search UI.

## Scoping

The rule is applied via a CSS module on the \`dangerouslySetInnerHTML\` wrapper in the manual detail page, not globally. So it doesn't leak into privacy (\`/privacy\` is outside AppShell anyway) or the agreement/settings markdown previews that go through the same \`markdownToHtml\`. Those aren't obvious deep-link destinations, and some of them render inside their own scrollable cards anyway.

## How to verify

1. Go to \`/help\`.
2. Search any section name (\`felsökning\`, \`SMS\`, \`QR\`, etc.).
3. Click a result — the section heading should sit ~20 px below the fixed header, fully visible.
4. Reload the page at a hashed URL like \`/sv/help/handout-staff#felsokning\` — same result.