### PR TITLE
fix(backup): set GNUPGHOME so gpg works under read_only container

### DIFF
--- a/docker-compose.backup.yml
+++ b/docker-compose.backup.yml
@@ -35,6 +35,14 @@ services:
             # Sourced from host .env, written by deploy.sh / update.sh from
             # the GitHub Secret of the same name. backup-db.sh aborts if unset.
             - DB_BACKUP_PASSPHRASE=${DB_BACKUP_PASSPHRASE}
+            # gpg normally creates and writes state files (keyring, random
+            # seed, socket dir) in ~/.gnupg. With read_only: true that
+            # directory is unwritable and gpg aborts with
+            # `can't create directory '/home/backupuser/.gnupg': Read-only
+            # file system`. Pointing GNUPGHOME at the tmpfs /tmp mount
+            # gives gpg a writable state dir per container run without
+            # widening the filesystem write surface.
+            - GNUPGHOME=/tmp/.gnupg
         depends_on:
             db:
                 condition: service_healthy


### PR DESCRIPTION
## What broke

PR #376 shipped with the db-backup container running under `read_only: true`. That's correct hardening, but gpg wants to create `~/.gnupg` for its state dir on first run — which fails under read-only root:

```
gpg: Fatal: can't create directory '/home/backupuser/.gnupg': Read-only file system
[2026-04-22 16:00:33] ERROR: Backup aborted in stage 'pg_dump|gpg' (exit 2)
```

The 02:00 Stockholm cron would hit this every night. Caught today by the first `./scripts/backup-manage.sh test` run against prod before the scheduled 02:00.

## The fix

One line added to `docker-compose.backup.yml`:

```yaml
- GNUPGHOME=/tmp/.gnupg
```

`/tmp` is already the tmpfs mount on this container (500m, `noexec,nosuid`). Pointing GNUPGHOME there gives gpg a writable state dir without widening any other mount. State is ephemeral, which is the right semantics anyway — we use symmetric AES256 passed on fd 0 via `builtin printf`, so there's no persistent keyring to worry about.

## Why this slipped through

Local E2E testing used a compose override that disabled `read_only: true` to allow a host volume mount for the fake-Swift directory. That disabled exactly the constraint that fails in prod. Two rounds of subagent review, `docker build`, and the healthcheck all passed. Only running against the real prod-configured container surfaced it.

## Good news from the failure

The error-handling from #376 worked exactly as designed:

- `set -o errtrace` + ERR trap fired with the correct stage (`pg_dump|gpg`)
- Slack got a real failure alert with the stage name
- `createdb` never ran → no scratch DB leaked
- Container stayed healthy, no partial upload
- Cleanup trap ran, removed the temp .pgpass

So the observability scaffolding worked. It's what made this diagnosable in under a minute instead of "backups stopped silently at 02:00 three days in a row."

## Verification

Before pushing, verified end-to-end against prod-equivalent constraints:

```bash
docker run --rm \
  --read-only \
  --tmpfs /tmp:noexec,nosuid,size=500m \
  -e GNUPGHOME=/tmp/.gnupg \
  ...
  matkassen-db-backup:test \
  /usr/local/bin/backup-db.sh
```

Full pipeline completed in ~1 second: pg_dump → gpg encrypt (AES256) → rclone upload → full-restore validation into scratch DB → sentinel query → scratch drop. Under the exact read-only + tmpfs constraints that failed in prod.

Consulted codex mcp on the fix choice. Options considered and rejected:

| Alternative | Why not |
| --- | --- |
| `--homedir /tmp/.gnupg` on every gpg call | Duplicated policy across 6 call sites; easier to regress |
| Add `/home/backupuser/.gnupg` as writable tmpfs | Adds another writable mount for no gain |
| `ENV GNUPGHOME` in Dockerfile | Less precise; the fix depends on the `/tmp` tmpfs guarantee, which is compose-owned |

## Post-merge

After merge + deploy, re-run `./scripts/backup-manage.sh test` on prod to confirm. Same steps as the aborted run, should complete successfully this time.