### PR TITLE
fix(nginx): forward X-Real-IP and own Referrer-Policy from middleware

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -169,4 +169,49 @@ describe("Middleware API Authentication", () => {
             expect(csp).toContain("script-src 'self' 'nonce-mockedNonce'");
         }
     });
+
+    /**
+     * TEST 6: Regression — /p/<parcel> MUST keep Referrer-Policy: no-referrer
+     *
+     * These pages contain PII (household name, pickup address) and are reached
+     * via unique SMS links. Leaking the parcel URL via Referer would expose
+     * that data to any third-party script a user subsequently visits.
+     *
+     * History: before PR #378, nginx also set a global
+     * `Referrer-Policy: strict-origin-when-cross-origin`. RFC 9110 combined
+     * the two headers into a single comma-separated value, and the W3C
+     * Referrer Policy parser uses the *last valid token*, so the effective
+     * policy was the nginx value — silently defeating the `no-referrer`
+     * intent. Ownership now lives entirely in middleware; nginx no longer
+     * sets Referrer-Policy. This test guards that invariant.
+     */
+    it("should set Referrer-Policy: no-referrer on public parcel routes", async () => {
+        const request = new NextRequest("http://localhost:3000/p/abc123xyz", {
+            method: "GET",
+        });
+
+        const response = await middleware(request);
+
+        expect(response.headers.get("Referrer-Policy")).toBe("no-referrer");
+    });
+
+    /**
+     * TEST 7: Non-/p/ routes get the default Referrer-Policy
+     *
+     * The middleware's addCSPHeaders helper sets
+     * `Referrer-Policy: strict-origin-when-cross-origin` unless a caller has
+     * already set a stricter value. Guards against a regression where the
+     * default is accidentally dropped (leaving no explicit header at all,
+     * which is a behavior change for pre-2021 browsers that defaulted to
+     * `no-referrer-when-downgrade`).
+     */
+    it("should set default Referrer-Policy on non-parcel routes", async () => {
+        const request = new NextRequest("http://localhost:3000/api/health", {
+            method: "GET",
+        });
+
+        const response = await middleware(request);
+
+        expect(response.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+    });
 });

