### PR TITLE
fix(ci): force-align VPS repo to origin/main and fail fast on errors

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -79,6 +79,8 @@ jobs:
                   script: |
                       # Fail fast on errors — this block used to swallow git failures and
                       # leave the VPS on an outdated commit while reporting success.
+                      # Assumes the remote login shell is bash (`pipefail` is a bashism;
+                      # dash/sh would error out immediately here — fail-loud, not silent).
                       set -euo pipefail
 
                       echo "Export GitHub secrets into environment variables"
@@ -146,6 +148,7 @@ jobs:
                   key: ${{ secrets.SERVER_SSH_KEY }}
                   script: |
                       # Fail fast on errors — see deploy-to-staging above for context.
+                      # Assumes the remote login shell is bash (`pipefail` is a bashism).
                       set -euo pipefail
 
                       echo "Export GitHub secrets into environment variables"

--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -77,6 +77,10 @@ jobs:
                   username: ${{ secrets.SERVER_USER }}
                   key: ${{ secrets.SERVER_SSH_KEY }}
                   script: |
+                      # Fail fast on errors — this block used to swallow git failures and
+                      # leave the VPS on an outdated commit while reporting success.
+                      set -euo pipefail
+
                       echo "Export GitHub secrets into environment variables"
                       export POSTGRES_PASSWORD="${{ secrets.POSTGRES_PASSWORD_STAGING }}"
                       export POSTGRES_USER="${{ secrets.POSTGRES_USER }}"
@@ -103,29 +107,29 @@ jobs:
                       export SWIFT_PREFIX="backups/${ENV_NAME}"
 
                       APP_DIR=~/matkassen
-                      if [ -d "$APP_DIR" ]; then
-                          echo "Pulling latest changes from the repository..."
-                          cd $APP_DIR
-                          echo "Discarding any local changes..."
-                          git reset --hard HEAD
-                          git clean -fd
-                          git pull origin main
-
-                          # Run the update.sh script which will apply migrations
-                          chmod +x update.sh
-                          ./update.sh
-                          UPDATE_STATUS=$?
-
-                          if [ $UPDATE_STATUS -ne 0 ]; then
-                              echo "❌ Deployment failed with status: $UPDATE_STATUS"
-                              exit $UPDATE_STATUS
-                          else
-                              echo "✅ Successfully deployed all updates."
-                          fi
-                      else
-                          echo "App directory not found"
+                      if [ ! -d "$APP_DIR" ]; then
+                          echo "❌ App directory not found"
                           exit 1
                       fi
+                      cd "$APP_DIR"
+
+                      # Force-align the repo to origin/main regardless of the branch
+                      # that happens to be checked out on the VPS. `git reset --hard HEAD`
+                      # followed by `git pull origin main` silently fails to update when
+                      # HEAD is on a diverged branch — that's how staging ended up stuck
+                      # on an old feature branch for ~a week.
+                      echo "Aligning VPS repo to origin/main..."
+                      git fetch --prune origin main
+                      git checkout --force -B main origin/main
+                      git clean -fd
+                      echo "HEAD: $(git rev-parse HEAD)  (workflow SHA: ${{ github.sha }})"
+
+                      # Run the update.sh script which will apply migrations.
+                      # `set -euo pipefail` above means a non-zero exit terminates the
+                      # whole script, so the previous UPDATE_STATUS dance is redundant.
+                      chmod +x update.sh
+                      ./update.sh
+                      echo "✅ Successfully deployed all updates."
 
     manual-deploy-to-production:
         needs: deploy-to-staging
@@ -141,6 +145,9 @@ jobs:
                   username: ${{ secrets.SERVER_USER }}
                   key: ${{ secrets.SERVER_SSH_KEY }}
                   script: |
+                      # Fail fast on errors — see deploy-to-staging above for context.
+                      set -euo pipefail
+
                       echo "Export GitHub secrets into environment variables"
                       export POSTGRES_PASSWORD="${{ secrets.POSTGRES_PASSWORD_PRODUCTION }}"
                       export POSTGRES_USER="${{ secrets.POSTGRES_USER }}"
@@ -184,26 +191,20 @@ jobs:
                       export SLACK_CHANNEL_ID="${{ secrets.SLACK_CHANNEL_ID }}"
 
                       APP_DIR=~/matkassen
-                      if [ -d "$APP_DIR" ]; then
-                          echo "Pulling latest changes from the repository..."
-                          cd $APP_DIR
-                          echo "Discarding any local changes..."
-                          git reset --hard HEAD
-                          git clean -fd
-                          git pull origin main
-
-                          # Run the update.sh script which will apply migrations
-                          chmod +x update.sh
-                          ./update.sh
-                          UPDATE_STATUS=$?
-
-                          if [ $UPDATE_STATUS -ne 0 ]; then
-                              echo "❌ Deployment failed with status: $UPDATE_STATUS"
-                              exit $UPDATE_STATUS
-                          else
-                              echo "✅ Successfully deployed all updates."
-                          fi
-                      else
-                          echo "App directory not found"
+                      if [ ! -d "$APP_DIR" ]; then
+                          echo "❌ App directory not found"
                           exit 1
                       fi
