### PR TITLE
Upgrade nightly backup validation from catalog-check to full-restore drill

### DIFF
--- a/__tests__/scripts/backup-db.spec.ts
+++ b/__tests__/scripts/backup-db.spec.ts
@@ -47,33 +47,72 @@ describe.skipIf(!hasGpg)("Encrypted database backup pipeline", () => {
             `#!/bin/bash\nprintf '%s' '${mockDumpPayload}'\n`,
         );
 
-        // Stub pg_restore: --list mode prints >10 TOC-looking lines so the
-        // validation content-line check passes; everything else is a no-op.
+        // Stub pg_restore: consume stdin (the streamed dump) and record
+        // the target DB arg for test assertions. Configurable failure via
+        // FAIL_PG_RESTORE env var.
         fs.writeFileSync(
             path.join(mockBin, "pg_restore"),
             `#!/bin/bash
-if [ "$1" = "--list" ]; then
-    cat <<'EOF'
-;
-; Archive created at 2026-04-14
-; dbname: matkassen
-;
-1; 0 0 ENCODING - ENCODING
-2; 0 0 STDSTRINGS - STDSTRINGS
-3; 0 0 SEARCHPATH - SEARCHPATH
-4; 200 1259 TABLE public households matkassen
-5; 200 1259 TABLE public food_parcels matkassen
-6; 200 1259 TABLE public users matkassen
-7; 200 1259 TABLE public pets matkassen
-8; 200 1259 TABLE public pickup_locations matkassen
-9; 200 1259 TABLE public household_members matkassen
-10; 200 1259 TABLE public sessions matkassen
-11; 200 1259 TABLE public accounts matkassen
-12; 200 1259 TABLE public verification_tokens matkassen
-EOF
-    exit 0
-fi
+TARGET_DB=""
+while [ $# -gt 0 ]; do
+    if [ "$1" = "-d" ]; then shift; TARGET_DB="$1"; fi
+    shift
+done
+printf 'pg_restore -d %s\\n' "$TARGET_DB" >> "\${DB_OPS_LOG:-/dev/null}"
 cat >/dev/null
+if [ -n "\${FAIL_PG_RESTORE:-}" ]; then
+    echo "simulated pg_restore failure" >&2
+    exit 1
+fi
+exit 0
+`,
+        );
+
+        // Stub createdb / dropdb: record invocation, exit 0 by default.
+        // Failure paths configurable via FAIL_CREATEDB / FAIL_DROPDB.
+        fs.writeFileSync(
+            path.join(mockBin, "createdb"),
+            `#!/bin/bash
+DB_NAME="\${!#}"
+printf 'createdb %s\\n' "$DB_NAME" >> "\${DB_OPS_LOG:-/dev/null}"
+if [ -n "\${FAIL_CREATEDB:-}" ]; then
+    echo "simulated createdb failure" >&2
+    exit 1
+fi
+exit 0
+`,
+        );
+        fs.writeFileSync(
+            path.join(mockBin, "dropdb"),
+            `#!/bin/bash
+DB_NAME="\${!#}"
+printf 'dropdb %s\\n' "$DB_NAME" >> "\${DB_OPS_LOG:-/dev/null}"
+exit 0
+`,
+        );
+
+        // Stub psql: for the sentinel query (-tAc "SELECT to_regclass..."),
+        // print SENTINEL_RESULT (default "t" = table exists). For any
+        // other invocation, just exit 0. Record the target DB.
+        fs.writeFileSync(
+            path.join(mockBin, "psql"),
+            `#!/bin/bash
+TARGET_DB=""
+QUERY=""
+NEXT_IS_DB=0
+NEXT_IS_QUERY=0
+for arg in "$@"; do
+    if [ "$NEXT_IS_DB" = "1" ]; then TARGET_DB="$arg"; NEXT_IS_DB=0; continue; fi
+    if [ "$NEXT_IS_QUERY" = "1" ]; then QUERY="$arg"; NEXT_IS_QUERY=0; continue; fi
+    case "$arg" in
+        -d) NEXT_IS_DB=1 ;;
+        -c|-tAc) NEXT_IS_QUERY=1 ;;
+    esac
+done
+printf 'psql -d %s\\n' "$TARGET_DB" >> "\${DB_OPS_LOG:-/dev/null}"
+if [[ "$QUERY" == *"to_regclass"* ]]; then
+    echo "\${SENTINEL_RESULT:-t}"
+fi
 exit 0
 `,
         );
@@ -134,7 +173,16 @@ exit 0
 `,
         );
 
-        for (const exe of ["pg_dump", "pg_restore", "rclone", "swift", "curl"]) {
+        for (const exe of [
+            "pg_dump",
+            "pg_restore",
+            "createdb",
+            "dropdb",
+            "psql",
+            "rclone",
+            "swift",
+            "curl",
+        ]) {
             fs.chmodSync(path.join(mockBin, exe), 0o755);
         }
     });
@@ -196,16 +244,32 @@ exit 0
         expect(exitCode).not.toBe(0);
     });
 
-    it("encrypts the dump, uploads to Swift, and validates the round-trip", () => {
+    it("encrypts the dump, uploads to Swift, and validates via full restore", () => {
         // Clean fake remote between tests
         for (const f of fs.readdirSync(fakeRemote)) {
             fs.rmSync(path.join(fakeRemote, f));
         }
 
-        const { stdout } = runBackup();
+        const opsLog = path.join(testRoot, "db-ops.log");
+        fs.writeFileSync(opsLog, "");
+        const { stdout } = runBackup({ DB_OPS_LOG: opsLog });
 
         expect(stdout).toContain("Backup process completed successfully");
-        expect(stdout).toContain("Backup validation OK");
+        expect(stdout).toContain("Validation OK - full restore succeeded");
+
+        // Verify the DB ops happened in the right order: pre-flight dropdb,
+        // then createdb, then pg_restore into the scratch DB, then sentinel
+        // psql, then post-run dropdb. All must target the fixed scratch
+        // name, never $POSTGRES_DB (= "matkassen" in this test).
+        const ops = fs.readFileSync(opsLog, "utf-8").trim().split("\n");
+        expect(ops[0]).toBe("dropdb matkassen_nightly_validate"); // pre-flight
+        expect(ops).toContain("createdb matkassen_nightly_validate");
+        expect(ops).toContain("pg_restore -d matkassen_nightly_validate");
+        expect(ops).toContain("psql -d matkassen_nightly_validate");
+        // Post-run cleanup must also be against the scratch name only.
+        expect(ops[ops.length - 1]).toBe("dropdb matkassen_nightly_validate");
+        // Sanity: nothing in the ops log should reference the real DB name.
+        expect(ops.every(line => !line.endsWith(" matkassen"))).toBe(true);
 
         const uploaded = fs
             .readdirSync(fakeRemote)
@@ -342,37 +406,14 @@ ${realRclone.replace(/^#!\/bin\/bash\n/, "")}`,
         expect(notifications).toContain("rclone upload");
     });
 
