### PR TITLE
Standardize help manual terminology and clarify role/function split

### DIFF
--- a/docs/admin-manual-sv.md
+++ b/docs/admin-manual-sv.md
@@ -1,6 +1,6 @@
-# Adminhandbok – Inställningar (sv)
+# Adminhandbok – Inställningar
 
-Kort översikt av kugghjulsmenyn. Avsedd för administratörer och koordinatorer.
+Den här handboken vänder sig till dig som sätter upp systemet – utlämningsställen, öppettider, registreringsformulär och liknande. Du behöver administratörsrollen. För det dagliga handläggararbetet (registrera hushåll, schemalägga matkassar, följa upp ärenden), se [Handläggarhandboken](./case-worker).
 
 ## Lägga till ny personal
 
@@ -76,8 +76,8 @@ Varningssystem för att identifiera hushåll med högt antal matkassar.
 ## Rekommenderat arbetssätt
 
 - Gör plats- och schemaändringar på dator för bäst överblick.
-- Efter schemaändringar: kontrollera veckovyn i `Schema` så att tiderna ser rätt ut.
-- Lös ärenden på startsidan regelbundet (olösta utlämningar, fel i SMS osv.).
+- Efter schemaändringar: kontrollera `Veckoschema` i `Schema` så att tiderna ser rätt ut.
+- Lös ärenden på startsidan regelbundet (oregistrerade utlämningar, fel i SMS osv.).
 
 ## Felsökning
 

--- a/docs/anvandarguide-sv.md
+++ b/docs/anvandarguide-sv.md
@@ -11,7 +11,7 @@ Så här är webbplatsen uppbyggd:
 ```mermaid
 flowchart TB
     subgraph Personalens sidor
-        Start["🏠 Startsida<br/>(Uppföljning)"]
+        Start["🏠 Startsida<br/>(Behöver uppföljning)"]
 
         Schema["📅 Schema"]
         Hushall["👥 Hushåll"]
@@ -33,11 +33,11 @@ flowchart TB
 
         Installningar --> AllmannaInst["Allmänna"]
         Installningar --> Platser["Utlämningsställen"]
-        Installningar --> Matkassegranser["Matkassegränser"]
+        Installningar --> Matkassegranser["Varningsgräns för matkassar"]
     end
 
     subgraph Mottagarens sida
-        Mottagare["📱 Matpaket-sida<br/>(öppen för alla)"]
+        Mottagare["📱 Matkasse-sida<br/>(öppen för alla)"]
     end
 
     DagensUtlamningar -.->|"QR-kod<br/>kopplar ihop"| Mottagare
@@ -128,13 +128,13 @@ flowchart TD
 
 ---
 
-## Uppgift 3: Hantera problem (Uppföljning)
+## Uppgift 3: Hantera problem (Behöver uppföljning)
 
 Startsidan visar saker som behöver åtgärdas.
 
 ```mermaid
 flowchart TD
-    Start["🏠 Startsida (Uppföljning)"]
+    Start["🏠 Startsida (Behöver uppföljning)"]
 
     Start --> Problem1
     Start --> Problem2
@@ -144,7 +144,7 @@ flowchart TD
         O1["Matkasse som borde<br/>ha lämnats ut igår"]
         O1 --> O2{"Vad hände?"}
         O2 -->|"Glömde registrera"| O3["Klicka 'Utlämnad'"]
-        O2 -->|"Kom aldrig"| O4["Klicka 'Uteblev'"]
+        O2 -->|"Kom aldrig"| O4["Klicka 'Markera utebliven'"]
     end
 
     subgraph Problem2["Utanför öppettider"]
@@ -182,7 +182,7 @@ flowchart TD
     subgraph Mottagarens upplevelse
         R1["📱 Får SMS ca 48h innan<br/>med länk till sin sida"]
         R2["Klickar på länken"]
-        R3["Ser sin matpaket-sida"]
+        R3["Ser sin matkasse-sida"]
 
         subgraph Sidan visar
             I1["📍 Plats och adress"]
@@ -207,13 +207,13 @@ flowchart TD
 
 ### Statusar som mottagaren kan se
 
