### PR TITLE
Use recipient perspective on public parcel page

### DIFF
--- a/docs/anvandarguide-sv.md
+++ b/docs/anvandarguide-sv.md
@@ -207,13 +207,13 @@ flowchart TD
 
 ### Statusar som mottagaren kan se
 
-| Status             | Färg   | Betydelse                 |
-| ------------------ | ------ | ------------------------- |
-| Planerad           | Grå    | Väntar på utlämningsdagen |
-| Redo för utlämning | Grön   | Dags att hämta!           |
-| Utlämnad           | Blå    | Redan hämtad              |
-| Förfallen          | Orange | Tiden har gått ut         |
-| Inställd           | Röd    | Avbokad                   |
+| Status               | Färg   | Betydelse                |
+| -------------------- | ------ | ------------------------ |
+| Planerad             | Grå    | Väntar på hämtningsdagen |
+| Redo för upphämtning | Grön   | Dags att hämta!          |
+| Upphämtad            | Blå    | Redan hämtad             |
+| Förfallen            | Orange | Tiden har gått ut        |
+| Inställd             | Röd    | Avbokad                  |
 
 ### Språkstöd
 

--- a/messages/public-sv.json
+++ b/messages/public-sv.json
@@ -1,9 +1,9 @@
 {
     "publicParcel": {
-        "title": "Matkasseutlämning",
-        "pickupInfo": "Utlämningsinformation",
+        "title": "Matkasse – upphämtning",
+        "pickupInfo": "Upphämtningsinformation",
         "location": "Plats",
-        "pickupWindow": "Utlämningstid",
+        "pickupWindow": "Upphämtningstid",
         "qrCodeLabel": "QR-kod",
         "qrCodeDescription": "Visa denna QR-kod när du hämtar din matkasse",
         "mapsLabel": "Få vägbeskrivning",
@@ -11,17 +11,17 @@
         "appleMaps": "Apple Maps",
         "status": {
             "scheduled": "Planerad",
-            "ready": "Redo för utlämning",
-            "collected": "Utlämnad",
+            "ready": "Redo för upphämtning",
+            "collected": "Upphämtad",
             "expired": "Förfallen",
             "cancelled": "Inställd"
         },
         "statusDescription": {
-            "scheduled": "Din utlämning är planerad. Vänligen kom under utlämningstiden.",
-            "ready": "Din matkasse är redo att hämtas nu!",
+            "scheduled": "Din upphämtning är planerad. Vänligen kom under upphämtningstiden.",
+            "ready": "Din matkasse är redo för upphämtning nu!",
             "collected": "Denna matkasse har redan hämtats.",
-            "expired": "Denna utlämning är inte längre giltig. Vänligen kontakta personal om du har frågor.",
-            "cancelled": "Denna utlämning har ställts in. Du behöver inte komma."
+            "expired": "Denna upphämtning är inte längre giltig. Vänligen kontakta personal om du har frågor.",
+            "cancelled": "Denna upphämtning har ställts in. Du behöver inte komma."
         },
         "pickupWindowFormat": "{startTime} - {endTime}",
         "dateFormat": {


### PR DESCRIPTION
## Summary

Follow-up to #374. The public parcel page is read by recipients picking up their food parcel — it should use their perspective ("ready for pickup" / "redo för upphämtning"), not the staff handout perspective ("ready for handout" / "redo för utlämning").

- `messages/public-sv.json`: restores recipient-perspective words (upphämtning, upphämtad, upphämtningstid) while keeping "matkasse" (the unified term from #374)
- `docs/anvandarguide-sv.md`: updates the recipient status table to match what the recipient actually sees on their screen