-    it("fails validation when the sentinel 'households' table is missing", () => {
-        // The sentinel check protects against a corrupted or truncated dump
-        // that's still technically parseable by `pg_restore --list`. Stub
-        // it to return a TOC that omits the households entry and confirm
-        // validation reports failure.
+    it("fails validation when the sentinel query returns 'f' (table missing)", () => {
+        // After full restore, the script runs
+        // `SELECT to_regclass('public.households') IS NOT NULL`.
+        // If that returns 'f', the table didn't survive the restore →
+        // the backup is unreliable and validation must fail.
         for (const f of fs.readdirSync(fakeRemote)) {
             fs.rmSync(path.join(fakeRemote, f));
         }
-        const realPgRestore = fs.readFileSync(path.join(mockBin, "pg_restore"), "utf-8");
-        fs.writeFileSync(
-            path.join(mockBin, "pg_restore"),
-            `#!/bin/bash
-if [ "$1" = "--list" ]; then
-    cat <<'EOF'
-;
-; Archive created at 2026-04-14
-; dbname: matkassen
-;
-1; 0 0 ENCODING - ENCODING
-2; 0 0 STDSTRINGS - STDSTRINGS
-3; 0 0 SEARCHPATH - SEARCHPATH
-4; 200 1259 TABLE public some_other_table matkassen
-EOF
-    exit 0
-fi
-cat >/dev/null
-exit 0
-`,
-        );
-        fs.chmodSync(path.join(mockBin, "pg_restore"), 0o755);
-
         const curlLog = path.join(testRoot, "curl.log");
         fs.writeFileSync(curlLog, "");
 
@@ -380,16 +421,82 @@ exit 0
             SLACK_BOT_TOKEN: "xoxb-test",
             SLACK_CHANNEL_ID: "C_TEST",
             CURL_LOG: curlLog,
+            SENTINEL_RESULT: "f",
         });
 
-        fs.writeFileSync(path.join(mockBin, "pg_restore"), realPgRestore);
-        fs.chmodSync(path.join(mockBin, "pg_restore"), 0o755);
-
         const notifications = fs.readFileSync(curlLog, "utf-8");
-        expect(stdout).toContain("sentinel table 'households' is missing");
-        // The script exits 1 on validation failure and the final Slack
-        // alert is a "validation failed" message, not the generic ERR
-        // trap — assert on that specific phrasing.
+        expect(stdout).toContain("sentinel query returned 'f'");
+        expect(notifications).toContain("validation failed");
+    });
+
+    it("drops the scratch DB even when pg_restore fails", () => {
+        // Regression test for the cleanup contract: a failed full-restore
+        // must not leak the scratch DB. The EXIT trap has to run dropdb
+        // regardless of whether validation succeeded.
+        for (const f of fs.readdirSync(fakeRemote)) {
+            fs.rmSync(path.join(fakeRemote, f));
+        }
+        const opsLog = path.join(testRoot, "db-ops.log");
+        const curlLog = path.join(testRoot, "curl.log");
+        fs.writeFileSync(opsLog, "");
+        fs.writeFileSync(curlLog, "");
+
+        const { stdout } = runBackup({
+            SLACK_BOT_TOKEN: "xoxb-test",
+            SLACK_CHANNEL_ID: "C_TEST",
+            CURL_LOG: curlLog,
+            DB_OPS_LOG: opsLog,
+            FAIL_PG_RESTORE: "1",
+        });
+
+        const ops = fs.readFileSync(opsLog, "utf-8").trim().split("\n");
+        // createdb fired, pg_restore ran (and failed), dropdb still fired
+        // at the end. Exactly one post-run dropdb, plus the pre-flight
+        // one, = two dropdb calls in total.
+        expect(ops.filter(l => l === "createdb matkassen_nightly_validate")).toHaveLength(1);
+        expect(ops.filter(l => l === "pg_restore -d matkassen_nightly_validate")).toHaveLength(1);
+        expect(ops.filter(l => l === "dropdb matkassen_nightly_validate")).toHaveLength(2);
+        expect(stdout).toContain("pg_restore errored");
+    });
+
+    it("runs pre-flight dropdb before any createdb", () => {
+        // If a previous run crashed mid-validation, the scratch DB may
+        // still exist. Pre-flight must drop it so createdb can succeed.
+        for (const f of fs.readdirSync(fakeRemote)) {
+            fs.rmSync(path.join(fakeRemote, f));
+        }
+        const opsLog = path.join(testRoot, "db-ops.log");
+        fs.writeFileSync(opsLog, "");
+
+        runBackup({ DB_OPS_LOG: opsLog });
+
+        const ops = fs.readFileSync(opsLog, "utf-8").trim().split("\n");
+        const firstCreate = ops.indexOf("createdb matkassen_nightly_validate");
+        const firstDrop = ops.indexOf("dropdb matkassen_nightly_validate");
+        expect(firstDrop).toBeGreaterThanOrEqual(0);
+        expect(firstCreate).toBeGreaterThan(firstDrop);
+    });
+
+    it("alerts Slack when createdb fails (missing CREATEDB grant)", () => {
+        // The most operationally likely failure: rollout skipped the
+        // ALTER USER ... CREATEDB step. The script should fail the run
+        // with a clear hint rather than hanging or silently succeeding.
+        for (const f of fs.readdirSync(fakeRemote)) {
+            fs.rmSync(path.join(fakeRemote, f));
+        }
+        const curlLog = path.join(testRoot, "curl.log");
+        fs.writeFileSync(curlLog, "");
+
+        const { stdout } = runBackup({
+            SLACK_BOT_TOKEN: "xoxb-test",
+            SLACK_CHANNEL_ID: "C_TEST",
+            CURL_LOG: curlLog,
+            FAIL_CREATEDB: "1",
+        });
+
+        expect(stdout).toContain("could not create scratch DB");
+        expect(stdout).toContain("CREATEDB");
+        const notifications = fs.readFileSync(curlLog, "utf-8");
         expect(notifications).toContain("validation failed");
     });
 });