+                      cd "$APP_DIR"
+
+                      # Force-align the repo to origin/main regardless of the branch
+                      # that happens to be checked out on the VPS (see staging block).
+                      echo "Aligning VPS repo to origin/main..."
+                      git fetch --prune origin main
+                      git checkout --force -B main origin/main
+                      git clean -fd
+                      echo "HEAD: $(git rev-parse HEAD)  (workflow SHA: ${{ github.sha }})"
+
+                      chmod +x update.sh
+                      ./update.sh
+                      echo "✅ Successfully deployed all updates."

--- a/.github/workflows/init_deploy.yml
+++ b/.github/workflows/init_deploy.yml
@@ -53,7 +53,8 @@ jobs:
                   script: |
                       # Fail fast on errors (defense in depth — init_deploy re-clones so
                       # the stale-branch bug doesn't apply, but strict mode is the right
-                      # default for deploy scripts).
+                      # default for deploy scripts). Assumes the remote login shell is
+                      # bash (`pipefail` is a bashism).
                       set -euo pipefail
 
                       echo "Export GitHub secrets into environment variables"

--- a/.github/workflows/init_deploy.yml
+++ b/.github/workflows/init_deploy.yml
@@ -51,6 +51,11 @@ jobs:
                   username: ${{ secrets.SERVER_USER }}
                   key: ${{ secrets.SERVER_SSH_KEY }}
                   script: |
+                      # Fail fast on errors (defense in depth — init_deploy re-clones so
+                      # the stale-branch bug doesn't apply, but strict mode is the right
+                      # default for deploy scripts).
+                      set -euo pipefail
+
                       echo "Export GitHub secrets into environment variables"
                       export POSTGRES_USER="${{ secrets.POSTGRES_USER }}"
                       export POSTGRES_DB="${{ secrets.POSTGRES_DB }}"
@@ -122,13 +127,7 @@ jobs:
 
                       echo "Run the deploy script"
                       chmod +x deploy.sh
+                      # `set -euo pipefail` above means a non-zero exit aborts the
+                      # whole script, so the explicit status check is redundant.
                       ./deploy.sh
-                      DEPLOY_STATUS=$?
-
-                      # Check deploy.sh script status
-                      if [ $DEPLOY_STATUS -ne 0 ]; then
-                          echo "❌ Deployment failed with status: $DEPLOY_STATUS"
-                          exit $DEPLOY_STATUS
-                      else
-                          echo "✅ Successfully deployed the application to the VPS."
-                      fi
+                      echo "✅ Successfully deployed the application to the VPS."


### PR DESCRIPTION
## Why

Staging had been stuck on \`feature/auth-eligibility-and-access-denied\` (HEAD \`8a28b15\`) since April 13. Every auto-deploy since then reported success but was a no-op for anything sourced from the VPS's git working tree. The app container kept getting fresh code from GHCR, so app-level behavior looked current — but nginx config (which is applied from the VPS's checkout, not from the container image) stayed frozen. This is how PR #378's nginx fix failed to take effect on staging even after a clean CI run, and it was only caught manually.

## The silent-failure mechanism

Both \`deploy-to-staging\` and \`manual-deploy-to-production\` ran:

\`\`\`bash
git reset --hard HEAD
git clean -fd
git pull origin main
./update.sh
\`\`\`

When the VPS is checked out on any branch other than \`main\`:

1. \`git reset --hard HEAD\` resets to that branch's HEAD — no-op, does not force-align to \`main\`.
2. \`git pull origin main\` attempts a merge of \`origin/main\` into the current branch. Either produces a merge commit (usually clean, but wrong) or fails with conflicts.
3. No \`set -e\` at the script level, so a failed pull didn't abort the deploy.
4. \`./update.sh\` (which does have \`set -Eeuo pipefail\` internally) then ran against stale files, regenerated nginx config from the stale template, and exited 0.

The workflow log showed green, nginx passed \`nginx -t\`, and nothing alerted.

## Changes

- **Replace reset+pull with a force-align:**
  \`\`\`bash
  git fetch --prune origin main
  git checkout --force -B main origin/main
  git clean -fd
  \`\`\`
  Works regardless of which branch is checked out. If someone debugs on the VPS and leaves a branch behind, the next deploy snaps back to \`main\` correctly.
- **Add \`set -euo pipefail\`** at the top of each \`script:\` block so any failed step (git, update.sh, anything) aborts the deploy instead of masking.
- **Drop the \`UPDATE_STATUS=\$?\` dance** — strict mode makes it redundant.
- **Echo HEAD vs \`\${{ github.sha }}\`** after checkout so future drift is visible in workflow logs without having to SSH into the VPS to diagnose.
- **\`init_deploy.yml\`** also gets strict mode as defense in depth, even though it re-clones and isn't affected by this specific bug.

\`update.sh\` and \`deploy.sh\` already set \`-Eeuo pipefail\` themselves; the bug lived entirely in the wrapper SSH script, not in those.

## Pre-emptive note on prod

Production may have the same stuck-branch state as staging did — worth running \`ssh ... 'cd ~/matkassen && git branch --show-current && git rev-parse HEAD'\` before merging this. If prod is on a diverged branch, this PR's first deploy there will still work (that's the point of \`--force -B\`), but it's good to confirm.