-| Status               | Färg   | Betydelse                |
-| -------------------- | ------ | ------------------------ |
-| Planerad             | Grå    | Väntar på hämtningsdagen |
-| Redo för upphämtning | Grön   | Dags att hämta!          |
-| Upphämtad            | Blå    | Redan hämtad             |
-| Förfallen            | Orange | Tiden har gått ut        |
-| Inställd             | Röd    | Avbokad                  |
+| Status             | Färg   | Betydelse                 |
+| ------------------ | ------ | ------------------------- |
+| Planerad           | Grå    | Väntar på utlämningsdagen |
+| Redo för utlämning | Grön   | Dags att hämta!           |
+| Utlämnad           | Blå    | Redan hämtad              |
+| Förfallen          | Orange | Tiden har gått ut         |
+| Inställd           | Röd    | Avbokad                   |
 
 ### Språkstöd
 
@@ -223,17 +223,17 @@ Mottagaren kan välja bland många språk: svenska, engelska, arabiska, somalisk
 
 ## Snabbreferens: Alla sidor
 
-| Sida                        | Vad du gör där                    |
-| --------------------------- | --------------------------------- |
-| **Uppföljning** (Startsida) | Se och åtgärda problem            |
-| **Schema**                  | Välj utlämningsställe             |
-| **Dagens utlämningar**      | Lämna ut matkassar, skanna QR     |
-| **Veckoschema**             | Se hela veckans bokningar, omboka |
-| **Hushåll**                 | Sök och visa alla hushåll         |
-| **Nytt hushåll**            | Registrera nytt hushåll           |
-| **Hushållsdetaljer**        | Se all info om ett hushåll        |
-| **Statistik**               | Se diagram och siffror            |
-| **Inställningar**           | Ändra systemkonfiguration         |
+| Sida                                | Vad du gör där                    |
+| ----------------------------------- | --------------------------------- |
+| **Behöver uppföljning** (Startsida) | Se och åtgärda problem            |
+| **Schema**                          | Välj utlämningsställe             |
+| **Dagens utlämningar**              | Lämna ut matkassar, skanna QR     |
+| **Veckoschema**                     | Se hela veckans bokningar, omboka |
+| **Hushåll**                         | Sök och visa alla hushåll         |
+| **Nytt hushåll**                    | Registrera nytt hushåll           |
+| **Hushållsdetaljer**                | Se all info om ett hushåll        |
+| **Statistik**                       | Se diagram och siffror            |
+| **Inställningar**                   | Ändra systemkonfiguration         |
 
 ---
 
@@ -242,7 +242,7 @@ Mottagaren kan välja bland många språk: svenska, engelska, arabiska, somalisk
 ### Före utdelningen
 
 - [ ] Logga in och gå till "Dagens utlämningar"
-- [ ] Kolla om det finns något under "Uppföljning"
+- [ ] Kolla om det finns något under "Behöver uppföljning"
 - [ ] Ha mobilen redo för QR-skanning
 
 ### Under utdelningen
@@ -253,7 +253,7 @@ Mottagaren kan välja bland många språk: svenska, engelska, arabiska, somalisk
 ### Efter utdelningen
 
 - [ ] Hantera eventuella uteblivna
-- [ ] Kolla "Uppföljning" nästa dag för missade registreringar
+- [ ] Kolla "Behöver uppföljning" nästa dag för missade registreringar
 
 ---
 

--- a/docs/case-worker-manual-sv.md
+++ b/docs/case-worker-manual-sv.md
@@ -1,6 +1,6 @@
-# Handbok för handläggare (sv)
+# Handbok för handläggare
 
-Kort guide för dig som registrerar hushåll och schemalägger matkassar.
+Den här handboken vänder sig till dig som tar emot hushåll och schemalägger matkassar. Du behöver administratörsrollen för att komma åt sidorna nedan, men de flesta handläggare rör sällan inställningssidorna – se [Adminhandboken](./administrator) för det.
 
 ## Snabbstart
 
@@ -42,13 +42,13 @@ Boka in hämtningstider för hushållet. Det finns två sätt att boka – välj
 **Från hushållskortet** – när du vill säkerställa att ett visst hushåll får matkasse:
 
 - Öppna hushållet → `Hantera matkassar`
-- Välj hämtplats och lägg till datum/tider
+- Välj utlämningsställe och lägg till datum/tider
 - Klicka `Spara matkassar`
 
-**Från veckovyn** – när du vill se lediga tider och fylla luckor:
+**Från Veckoschema** – när du vill se lediga tider och fylla luckor:
 