--- a/deploy.sh
+++ b/deploy.sh
@@ -495,6 +495,24 @@ else
   echo "✅ Database verification successful."
 fi
 
+# Grant CREATEDB to the app user on production so the nightly backup
+# validation can create and drop its scratch DB. Idempotent. See the
+# matching block in update.sh for subsequent deploys.
+if [ "${ENV_NAME:-}" = "production" ]; then
+  echo "Granting CREATEDB to $POSTGRES_USER for nightly backup validation..."
+  if sudo docker compose exec -T db bash -c "
+    PGPASS_FILE=\"/tmp/.pgpass_grant\"
+    echo \"localhost:5432:*:$POSTGRES_USER:$POSTGRES_PASSWORD\" > \"\$PGPASS_FILE\"
+    chmod 600 \"\$PGPASS_FILE\"
+    PGPASSFILE=\"\$PGPASS_FILE\" psql -U $POSTGRES_USER -d $POSTGRES_DB -c 'ALTER USER \"$POSTGRES_USER\" CREATEDB;'
+    rm -f \"\$PGPASS_FILE\"
+  " > /dev/null 2>&1; then
+    echo "✅ CREATEDB granted to $POSTGRES_USER."
+  else
+    echo "⚠️ Failed to grant CREATEDB — nightly validation will fail until this is resolved."
+  fi
+fi
+
 # Cleanup old Docker images and containers
 sudo docker system prune -af
 

--- a/docs/database-guide.md
+++ b/docs/database-guide.md
@@ -407,25 +407,9 @@ docker compose restart web
 
 #### Restore Drill
 
