### PR TITLE
Force dompurify >=3.4.0 to patch GHSA-39q2-94rc-95cp

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
             "minimatch": ">=10.2.1",
             "yaml": ">=2.8.3",
             "brace-expansion": ">=5.0.5",
-            "picomatch": ">=4.0.4"
+            "picomatch": ">=4.0.4",
+            "dompurify": ">=3.4.0"
         }
     },
     "packageManager": "pnpm@10.29.3+sha512.498e1fb4cca5aa06c1dcf2611e6fafc50972ffe7189998c409e90de74566444298ffe43e6cd2acdc775ba1aa7cc5e092a8b7054c811ba8c5770f84693d33d2dc"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   yaml: '>=2.8.3'
   brace-expansion: '>=5.0.5'
   picomatch: '>=4.0.4'
+  dompurify: '>=3.4.0'
 
 importers:
 
@@ -2485,8 +2486,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   drizzle-kit@0.31.8:
     resolution: {integrity: sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg==}
@@ -6556,7 +6557,7 @@ snapshots:
       '@babel/runtime': 7.28.4
       csstype: 3.1.3
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7350,7 +7351,7 @@ snapshots:
 
   isomorphic-dompurify@2.25.0:
     dependencies:
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       jsdom: 26.1.0
     transitivePeerDependencies:
       - bufferutil
@@ -7522,7 +7523,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.19
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       katex: 0.16.45
       khroma: 2.1.0
       lodash-es: 4.18.1


### PR DESCRIPTION
## Why

[GHSA-39q2-94rc-95cp](https://github.com/advisories/GHSA-39q2-94rc-95cp) (moderate, CVSS 5.3) is a logic error in DOMPurify <= 3.3.3 where forbidden tags slip past the filter when an app passes `ADD_TAGS` as a function alongside `FORBID_TAGS`. The tag check short-circuits in the wrong order, so forbidden entries are accepted instead of rejected. Fixed in `dompurify@3.4.0`.

We use `dompurify` transitively — primarily via `isomorphic-dompurify` (used in `app/utils/markdown-to-html.ts` to sanitise /help markdown and in `CommentHtml.tsx` to render household comments), and also via `mermaid`. Our own usage doesn't pass `ADD_TAGS` as a function, so exposure is low, but we should still be on a patched version.

## Approach

Add a single `pnpm.overrides` entry pinning `dompurify` to `>=3.4.0`:

```json
"dompurify": ">=3.4.0"
```

Why an override instead of a dependency bump:

| Option | Change | Risk |
|---|---|---|
| Bump `isomorphic-dompurify` to 3.x | Major version bump (2 → 3), peer-dep ripples (`jsdom` ^28 etc.) | Higher — touches public API surface |
| **pnpm override (chosen)** | One line, covers every transitive consumer at once | Low — `isomorphic-dompurify@^2.25.0` already accepts `dompurify@^3.2.6`, so 3.4.0 fits the existing range |

The lockfile confirms both `isomorphic-dompurify` and `mermaid` now resolve `dompurify@3.4.0`.

## Verification

- `pnpm audit --prod` → no known vulnerabilities
- `pnpm test` → 1558 passed, 1 skipped (including the markdown-to-html sanitisation tests)
- `pnpm typecheck` → clean