-- Gå till `Schema` → välj utlämningsställe → veckovy
-- Veckovyn visar alla tider och beläggning, även veckor utan bokningar
+- Gå till `Schema` → välj utlämningsställe → `Veckoschema`
+- Veckoschemat visar alla tider och beläggning, även veckor utan bokningar
 - Klicka på en ledig tid och välj hushåll
 - Bra när du vill fördela hushåll jämnt över tillgängliga tider
 
@@ -86,7 +86,7 @@ Intern information kopplad till hushållet.
 
 Startsidan visar ärenden som behöver åtgärdas:
 
-1. **Olösta utlämningar** – tidigare bokningar utan utfall.
+1. **Oregistrerade utlämningar** – tidigare bokningar utan utfall.
 2. **Utanför öppettiderna** – bokningar utanför platsens öppettider.
 3. **Misslyckade SMS** – sändningsfel att hantera.
 

--- a/docs/handout-staff-manual-sv.md
+++ b/docs/handout-staff-manual-sv.md
@@ -1,4 +1,4 @@
-# Handbok för utlämningspersonal (sv)
+# Handbok för utlämningspersonal
 
 Kort guide för dig som lämnar ut matkassar.
 
@@ -9,45 +9,45 @@ Kort guide för dig som lämnar ut matkassar.
 - För dagen-vid-dörren: mobiltelefon är smidigast (se Dagens utdelningar).
 - För planering och större ändringar: använd dator.
 
-## Veckoplanering (veckovy)
+## Veckoschema
 
 Översikt över kommande bokningar och beläggning.
 
-- Gå till `Schema` → veckovy för valt utlämningsställe.
+- Gå till `Schema` → `Veckoschema` för valt utlämningsställe.
 - Se beläggning per dag, hitta luckor och flytta tider vid behov.
 - Klicka på en ledig tid för att boka in ett hushåll direkt.
-- Veckovyn visar alla tider även veckor utan bokningar – bra för att se tillgängliga tider.
-- Använd veckovy när du planerar kommande dagar/veckor.
+- Veckoschemat visar alla tider även veckor utan bokningar – bra för att se tillgängliga tider.
+- Använd Veckoschema när du planerar kommande dagar/veckor.
 
-## Dagens utlämningar (dagvy)
+## Dagens utlämningar
 
-Arbetsvy för att hantera dagens hämtningar.
+Arbetsvy för att hantera dagens utlämningar.
 
-- Gå till `Schema` → `Dagens utlämningar` för din favoritplats (eller välj plats i listan).
+- Gå till `Schema` → `Dagens utlämningar` för din favoritplats (eller välj utlämningsställe i listan).
 - Visar bara dagens bokningar, grupperade per tidsfönster, med progressräknare.
 - Uppdatera vid behov (dra ner på mobil eller använd uppdatera-knappen).
-- Öppna en rad för att se detaljer och markera "Hämtad" eller "Ej hämtad" (no-show).
+- Öppna en rad för att se detaljer och välj `Markera utlämnad` eller `Markera utebliven`.
 - Bäst på mobil när du står i dörren.
 
-## Markera ej hämtad (no-show)
+## Markera utebliven
 
 Registrera när mottagaren inte hämtar sin matkasse.
 
-- Om mottagaren inte dyker upp: öppna bokningen och markera "Ej hämtad".
+- Om mottagaren inte dyker upp: öppna bokningen och välj `Markera utebliven`.
 - Kan endast göras för dagens eller tidigare bokningar.
-- Hjälper till att hålla statistiken korrekt och rensa olösta utlämningar.
+- Hjälper till att hålla statistiken korrekt och rensa oregistrerade utlämningar.
 
 ## Hitta hushåll och boka
 
 Sök upp hushåll och hantera deras bokningar.
 
 - `Hushåll`: sök på namn/telefon, öppna kortet och se historik och kommentarer.
-- Skapa nytt hushåll när någon är ny; fyll i namn, telefon och hämtningsplats.
+- Skapa nytt hushåll när någon är ny; fyll i namn, telefon och utlämningsställe.
 - Telefonnummer visas alltid som +467... (E.164-standard). Om du anger 07... konverteras det automatiskt – detta är avsiktligt.
 
 **När du bokar från hushållskortet** – bra när du vill säkerställa att ett visst hushåll får matkasse.
 