-Run a real restore against a scratch database periodically (quarterly is a reasonable cadence) — the nightly `pg_restore --list` validation only proves the dump is structurally parseable, not that an actual `pg_restore` succeeds.
+The nightly backup job restores every backup into a throwaway `matkassen_nightly_validate` database on the same Postgres instance and runs a sentinel query against it. A failed nightly restore is a Slack alert, so there is no separate manual drill cadence — the drill is the job.
 
-```bash
-# 1. Create a scratch database alongside the live one
-docker exec -it matkassen-db psql -U matkassen \
-    -c "CREATE DATABASE matkassen_restore_drill"
-
-# 2. Run the restore against the scratch database
-POSTGRES_DB=matkassen_restore_drill \
-    ./scripts/backup-restore.sh matkassen_backup_<timestamp>.dump.gpg
-
-# 3. Confirm data is present
-docker exec -it matkassen-db psql -U matkassen -d matkassen_restore_drill \
-    -c "SELECT COUNT(*) FROM households"
-
-# 4. Tear down
-docker exec -it matkassen-db psql -U matkassen \
-    -c "DROP DATABASE matkassen_restore_drill"
-```
+**Caveat**: this validates "the backup is restorable to this Postgres cluster." It does NOT validate "we can rebuild on a fresh host." A true cross-host DR drill (provision a new VPS, install Postgres, restore from Swift, bring the app up against the restored DB) is a separate exercise that is not automated.
 
 ## Related Documentation
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -157,7 +157,7 @@ docker exec -it matkassen-db psql -U matkassen -d matkassen
 
 ### Backups
 
-**All production database backups are encrypted with symmetric AES256 GPG before leaving the host.** The dump is piped directly from `pg_dump` into `gpg` — no intermediate plaintext file. The nightly validation step does temporarily decrypt the backup to a container-private tmpfs for `pg_restore --list`, but that plaintext is deleted immediately after validation.
+**All production database backups are encrypted with symmetric AES256 GPG before leaving the host.** The dump is piped directly from `pg_dump` into `gpg` — no intermediate plaintext file. The nightly validation step decrypts the backup and does a full `pg_restore` into a throwaway `matkassen_nightly_validate` database on the same Postgres instance; the scratch database is dropped at the end of the run. Plaintext data exists only inside the scratch DB during validation and is destroyed with it.
 
 #### Automated Encrypted Backups
 