--- a/app/p/[parcelId]/page.tsx
+++ b/app/p/[parcelId]/page.tsx
@@ -233,7 +233,9 @@ export default async function PublicParcelPage({ params, searchParams }: PublicP
     // Abuse dampener: fail closed with a 404 if the same IP hammers the
     // endpoint. Parcel IDs are unguessable (nanoid(12) ≈ 72 bits), so this
     // isn't an enumeration defense — it just blunts scraping and hot-loops.
-    // x-real-ip is set by nginx from $remote_addr (see nginx/shared.conf).
+    // x-real-ip is set by nginx from $remote_addr in each `location` block
+    // of nginx/nginx.conf.template (it has to be declared per-location
+    // because nginx's proxy_set_header uses replace-not-merge inheritance).
     const requestHeaders = await headers();
     const ip = requestHeaders.get("x-real-ip") ?? "unknown";
     const rateLimit = checkRateLimit(`public-parcel:${ip}`, PUBLIC_RATE_LIMITS.PARCEL_LOOKUP);

--- a/middleware.ts
+++ b/middleware.ts
@@ -170,7 +170,13 @@ export default async function middleware(request: NextRequest) {
     return addCSPHeaders(response);
 }
 
-// Configure the matcher to include both page routes and API routes
+// Configure the matcher to include both page routes and API routes.
+// Note: the excluded paths (_next/static, _next/image, favicon.svg, flags/)
+// will not receive a Referrer-Policy header since middleware owns that header
+// and nginx no longer sets it (see addCSPHeaders above). These responses are
+// static assets (JS/CSS/images) that don't originate outbound navigation, so
+// Referer leakage isn't a concern; modern browsers also default to
+// "strict-origin-when-cross-origin" which matches our explicit default.
 export const config = {
     matcher: [
         /*

--- a/middleware.ts
+++ b/middleware.ts
@@ -48,10 +48,17 @@ export default async function middleware(request: NextRequest) {
     // Generate nonce for CSP
     const nonce = generateNonce();
 
-    // Helper function to add CSP headers to response
+    // Helper function to add CSP + a default Referrer-Policy to the response.
+    // Referrer-Policy is owned entirely by middleware (not nginx) so routes
+    // like /p/<parcel> can override the default with "no-referrer" without
+    // producing two conflicting headers. We only set the default if a caller
+    // hasn't already set one — that way the stricter per-route value wins.
     const addCSPHeaders = (response: NextResponse) => {
         response.headers.set("Content-Security-Policy", createCSP(nonce));
         response.headers.set("x-nonce", nonce);
+        if (!response.headers.has("Referrer-Policy")) {
+            response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+        }
         return response;
     };
 

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -23,30 +23,39 @@ server {
     # Include shared configuration (rate limiting, gzip, security headers, proxy settings)
     include /etc/nginx/shared.conf;
 
+    # NOTE: nginx's `proxy_set_header` uses "replace, not merge" semantics —
+    # any directives declared inside a location block drop ALL inherited
+    # `proxy_set_header` directives from the server/http scope. So each
+    # location below must list every header we want forwarded to Next.js,
+    # including X-Real-IP and X-Forwarded-For (used for rate limiting and
+    # CSP violation reports). Scalar directives like proxy_http_version do
+    # inherit and live in shared.conf.
+
     # Static assets with smart caching
     location /_next/static/ {
         proxy_pass http://nextjs_backend;
-        # Ensure correct host and forwarded headers reach Next.js (local only)
-        # The shared.conf sets these generally; we duplicate in local to be explicit
         proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Forwarded-Port $server_port;
-        # Proxy settings are inherited from shared.conf
+        proxy_set_header X-Accel-Buffering no;
         # Let Next.js handle caching headers
     }
 
     # Everything else goes to Next.js
     location / {
         proxy_pass http://nextjs_backend;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        # Ensure correct host and forwarded headers reach Next.js (local only)
-        # The shared.conf sets these generally; we duplicate in local to be explicit
         proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Forwarded-Port $server_port;
-        # Other proxy settings are inherited from shared.conf
+        proxy_set_header X-Accel-Buffering no;
+        # WebSocket support (Next.js HMR, server-sent events, etc.)
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
     }
 }

--- a/nginx/shared.conf
+++ b/nginx/shared.conf
@@ -18,9 +18,14 @@ gzip_types
     application/json;
 
 # Security headers
+# Referrer-Policy is intentionally NOT set here. The Next.js middleware
+# (middleware.ts) owns it so individual routes can override — e.g.,
+# /p/<parcel> uses "no-referrer" to prevent parcel URL leakage via Referer.
+# If nginx also set a value, RFC 9110 would combine the two and the W3C
+# Referrer-Policy algorithm would pick the last valid token, silently
+# defeating the middleware's stricter per-route policy.
 add_header X-Content-Type-Options "nosniff" always;
 add_header X-Frame-Options "DENY" always;
-add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header Strict-Transport-Security "max-age=86400; includeSubDomains" always; # 1 day — increase after verifying all subdomains
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
@@ -30,20 +35,13 @@ client_max_body_size 10M;
 # Rate limiting for all requests
 limit_req zone=app burst=100 nodelay;
 
-# Shared proxy settings
+# Scalar proxy settings — these inherit into location blocks normally.
+# proxy_set_header directives do NOT inherit once a location declares any
+# of its own (nginx's "replace, not merge" rule), so the full header list
+# lives in the location blocks in nginx.conf.template, not here.
 proxy_http_version 1.1;
-# Preserve the original Host header including port (e.g., localhost:8080)
-proxy_set_header Host $http_host;
-proxy_set_header X-Real-IP $remote_addr;
-proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-proxy_set_header X-Forwarded-Proto $scheme;
-proxy_set_header X-Forwarded-Host $http_host;
-proxy_set_header X-Forwarded-Port $server_port;
 proxy_cache_bypass $http_upgrade;
+proxy_buffering off;
 
 # Strip internal nonce header before sending to client
 proxy_hide_header x-nonce;
-
-# Streaming configuration
-proxy_buffering off;
-proxy_set_header X-Accel-Buffering no;


### PR DESCRIPTION
## Why

PR #372 added two features (public parcel rate limit + PII-strict Referrer-Policy) that both turned out to be defeated by pre-existing nginx config bugs. Staging smoke tests after #372 merged caught both. This PR fixes the underlying nginx config so those features actually work, and as a side effect also fixes a latent observability bug on prod (CSP violation reports have been logging \`ip: \"unknown\"\` since they were introduced).

## What changed and why

### 1. nginx \`proxy_set_header\` inheritance

\`proxy_set_header\` uses **replace, not merge** semantics across scopes: if a \`location\` block declares *any* \`proxy_set_header\`, it drops ALL inherited ones from the server/http scope ([nginx docs](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header)). Each server block was declaring \`Host\` + three \`X-Forwarded-*\` headers inline, which dropped \`X-Real-IP\` and \`X-Forwarded-For\` from shared.conf. The app was receiving neither.

| Caller | What broke |
|---|---|
| \`app/p/[parcelId]/page.tsx\` (new in #372) | Rate limit bucket always \`public-parcel:unknown\` → global rate limit, not per-IP. Any single client can exhaust the limit for everyone. |
| \`app/api/csp-report/route.ts\` (pre-existing) | CSP violation reports have been logging \`ip: \"unknown\"\` for every report since the endpoint was added. Latent observability bug on prod. |

**Fix:** list every \`proxy_set_header\` explicitly in each location block in \`nginx.conf.template\` (including \`X-Real-IP\` and \`X-Forwarded-For\`), and document the replace-not-merge gotcha with a comment. Drop the dead \`proxy_set_header\` directives from \`shared.conf\` — they were never reaching Next.js. Scalar settings (\`proxy_http_version\`, \`proxy_cache_bypass\`, \`proxy_buffering\`) stay in shared.conf since those *do* inherit normally.

### 2. Conflicting \`Referrer-Policy\` headers

The middleware (from #372) set \`Referrer-Policy: no-referrer\` for \`/p/*\`; \`shared.conf\` also set \`Referrer-Policy: strict-origin-when-cross-origin\` globally. Per [RFC 9110 §5.2](https://www.rfc-editor.org/rfc/rfc9110), same-name headers combine into a single comma-separated value; per the [W3C Referrer Policy §8.1 parsing algorithm](https://www.w3.org/TR/referrer-policy/), iteration ends at the *last valid token*. Observed on staging:

\`\`\`
referrer-policy: no-referrer                            ← middleware
Referrer-Policy: strict-origin-when-cross-origin        ← nginx
\`\`\`

Effective policy = \`strict-origin-when-cross-origin\`. The middleware header was silently defeated and the parcel URL could still leak via Referer.

**Fix:** single owner per response. Remove Referrer-Policy from \`shared.conf\`. Set a default of \`strict-origin-when-cross-origin\` in the middleware's CSP helper, but only when the caller hasn't already set one — so \`/p/*\`'s stricter \`no-referrer\` still wins without conflict.

## Prior art

Codex MCP independently confirmed both diagnoses against the authoritative sources above and recommended blocking the production rollout of #372 until these fixes land.

## Impact on other routes

- Non-\`/p/*\` routes still get \`Referrer-Policy: strict-origin-when-cross-origin\`, just from Next.js instead of nginx. Identical effective policy.
- Static assets (matched out of middleware by the matcher) no longer receive an explicit Referrer-Policy; modern browsers default to the same \`strict-origin-when-cross-origin\`. Static asset URLs don't carry PII, so the slight difference in pre-2021 browsers isn't meaningful.