-**När du bokar från veckovyn** – bra när du vill se lediga tider och fördela hushåll jämnt. Veckovyn visar alla tider och beläggning, även veckor utan bokningar.
+**När du bokar från Veckoschema** – bra när du vill se lediga tider och fördela hushåll jämnt. Veckoschemat visar alla tider och beläggning, även veckor utan bokningar.
 
 ## Kommentarer
 
@@ -71,14 +71,14 @@ Automatiska påminnelser till mottagarna.
 
 Snabb identifiering av mottagare vid utlämning.
 
-- QR-kod är ett hjälpmedel, inte ett krav; du hittar alltid bokningen via `Dagens utlämningar` och kan markera hämtad där.
+- QR-kod är ett hjälpmedel, inte ett krav; du hittar alltid bokningen via `Dagens utlämningar` och kan välja `Markera utlämnad` där.
 - Snabbast: be mottagaren öppna QR-koden i sitt SMS på sin egen mobil och skanna med din mobilkamera.
 - Alternativ (t.ex. vid laptop): använd QR-scannersidan via länk i navigationen.
-- När du öppnar bokningen: kontrollera uppgifter och markera "Hämtad".
+- När du öppnar bokningen: kontrollera uppgifter och välj `Markera utlämnad`.
 
 ## Tips under utdelning
 
-- Håll dig i dagvyn för att undvika att missa sena ankomster; samma dag visas alltid som "kommande" tills du markerar hämtad.
+- Håll dig i `Dagens utlämningar` för att undvika att missa sena ankomster; samma dag visas alltid som "kommande" tills du markerar den utlämnad.
 - Lägg en kommentar i hushållskortet om något avviker (t.ex. fel nummer, bud hämtar).
 - Vid frågor om plats eller tider: öppna länken i SMS:et – den visar adress och karta.
 
@@ -86,8 +86,8 @@ Snabb identifiering av mottagare vid utlämning.
 
 **Hittar inte hushållet** – Rensa sökfältet, uppdatera sidan, kontrollera stavning.
 
-**Kan inte markera hämtad** – Kontrollera att bokningen inte redan är markerad eller borttagen.
+**Kan inte markera utlämnad** – Kontrollera att bokningen inte redan är markerad eller borttagen.
 
-**Mottagaren fick inget SMS** – Kontrollera hushållets SMS-historik via hushållskortet, eller be en administratör titta i uppföljningsvyn. Dela annars länken direkt.
+**Mottagaren fick inget SMS** – Kontrollera hushållets SMS-historik via hushållskortet, eller be en administratör titta i `Behöver uppföljning`. Dela annars länken direkt.
 
 **QR-kod skannar inte** – Höj skärmljusstyrkan, testa annan vinkel, eller sök fram bokningen manuellt i `Dagens utlämningar`.

--- a/messages/en.json
+++ b/messages/en.json
@@ -122,15 +122,15 @@
             },
             "handoutStaff": {
                 "title": "Handout staff manual",
-                "description": "Day-to-day operations: today's handouts, no-shows, QR scanning, and SMS basics."
+                "description": "For you at the door — today's handouts, no-shows, and SMS."
             },
             "caseWorker": {
                 "title": "Case worker manual",
-                "description": "Registering households and scheduling food parcels."
+                "description": "For you welcoming new households, scheduling food parcels, and following up on issues. Requires the administrator role."
             },
             "admin": {
                 "title": "Administrator manual",
-                "description": "Settings, locations, schedules, verification checklist, and onboarding new staff."
+                "description": "For you setting up the system — locations, opening hours, enrollment checklist, and new staff. Requires the administrator role."
             }
         }
     },