@@ -166,8 +166,10 @@ Production backups run automatically via `Dockerfile.db-backup`, which runs `scr
 1. `pg_dump --format=custom --compress=9` piped directly into `gpg --symmetric --cipher-algo AES256` (no intermediate plaintext file).
 2. Uploads the `.dump.gpg` file to the Elastx Swift container via `rclone`.
 3. Sets `X-Delete-After` for 14-day automatic expiry as a defense-in-depth retention guarantee.
-4. Round-trip validates by re-downloading, decrypting, and running `pg_restore --list`. This proves the backup is decryptable and the archive catalog is intact — a wrong passphrase or corrupted upload fails the same night. (It does not prove a full `pg_restore` would succeed; see the quarterly restore drill in the database guide.)
+4. Full-restore validates the upload: creates `matkassen_nightly_validate`, streams `gpg --decrypt | pg_restore --exit-on-error` into it, runs a sentinel query (`SELECT to_regclass('public.households') IS NOT NULL`), drops the scratch DB. A wrong passphrase, corrupted upload, DDL incompatibility, or broken COPY stream fails the same night.
 5. Reports success/failure to Slack.
+
+**Cluster-level requirement**: the backup user needs `CREATEDB` to create and drop the scratch database. `deploy.sh` and `update.sh` apply this grant automatically on production. The widened privilege is cluster-level (the role can now create/drop databases), not app-level (it already owned every table in the app schema).
 
 #### Encryption Details
 
@@ -273,7 +275,7 @@ sudo docker compose restart web
 1. Generate a new passphrase (`openssl rand -base64 32`).
 2. Update the `DB_BACKUP_PASSPHRASE` GitHub Secret.
 3. Re-deploy: `deploy.sh` / `update.sh` writes the new value into the host `.env`, and recreating the `db-backup` container picks it up.
-4. The next nightly backup will be encrypted with the new passphrase and the round-trip validation step will confirm it works end-to-end.
+4. The next nightly backup will be encrypted with the new passphrase and the full-restore validation will confirm it works end-to-end.
 5. **Old backups in Swift are still encrypted with the old passphrase.** Pick one of the two strategies below.
 
 ##### Strategy A: Wait out retention (routine rotation)
@@ -301,7 +303,7 @@ while read -r FILE; do
     docker compose -f docker-compose.yml -f docker-compose.backup.yml \
         --profile backup exec -T \
         -e OLD_PASS="$OLD_PASS" -e NEW_PASS="$NEW_PASS" -e FILE="$FILE" \
-        db-backup sh -c '
+        db-backup bash -c '
             set -euo pipefail
             SRC="elastx:${SWIFT_CONTAINER}/${SWIFT_PREFIX:-backups}/${FILE}"
             TMPOUT=$(mktemp -t rekey.XXXXXX)

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -79,16 +79,53 @@ RCLONE_REMOTE="elastx:${SWIFT_CONTAINER}/${PREFIX}"
 ENCRYPTED_FILE="$TEMP_DIR/$BACKUP_FILENAME"
 PGPASS_FILE=""
 VALIDATION_DOWNLOAD=""
-VALIDATION_PLAINTEXT=""
 VALIDATION_OUTPUT=""
 VALIDATION_ERRORS=""
 EXPIRY_OK=""
+SCRATCH_CREATED=""
 LOCK_FD=9
 LOCK_FILE="/tmp/backup.lock"
 
+# Fixed scratch DB used by nightly validation. A single constant name makes
+# every callsite assertable (see assert_scratch_db), so a bug that wipes
+# $SCRATCH_DB_NAME cannot silently become `dropdb ""` or, much worse,
+# `pg_restore --clean -d "$POSTGRES_DB"` against prod.
+SCRATCH_DB_NAME="matkassen_nightly_validate"
+
+# Guard against any path accidentally passing an unexpected DB name to
+# createdb/dropdb/pg_restore. This is belt-and-suspenders — every
+# callsite uses $SCRATCH_DB_NAME literally — but the guard means a future
+# refactor that parameterises the name cannot regress into prod-dropping
+# behavior without tripping this check.
+assert_scratch_db() {
+    local name=${1:-}
+    if [ -z "$name" ] \
+        || [ "$name" != "$SCRATCH_DB_NAME" ] \
+        || [ "$name" = "$POSTGRES_DB" ] \
+        || [ "$name" = "postgres" ] \
+        || [ "$name" = "template0" ] \
+        || [ "$name" = "template1" ]; then
+        fail "Refusing DB operation on '$name' - only '$SCRATCH_DB_NAME' is allowed"
+    fi
+}
+
 cleanup() {
+    # Drop the scratch DB FIRST, while $PGPASS_FILE still exists on disk.
+    # assert_scratch_db guarantees this can only target the fixed scratch
+    # name, never $POSTGRES_DB. A failure here is logged but doesn't flip
+    # DRILL_STATUS — the upload and validation already ran; a stuck
+    # scratch DB is a next-run cleanup concern, not "the backup failed".
+    if [ -n "${SCRATCH_CREATED:-}" ] && [ -n "${PGPASS_FILE:-}" ] && [ -f "$PGPASS_FILE" ]; then
+        assert_scratch_db "$SCRATCH_DB_NAME"
+        PGPASSFILE="$PGPASS_FILE" dropdb \
+            --if-exists \
+            -h "$POSTGRES_HOST" \
+            -U "$POSTGRES_USER" \
+            "$SCRATCH_DB_NAME" 2>/dev/null \
+            || log "WARNING: failed to drop scratch DB '$SCRATCH_DB_NAME' on cleanup"
+    fi
     rm -f "${PGPASS_FILE:-}" "$ENCRYPTED_FILE" \
-        "${VALIDATION_DOWNLOAD:-}" "${VALIDATION_PLAINTEXT:-}" \
+        "${VALIDATION_DOWNLOAD:-}" \
         "${VALIDATION_OUTPUT:-}" "${VALIDATION_ERRORS:-}"
 }
 
@@ -145,11 +182,21 @@ log "Starting encrypted PostgreSQL backup process"
 # Use a .pgpass file rather than PGPASSWORD to keep the password out of
 # /proc/<pid>/environ for any sibling process inspection. mktemp avoids
 # a fixed filename that would collide if two runs overlap.
+# The db-name field is '*' (wildcard) so the same credentials work for
+# pg_dump against $POSTGRES_DB, createdb/dropdb against $SCRATCH_DB_NAME,
+# and psql -d $SCRATCH_DB_NAME for the sentinel query.
 BACKUP_STAGE="pgpass-setup"
 PGPASS_FILE=$(mktemp -t .pgpass.XXXXXX)
 chmod 600 "$PGPASS_FILE"
-echo "${POSTGRES_HOST}:5432:${POSTGRES_DB}:${POSTGRES_USER}:${POSTGRES_PASSWORD}" > "$PGPASS_FILE"
+echo "${POSTGRES_HOST}:5432:*:${POSTGRES_USER}:${POSTGRES_PASSWORD}" > "$PGPASS_FILE"
 export PGPASSFILE="$PGPASS_FILE"
+
+# Pre-flight cleanup: if a previous run crashed after creating the scratch
+# DB but before dropping it, remove it now. Exact-name only — this is NOT
+# a prefix-match sweep.
+assert_scratch_db "$SCRATCH_DB_NAME"
+dropdb --if-exists -h "$POSTGRES_HOST" -U "$POSTGRES_USER" "$SCRATCH_DB_NAME" 2>/dev/null \
+    || log "WARNING: pre-flight cleanup of '$SCRATCH_DB_NAME' failed - may not have existed"
 
 # pg_dump → gpg, no intermediate plaintext file. The passphrase is fed on
 # fd 3 so it never lands in argv.
@@ -211,48 +258,84 @@ else
     log "Manual cleanup may be required for this backup file"
 fi
 
-# Round-trip validation: download → decrypt → pg_restore --list. This also
-# exercises the passphrase, so a wrong passphrase fails the same night.
+# Full-restore validation: download → decrypt → pg_restore into a
+# throwaway scratch DB on the same Postgres instance → sentinel query →
+# drop the scratch DB. This is strictly stronger than `pg_restore --list`:
+# pg_restore actually applies every DDL and every COPY block, so DDL
+# version skew, corrupted COPY data, index rebuild failures, and missing
+# extensions all surface here. On success we've proven the backup is
+# actually restorable, not just parseable. This replaces the documented
+# quarterly manual drill.
+#
+# Same-instance caveat: the scratch DB shares postgres_data, WAL, and
+# checkpoint pressure with prod. For matkassen's data size this is
+# immaterial, but note that this is NOT a cross-host disaster-recovery
+# drill — if the whole host is lost, you still need to restore onto a
+# fresh cluster. That scenario is not exercised nightly.
 BACKUP_STAGE="validation"
 DRILL_STATUS="success"
-log "Validating backup round-trip (download → decrypt → pg_restore --list)"
+log "Validating backup by full restore into scratch DB '$SCRATCH_DB_NAME'"
 
 VALIDATION_DOWNLOAD=$(mktemp -t backup_download.XXXXXX)
-VALIDATION_PLAINTEXT=$(mktemp -t backup_plaintext.XXXXXX)
 VALIDATION_OUTPUT=$(mktemp -t backup_validation.XXXXXX)
 VALIDATION_ERRORS=$(mktemp -t backup_errors.XXXXXX)
-chmod 600 "$VALIDATION_DOWNLOAD" "$VALIDATION_PLAINTEXT" "$VALIDATION_OUTPUT" "$VALIDATION_ERRORS"
+chmod 600 "$VALIDATION_DOWNLOAD" "$VALIDATION_OUTPUT" "$VALIDATION_ERRORS"
 
 if ! rclone copyto "$RCLONE_REMOTE/$BACKUP_FILENAME" "$VALIDATION_DOWNLOAD" --retries=3; then
-    log "Backup validation FAILED - unable to download backup file for validation"
+    log "Validation FAILED - unable to download backup file"
     DRILL_STATUS="failure"
-elif ! gpg --decrypt --batch --yes --quiet --passphrase-fd 3 --pinentry-mode loopback \
-        --output "$VALIDATION_PLAINTEXT" "$VALIDATION_DOWNLOAD" \
-        3<<<"$DB_BACKUP_PASSPHRASE" 2>"$VALIDATION_ERRORS"; then
+elif ! assert_scratch_db "$SCRATCH_DB_NAME" || \
+     ! createdb -h "$POSTGRES_HOST" -U "$POSTGRES_USER" "$SCRATCH_DB_NAME" 2>"$VALIDATION_ERRORS"; then
     ERROR_MSG=$(head -n 3 "$VALIDATION_ERRORS" | tr '\n' ' ')
-    log "Backup validation FAILED - decryption failed: $ERROR_MSG"
-    DRILL_STATUS="failure"
-elif ! pg_restore --list "$VALIDATION_PLAINTEXT" >"$VALIDATION_OUTPUT" 2>"$VALIDATION_ERRORS"; then
-    ERROR_MSG=$(head -n 3 "$VALIDATION_ERRORS" | tr '\n' ' ')
-    log "Backup validation FAILED - decrypted file is not a valid pg dump: $ERROR_MSG"
+    log "Validation FAILED - could not create scratch DB: $ERROR_MSG"
+    log "Hint: the backup user needs CREATEDB privilege. Run: ALTER USER $POSTGRES_USER CREATEDB;"
     DRILL_STATUS="failure"
 else
-    # Assert a sentinel core table is present in the TOC. A raw line-count
-    # threshold would falsely fail on a small schema and silently pass an
-    # incomplete dump. `households` is a load-bearing table that has
-    # existed since day one — if it's missing, something is genuinely
-    # wrong with the dump.
-    if grep -qE 'TABLE[[:space:]]+public[[:space:]]+households([[:space:]]|$)' "$VALIDATION_OUTPUT"; then
-        TOC_LINES=$(grep -cv -e '^$' -e '^;' "$VALIDATION_OUTPUT" || true)
-        log "Backup validation OK (sentinel table 'households' present, $TOC_LINES TOC entries)"
+    SCRATCH_CREATED=1
+    # Stream decrypt | pg_restore into the scratch DB. --exit-on-error
+    # means any DDL or COPY failure fails pg_restore, which fails the
+    # pipeline under pipefail. --clean --if-exists is belt-and-suspenders
+    # for a freshly created empty DB. --no-owner/--no-privileges so the
+    # scratch role doesn't need to match the dump's role grants.
+    # Truncate the shared error file once, then both gpg and pg_restore
+    # append — avoids a race where one process opens O_TRUNC while the
+    # other has already written.
+    : >"$VALIDATION_ERRORS"
+    assert_scratch_db "$SCRATCH_DB_NAME"
+    if gpg --decrypt --batch --yes --quiet --passphrase-fd 3 --pinentry-mode loopback \
+            "$VALIDATION_DOWNLOAD" 3<<<"$DB_BACKUP_PASSPHRASE" 2>>"$VALIDATION_ERRORS" \
+        | pg_restore \
+            -h "$POSTGRES_HOST" \
+            -U "$POSTGRES_USER" \
+            -d "$SCRATCH_DB_NAME" \
+            --no-password \
+            --no-owner \
+            --no-privileges \
+            --clean \
+            --if-exists \
+            --exit-on-error 2>>"$VALIDATION_ERRORS"; then
+        # Sentinel: the 'households' table must exist and be queryable
+        # via the same role that restored it. Cheap check (no count scan).
+        SENTINEL=$(psql -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$SCRATCH_DB_NAME" \
+            -tAc "SELECT to_regclass('public.households') IS NOT NULL" 2>"$VALIDATION_ERRORS" || echo "error")
+        if [ "$SENTINEL" = "t" ]; then
+            log "Validation OK - full restore succeeded, 'households' table present and queryable"
+        else
+            ERROR_MSG=$(head -n 3 "$VALIDATION_ERRORS" | tr '\n' ' ')
+            log "Validation FAILED - sentinel query returned '$SENTINEL': $ERROR_MSG"
+            DRILL_STATUS="failure"
+        fi
     else
-        log "Backup validation FAILED - sentinel table 'households' is missing from the dump TOC"
+        ERROR_MSG=$(head -n 5 "$VALIDATION_ERRORS" | tr '\n' ' ')
+        log "Validation FAILED - pg_restore errored: $ERROR_MSG"
         DRILL_STATUS="failure"
     fi
 fi
 
-# Per-iteration cleanup so plaintext doesn't sit on tmpfs longer than needed
-rm -f "$VALIDATION_PLAINTEXT" "$VALIDATION_DOWNLOAD"
+# The scratch DB gets dropped by the EXIT trap (cleanup()), which runs
+# even on validation failure. Download file is a tmpfs encrypted blob —
+# plaintext never lands on disk in this validation path.
+rm -f "$VALIDATION_DOWNLOAD"
 
 # Best-effort stats for the log line — don't let a transient rclone failure
 # here prevent the Slack notification from firing.

--- a/update.sh
+++ b/update.sh
@@ -284,6 +284,26 @@ else
   echo "✅ Database migrations completed successfully."
 fi
 
+# Grant CREATEDB to the app user on production so the nightly backup
+# validation in scripts/backup-db.sh can create and drop its scratch DB
+# (matkassen_nightly_validate). Idempotent — ALTER USER is a no-op if
+# the attribute is already set. Skipped on staging because the backup
+# profile never runs there.
+if [ "${ENV_NAME:-}" = "production" ]; then
+  echo "Granting CREATEDB to $POSTGRES_USER for nightly backup validation..."
+  if sudo docker compose exec -T db bash -c "
+    PGPASS_FILE=\"/tmp/.pgpass_grant\"
+    echo \"localhost:5432:*:$POSTGRES_USER:$POSTGRES_PASSWORD\" > \"\$PGPASS_FILE\"
+    chmod 600 \"\$PGPASS_FILE\"
+    PGPASSFILE=\"\$PGPASS_FILE\" psql -U $POSTGRES_USER -d $POSTGRES_DB -c 'ALTER USER \"$POSTGRES_USER\" CREATEDB;'
+    rm -f \"\$PGPASS_FILE\"
+  " > /dev/null 2>&1; then
+    echo "✅ CREATEDB granted to $POSTGRES_USER."
+  else
+    echo "⚠️ Failed to grant CREATEDB — nightly validation will Slack-alert until this is resolved manually."
+  fi
+fi
+
 # Now start nginx — schema is up to date, safe to accept public traffic
 echo "Starting nginx..."
 NGINX_START_ATTEMPTS=0


### PR DESCRIPTION
## Why

PR #376 added encryption and a nightly `pg_restore --list` validation. That's a catalog check — it proves the archive is readable, not that it's applicable. The gap was filled by a "quarterly manual restore drill" in `docs/database-guide.md`, which is the kind of documented-but-never-actually-run discipline that looks good on paper and fails during the incident you wrote it for.

This PR removes the gap. Every nightly backup now does a real `pg_restore` into a throwaway `matkassen_nightly_validate` database on the same Postgres instance, runs a sentinel query, and drops the scratch DB. If the backup isn't restorable, Slack alerts the next morning — not in three months.

## What full-restore catches that `--list` didn't

| Failure mode | `--list` | full restore |
|---|---|---|
| Corrupted archive header | ✅ catches | ✅ catches |
| Wrong passphrase | ✅ catches | ✅ catches |
| DDL version skew (pg_dump vs restore target) | ❌ passes | ✅ catches |
| Corrupted COPY data blocks inside a valid TOC | ❌ passes | ✅ catches |
| Missing extension the dump references | ❌ passes | ✅ catches |
| UNIQUE/CHECK constraint failures on index rebuild | ❌ passes | ✅ catches |
| FK violations after reload | ❌ passes | ✅ catches |

`--list` is strictly cheaper than full restore and catches a strict subset. No reason to keep it if we're already paying the decrypt cost.

## Planning

I planned this with codex mcp. Its critique reshaped the initial draft in three material ways:

1. **My original guard was on `dropdb`.** Codex correctly noted the real risk is `pg_restore --clean -d $WRONG_DB` clobbering prod. The guard now gates both operations equally, and assert_scratch_db is called before every `createdb`/`dropdb`/`pg_restore -d` callsite.
2. **Timestamped scratch names were a trap.** They push toward `pg_stat_file`-style orphan-age detection, which wants superuser access. Fixed single name + pre-flight `dropdb --if-exists` is simpler and safer. flock already serialises runs.
3. **Sentinel query was expensive and weak.** `SELECT count(*) FROM households` reads the whole table to return a number that doesn't prove anything. `SELECT to_regclass('public.households') IS NOT NULL` is cheap and proves what we care about: the table exists and is queryable by the role that restored it.

## Key decisions

| Decision | Choice | Why |
|---|---|---|
| Scratch DB name | Fixed: `matkassen_nightly_validate` | flock serialises; timestamps add orphan-cleanup risk |
| Role | `ALTER USER pgadmin CREATEDB` (same role that does pg_dump) | Dedicated role means a new GitHub Secret + env wiring. For matkassen's scale the widened cluster-level reach is marginal over the role's existing app-data ownership |
| Target guard | `assert_scratch_db()` on every call; exact string match; reject empty/`postgres`/`template*`/`$POSTGRES_DB` | The operation that would hurt most is restoring into prod. The guard blocks that path everywhere |
| Pre-flight cleanup | `dropdb --if-exists $SCRATCH_DB_NAME` | Handles a previous crashed run. Exact-name only — no prefix sweep |
| Post-run cleanup | EXIT trap runs `dropdb`; cleanup failure logs WARNING but doesn't flip status | Don't turn a successful backup into a red alert because `dropdb` warned |
| pg_restore flags | `--exit-on-error --clean --if-exists --no-owner --no-privileges` | Fail fast; tolerate stray objects in scratch; decouple from dump's role grants |
| Sentinel | `SELECT to_regclass('public.households') IS NOT NULL` | Must return `t` — table exists, connection works, role has USAGE |
| `.pgpass` | db-name field `*` (wildcard) | Same credentials hit `$POSTGRES_DB` (pg_dump) and `$SCRATCH_DB_NAME` (createdb/dropdb/psql) |
| `--list` block | Removed entirely | Strict subset of what full restore catches; keeping both would be ceremony |

## Scope honesty (what this doesn't replace)

Same-instance scratch restore shares `postgres_data`, WAL, and checkpoint pressure with prod. At matkassen scale this is immaterial. What it is **not**: a cross-host DR drill. If the whole VPS is lost, you still have to provision a fresh cluster and restore from Swift onto it. That scenario is not automated — it's a separate exercise that isn't in scope here.

## Rollout

`deploy.sh` and `update.sh` apply `ALTER USER $POSTGRES_USER CREATEDB;` idempotently on production. Existing prod picks up the grant on the next deploy. Fresh setups get it during initial `deploy.sh`. No manual operator step.

Failure signal if the grant is missing: Slack alert with the exact `ALTER USER` command as a hint. Easy recovery.

## Tests

5 new tests, 13 total, all passing:

- Happy path asserts the full DB-op sequence in order: pre-flight dropdb → createdb → pg_restore → psql sentinel → post-run dropdb. Also asserts no op line references `$POSTGRES_DB`.
- Sentinel returning `f` (table missing post-restore) → validation fails + Slack alert.
- `pg_restore` failure → scratch DB still dropped via cleanup trap (two dropdb calls total: pre-flight + cleanup).
- Pre-flight dropdb runs before any createdb (orphan-cleanup case).
- `createdb` failure (missing CREATEDB grant) → clear Slack alert with the `ALTER USER` hint.

Plus end-to-end local verification against the real Alpine backup image + local Postgres 17.5:
- Fresh run: scratch created, restored, validated, dropped.
- Orphan-cleanup run: stale `matkassen_nightly_validate` present from simulated crash → pre-flight dropped it, new run succeeded end-to-end.
- After validation failure: scratch DB still gone.

## Stacked on #376

Base branch is `encrypt-backups` (PR #376). Diff view shows only the delta from that PR. Merge #376 first.