--- a/messages/public-sv.json
+++ b/messages/public-sv.json
@@ -1,27 +1,27 @@
 {
     "publicParcel": {
-        "title": "Matpaket Upphämtning",
-        "pickupInfo": "Upphämtningsinformation",
+        "title": "Matkasseutlämning",
+        "pickupInfo": "Utlämningsinformation",
         "location": "Plats",
-        "pickupWindow": "Upphämtningstid",
+        "pickupWindow": "Utlämningstid",
         "qrCodeLabel": "QR-kod",
-        "qrCodeDescription": "Visa denna QR-kod när du hämtar ditt matpaket",
+        "qrCodeDescription": "Visa denna QR-kod när du hämtar din matkasse",
         "mapsLabel": "Få vägbeskrivning",
         "googleMaps": "Google Maps",
         "appleMaps": "Apple Maps",
         "status": {
             "scheduled": "Planerad",
-            "ready": "Redo för upphämtning",
-            "collected": "Upphämtad",
+            "ready": "Redo för utlämning",
+            "collected": "Utlämnad",
             "expired": "Förfallen",
             "cancelled": "Inställd"
         },
         "statusDescription": {
-            "scheduled": "Din upphämtning är planerad. Vänligen kom under upphämtningstiden.",
-            "ready": "Ditt matpaket är redo för upphämtning nu!",
-            "collected": "Detta matpaket har redan hämtats.",
-            "expired": "Denna upphämtning är inte längre giltig. Vänligen kontakta personal om du har frågor.",
-            "cancelled": "Denna upphämtning har ställts in. Du behöver inte komma."
+            "scheduled": "Din utlämning är planerad. Vänligen kom under utlämningstiden.",
+            "ready": "Din matkasse är redo att hämtas nu!",
+            "collected": "Denna matkasse har redan hämtats.",
+            "expired": "Denna utlämning är inte längre giltig. Vänligen kontakta personal om du har frågor.",
+            "cancelled": "Denna utlämning har ställts in. Du behöver inte komma."
         },
         "pickupWindowFormat": "{startTime} - {endTime}",
         "dateFormat": {

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -107,15 +107,15 @@
             },
             "handoutStaff": {
                 "title": "Handbok för utlämningspersonal",
-                "description": "Vardagliga uppgifter: dagens utlämningar, uteblivna, QR-skanning och SMS."
+                "description": "För dig vid dörren — dagens utlämningar, uteblivna och SMS."
             },
             "caseWorker": {
                 "title": "Handbok för handläggare",
-                "description": "Registrering av hushåll och schemaläggning av matkassar."
+                "description": "För dig som tar emot nya hushåll, schemalägger matkassar och följer upp ärenden. Kräver administratörsrollen."
             },
             "admin": {
                 "title": "Handbok för administratörer",
-                "description": "Inställningar, utlämningsställen, scheman, registreringsformulär och ny personal."
+                "description": "För dig som sätter upp systemet — utlämningsställen, öppettider, registreringsformulär och ny personal. Kräver administratörsrollen."
             }
         }
     },


### PR DESCRIPTION
## Summary

Staff docs used inconsistent names for the same concepts — veckovy/Veckoschema, hämtplats/utlämningsställe, Ej hämtad/Utebliven, matpaket/matkasse, Uppföljning/Behöver uppföljning. This creates unnecessary confusion for new staff.

**Terminology standardization:** all four manuals and the Swedish public parcel page now use a single canonical term per concept, grounded in what `messages/sv.json` actually shows in the UI:

| Concept | Canonical term | Replaced variants |
|---|---|---|
| Weekly view | Veckoschema | veckovy, Veckoplanering |
| Pickup location | Utlämningsställe | hämtplats, hämtningsplats |
| No-show status | Utebliven / Markera utebliven | Ej hämtad, no-show, Uteblev |
| Picked-up status | Utlämnad / Markera utlämnad | Hämtad, Uthämtad, Upphämtad |
| Food parcel | matkasse | matpaket |
| Issues page | Behöver uppföljning | Uppföljning (bare), uppföljningsvyn |
| Unresolved handouts | Oregistrerade utlämningar | Olösta utlämningar |

**Role/function clarity:** the app has two auth roles (administrator, handout_staff) but three distinct lines of work: admin setup, case work, and handout. The case-worker and admin manuals both require the administrator role but cover different day-to-day work. Each manual now opens with a line explaining who it's for and cross-links to its sibling. The `/help` index descriptions mirror this.

**Recipient page (`public-sv.json`):** unified to match staff terminology — "Matpaket Upphämtning" → "Matkasseutlämning", status labels like "Upphämtad" → "Utlämnad". Non-Swedish public locale files are untouched.

Other small fixes: dropped redundant "(sv)" suffix from manual H1 titles, fixed "Matkassegränser" → "Varningsgräns för matkassar" in the overview diagram.