### PR TITLE
chore(ops): harden app dir perms to 700 and drop fragile ~/matkassen paths

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -108,7 +108,11 @@ jobs:
                       # Backups disabled on staging by policy (no db-backup related secrets exported)
                       export SWIFT_PREFIX="backups/${ENV_NAME}"
 
-                      APP_DIR=~/matkassen
+                      # Explicit path rather than `~/matkassen`. ssh-action runs as
+                      # the `ubuntu` user so `~` resolves correctly today, but
+                      # hardcoding prevents a future `sudo ...` wrapper from
+                      # silently redirecting to /root/matkassen.
+                      APP_DIR="/home/ubuntu/matkassen"
                       if [ ! -d "$APP_DIR" ]; then
                           echo "❌ App directory not found"
                           exit 1
@@ -193,7 +197,11 @@ jobs:
                       export SLACK_BOT_TOKEN="${{ secrets.SLACK_BOT_TOKEN }}"
                       export SLACK_CHANNEL_ID="${{ secrets.SLACK_CHANNEL_ID }}"
 
-                      APP_DIR=~/matkassen
+                      # Explicit path rather than `~/matkassen`. ssh-action runs as
+                      # the `ubuntu` user so `~` resolves correctly today, but
+                      # hardcoding prevents a future `sudo ...` wrapper from
+                      # silently redirecting to /root/matkassen.
+                      APP_DIR="/home/ubuntu/matkassen"
                       if [ ! -d "$APP_DIR" ]; then
                           echo "❌ App directory not found"
                           exit 1

--- a/.github/workflows/init_deploy.yml
+++ b/.github/workflows/init_deploy.yml
@@ -114,17 +114,28 @@ jobs:
                       # Derive Swift prefix from env name
                       export SWIFT_PREFIX="backups/${ENV_NAME}"
 
+                      # Explicit path rather than `~/matkassen`. The ssh-action runs
+                      # this as the `ubuntu` user so `~` would resolve correctly,
+                      # but hardcoding removes the fragility if anyone ever wraps
+                      # a command in sudo.
+                      APP_DIR="/home/ubuntu/matkassen"
+
                       echo "Checking if app directory exists"
-                      if [ -d ~/matkassen ]; then
+                      if [ -d "$APP_DIR" ]; then
                         echo "Directory exists, removing it"
-                        rm -rf ~/matkassen
+                        rm -rf "$APP_DIR"
                       fi
 
+                      # Create the directory with owner-only perms BEFORE git
+                      # clone, so the repo lands in an already-hardened dir.
+                      # git clone into an existing empty directory is supported.
+                      sudo install -d -m 700 -o ubuntu -g ubuntu "$APP_DIR"
+
                       echo "Cloning the repository (shallow clone for faster deployment)"
-                      git clone --depth 1 https://github.com/Vasteras-Stadsmission/matkassen.git ~/matkassen
+                      git clone --depth 1 https://github.com/Vasteras-Stadsmission/matkassen.git "$APP_DIR"
 
                       echo "Change directory to the app folder"
-                      cd ~/matkassen
+                      cd "$APP_DIR"
 
                       echo "Run the deploy script"
                       chmod +x deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -63,7 +63,19 @@ fi
 
 GITHUB_ORG=vasteras-stadsmission
 PROJECT_NAME=matkassen
-APP_DIR=~/"$PROJECT_NAME"
+# Explicit path rather than `~/$PROJECT_NAME`. When any step of this
+# script runs via `sudo` (not the current pattern, but a future contributor
+# could), `~` would resolve to /root instead of /home/ubuntu. The deploy
+# user is always `ubuntu` per the SSH workflow, so hardcoding is safe.
+APP_DIR="/home/ubuntu/$PROJECT_NAME"
+
+# Harden the app directory: owner-only access. `.env` alone is 600, but
+# without restricting directory perms another user in the ubuntu group
+# could unlink/replace the file. `install -d` creates-or-updates mode and
+# ownership idempotently on every deploy, so the hardening persists even
+# if something ever resets the directory.
+sudo install -d -m 700 -o ubuntu -g ubuntu "$APP_DIR"
+
 # Derive backup settings from environment
 SWIFT_PREFIX="backups/${ENV_NAME:-staging}"
 OS_AUTH_TYPE="${OS_AUTH_TYPE:-v3applicationcredential}"
@@ -200,66 +212,78 @@ DATABASE_URL="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@db:5432/$POSTGRES_DB"
 # For external tools (like Drizzle Studio)
 DATABASE_URL_EXTERNAL="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/$POSTGRES_DB"
 
-# Create the .env file inside the app directory (~/matkassen/.env)
-# Set restrictive permissions before writing secrets
-echo "AUTH_GITHUB_ID=\"$AUTH_GITHUB_ID\"" > "$APP_DIR/.env"
-chmod 600 "$APP_DIR/.env"
-echo "AUTH_GITHUB_SECRET=\"$AUTH_GITHUB_SECRET\"" >> "$APP_DIR/.env"
-echo "AUTH_GITHUB_APP_ID=\"$AUTH_GITHUB_APP_ID\"" >> "$APP_DIR/.env"
-echo "AUTH_GITHUB_APP_PRIVATE_KEY=\"$AUTH_GITHUB_APP_PRIVATE_KEY\"" >> "$APP_DIR/.env"
-echo "AUTH_GITHUB_APP_INSTALLATION_ID=\"$AUTH_GITHUB_APP_INSTALLATION_ID\"" >> "$APP_DIR/.env"
-echo "AUTH_REDIRECT_PROXY_URL=https://$DOMAIN_NAME/api/auth" >> "$APP_DIR/.env"
-echo "AUTH_SECRET=\"$AUTH_SECRET\"" >> "$APP_DIR/.env"
-echo "AUTH_TRUST_HOST=true" >> "$APP_DIR/.env"
-echo "AUTH_URL=https://$DOMAIN_NAME/api/auth" >> "$APP_DIR/.env"
-echo "DATABASE_URL=\"$DATABASE_URL\"" >> "$APP_DIR/.env"
-echo "DATABASE_URL_EXTERNAL=\"$DATABASE_URL_EXTERNAL\"" >> "$APP_DIR/.env"
-echo "EMAIL=\"$EMAIL\"" >> "$APP_DIR/.env" # Needed for Certbot
-echo "GITHUB_ORG=\"$GITHUB_ORG\"" >> "$APP_DIR/.env"
-echo "POSTGRES_DB=\"$POSTGRES_DB\"" >> "$APP_DIR/.env"
-echo "POSTGRES_PASSWORD=\"$POSTGRES_PASSWORD\"" >> "$APP_DIR/.env"
-echo "POSTGRES_USER=\"$POSTGRES_USER\"" >> "$APP_DIR/.env"
-echo "ENV_NAME=\"${ENV_NAME:-staging}\"" >> "$APP_DIR/.env" # Environment identifier (production/staging)
-# SMS configuration (conditional - only if credentials are provided)
-if [ -n "${HELLO_SMS_USERNAME:-}" ]; then
-  echo "HELLO_SMS_USERNAME=\"$HELLO_SMS_USERNAME\"" >> "$APP_DIR/.env"
-fi
-if [ -n "${HELLO_SMS_PASSWORD:-}" ]; then
-  echo "HELLO_SMS_PASSWORD=\"$HELLO_SMS_PASSWORD\"" >> "$APP_DIR/.env"
-fi
-echo "HELLO_SMS_TEST_MODE=\"${HELLO_SMS_TEST_MODE:-true}\"" >> "$APP_DIR/.env"
-echo "SMS_SEND_INTERVAL=\"${SMS_SEND_INTERVAL:-5 minutes}\"" >> "$APP_DIR/.env"
-# SMS callback webhook secret (required for HelloSMS status callbacks in production)
-if [ -n "${SMS_CALLBACK_SECRET:-}" ]; then
-  echo "SMS_CALLBACK_SECRET=\"${SMS_CALLBACK_SECRET}\"" >> "$APP_DIR/.env"
-fi
-# Logging configuration
-echo "LOG_LEVEL=\"${LOG_LEVEL:-info}\"" >> "$APP_DIR/.env"
-# White-label configuration (required in production)
-echo "NEXT_PUBLIC_BRAND_NAME=\"${BRAND_NAME}\"" >> "$APP_DIR/.env"
-echo "NEXT_PUBLIC_BASE_URL=\"https://$DOMAIN_NAME\"" >> "$APP_DIR/.env"
-# SMS sender name (optional - defaults to BRAND_NAME if not set)
-if [ -n "${SMS_SENDER:-}" ]; then
-  echo "NEXT_PUBLIC_SMS_SENDER=\"${SMS_SENDER}\"" >> "$APP_DIR/.env"
-fi
-# Anonymization scheduler configuration (always enabled for GDPR compliance)
-echo "ANONYMIZATION_SCHEDULE=\"${ANONYMIZATION_SCHEDULE:-0 2 * * 0}\"" >> "$APP_DIR/.env"
-echo "ANONYMIZATION_INACTIVE_DURATION=\"${ANONYMIZATION_INACTIVE_DURATION:-1 year}\"" >> "$APP_DIR/.env"
-# SMS health report schedule (daily at 8 AM Stockholm time)
-echo "SMS_REPORT_SCHEDULE=\"${SMS_REPORT_SCHEDULE:-0 8 * * *}\"" >> "$APP_DIR/.env"
-# Org membership sync schedule (daily at 3 AM Stockholm time)
-echo "ORG_SYNC_SCHEDULE=\"${ORG_SYNC_SCHEDULE:-0 3 * * *}\"" >> "$APP_DIR/.env"
-# Slack notifications (optional - alerts only sent when ENV_NAME=production)
-if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
-  echo "SLACK_BOT_TOKEN=\"${SLACK_BOT_TOKEN}\"" >> "$APP_DIR/.env"
-fi
-if [ -n "${SLACK_CHANNEL_ID:-}" ]; then
-  echo "SLACK_CHANNEL_ID=\"${SLACK_CHANNEL_ID}\"" >> "$APP_DIR/.env"
-fi
-# Database backup encryption (GDPR compliance - production only)
-if [ "${ENV_NAME:-staging}" = "production" ]; then
-  echo "DB_BACKUP_PASSPHRASE=\"${DB_BACKUP_PASSPHRASE}\"" >> "$APP_DIR/.env"
-fi
+# Create the .env file atomically with mode 600.
+# Same pattern as update.sh: write to a temp file, then `install -m 600`
+# moves it into place in a single step. Shell redirection alone would
+# create the file with umask-default perms (typically 644) before any
+# chmod could tighten it — a small race window where secrets land in a
+# world-readable file.
+echo "Creating .env file..."
+tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+
+{
+  printf 'AUTH_GITHUB_ID="%s"\n' "$AUTH_GITHUB_ID"
+  printf 'AUTH_GITHUB_SECRET="%s"\n' "$AUTH_GITHUB_SECRET"
+  printf 'AUTH_GITHUB_APP_ID="%s"\n' "$AUTH_GITHUB_APP_ID"
+  printf 'AUTH_GITHUB_APP_PRIVATE_KEY="%s"\n' "$AUTH_GITHUB_APP_PRIVATE_KEY"
+  printf 'AUTH_GITHUB_APP_INSTALLATION_ID="%s"\n' "$AUTH_GITHUB_APP_INSTALLATION_ID"
+  printf 'AUTH_REDIRECT_PROXY_URL="https://%s/api/auth"\n' "$DOMAIN_NAME"
+  printf 'AUTH_SECRET="%s"\n' "$AUTH_SECRET"
+  printf 'AUTH_TRUST_HOST=true\n'
+  printf 'AUTH_URL="https://%s/api/auth"\n' "$DOMAIN_NAME"
+  printf 'DATABASE_URL="%s"\n' "$DATABASE_URL"
+  printf 'DATABASE_URL_EXTERNAL="%s"\n' "$DATABASE_URL_EXTERNAL"
+  printf 'EMAIL="%s"\n' "$EMAIL"
+  printf 'GITHUB_ORG="%s"\n' "$GITHUB_ORG"
+  printf 'POSTGRES_DB="%s"\n' "$POSTGRES_DB"
+  printf 'POSTGRES_PASSWORD="%s"\n' "$POSTGRES_PASSWORD"
+  printf 'POSTGRES_USER="%s"\n' "$POSTGRES_USER"
+  printf 'ENV_NAME="%s"\n' "${ENV_NAME:-staging}"
+  # SMS configuration (conditional - only if credentials are provided)
+  if [ -n "${HELLO_SMS_USERNAME:-}" ]; then
+    printf 'HELLO_SMS_USERNAME="%s"\n' "$HELLO_SMS_USERNAME"
+  fi
+  if [ -n "${HELLO_SMS_PASSWORD:-}" ]; then
+    printf 'HELLO_SMS_PASSWORD="%s"\n' "$HELLO_SMS_PASSWORD"
+  fi
+  printf 'HELLO_SMS_TEST_MODE="%s"\n' "${HELLO_SMS_TEST_MODE:-true}"
+  printf 'SMS_SEND_INTERVAL="%s"\n' "${SMS_SEND_INTERVAL:-5 minutes}"
+  # SMS callback webhook secret (required for HelloSMS status callbacks in production)
+  if [ -n "${SMS_CALLBACK_SECRET:-}" ]; then
+    printf 'SMS_CALLBACK_SECRET="%s"\n' "${SMS_CALLBACK_SECRET}"
+  fi
+  # Logging configuration
+  printf 'LOG_LEVEL="%s"\n' "${LOG_LEVEL:-info}"
+  # White-label configuration (required in production)
+  printf 'NEXT_PUBLIC_BRAND_NAME="%s"\n' "${BRAND_NAME}"
+  printf 'NEXT_PUBLIC_BASE_URL="https://%s"\n' "$DOMAIN_NAME"
+  # SMS sender name (optional - defaults to BRAND_NAME if not set)
+  if [ -n "${SMS_SENDER:-}" ]; then
+    printf 'NEXT_PUBLIC_SMS_SENDER="%s"\n' "${SMS_SENDER}"
+  fi
+  # Anonymization scheduler configuration (always enabled for GDPR compliance)
+  printf 'ANONYMIZATION_SCHEDULE="%s"\n' "${ANONYMIZATION_SCHEDULE:-0 2 * * 0}"
+  printf 'ANONYMIZATION_INACTIVE_DURATION="%s"\n' "${ANONYMIZATION_INACTIVE_DURATION:-1 year}"
+  # SMS health report schedule (daily at 8 AM Stockholm time)
+  printf 'SMS_REPORT_SCHEDULE="%s"\n' "${SMS_REPORT_SCHEDULE:-0 8 * * *}"
+  # Org membership sync schedule (daily at 3 AM Stockholm time)
+  printf 'ORG_SYNC_SCHEDULE="%s"\n' "${ORG_SYNC_SCHEDULE:-0 3 * * *}"
+  # Slack notifications (optional - alerts only sent when ENV_NAME=production)
+  if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
+    printf 'SLACK_BOT_TOKEN="%s"\n' "${SLACK_BOT_TOKEN}"
+  fi
+  if [ -n "${SLACK_CHANNEL_ID:-}" ]; then
+    printf 'SLACK_CHANNEL_ID="%s"\n' "${SLACK_CHANNEL_ID}"
+  fi
+  # Database backup encryption (GDPR compliance - production only)
+  if [ "${ENV_NAME:-staging}" = "production" ]; then
+    printf 'DB_BACKUP_PASSPHRASE="%s"\n' "${DB_BACKUP_PASSPHRASE}"
+  fi
+} > "$tmp"
+
+# Install atomically with mode 600 (rw-------)
+install -m 600 "$tmp" "$APP_DIR/.env"
+[ -f "$APP_DIR/.env" ] || { echo "ERROR: Failed to create .env file"; exit 1; }
 
 # Install Nginx
 sudo apt install nginx -y

--- a/update.sh
+++ b/update.sh
@@ -39,7 +39,16 @@ trap cleanup EXIT
 # Script Vars
 PROJECT_NAME=matkassen
 GITHUB_ORG=vasteras-stadsmission
-APP_DIR=~/"$PROJECT_NAME"
+# Explicit path rather than `~/$PROJECT_NAME`. If any future change runs
+# this script via sudo, `~` would resolve to /root instead of the deploy
+# user's home. The deploy user is always `ubuntu` per the SSH workflow.
+APP_DIR="/home/ubuntu/$PROJECT_NAME"
+
+# Idempotently harden the app directory: owner-only access. Without this,
+# a reset of the directory (e.g. a fresh init_deploy re-run) would leave
+# the parent at default 755, which lets anyone in the ubuntu group
+# unlink/replace .env despite its own 600 perms.
+sudo install -d -m 700 -o ubuntu -g ubuntu "$APP_DIR"
 
 # For Docker internal communication ("db" is the name of Postgres container)
 DATABASE_URL="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@db:5432/$POSTGRES_DB"


### PR DESCRIPTION
## Why

`~/matkassen` on the VPS was `drwxrwxr-x (775)` while `.env` inside it was already `rw------- (600)`. That's a leaky combination — directory write perms govern whether a file can be unlinked/replaced regardless of the file's own mode. Any user in the `ubuntu` group could swap `.env` for a malicious version despite never being able to read the original contents.

This PR tightens the directory to `drwx------ (700)` owner-only and — critically — enforces that state on every deploy, so a future re-init or any other op that recreates the directory doesn't silently regress the hardening.

## Planned with codex-mcp

Submitted my draft to codex; it caught three things I had wrong:

1. **`git clone` doesn't happen in `deploy.sh`** — it happens in `init_deploy.yml`. So the "before or after git clone" question in my draft was misframed.
2. **`update.sh` already writes `.env` correctly** using a temp-file + `install -m 600` pattern. No changes needed there. But **`deploy.sh` was weaker** — shell redirection creates the file at umask-default perms (typically 644) *before* the subsequent `chmod 600` tightens it. Small window, wrong. Refactored to match `update.sh`.
3. **The workflow YAMLs (`init_deploy.yml`, `continuous_deployment.yml`) also use `~/matkassen`** — if the goal is "stop relying on `~` and ensure correct dir perms always," those need the same treatment.

All three incorporated below.

## Changes

### Shell scripts

- **`deploy.sh`**
  - `APP_DIR=~/"$PROJECT_NAME"` → `APP_DIR="/home/ubuntu/$PROJECT_NAME"`. `~` resolves to `/root` if any step ever runs under `sudo ./deploy.sh` — latent foot-gun. Hardcoding is safe because the deploy user is always `ubuntu` per the SSH workflow.
  - Added `sudo install -d -m 700 -o ubuntu -g ubuntu "$APP_DIR"` right after `APP_DIR` is set. Creates-or-updates the dir with correct mode and ownership in one idempotent step.
  - Refactored `.env` writing from the `echo > file; chmod 600 file; echo >> file; ...` pattern to `update.sh`'s atomic temp-file + `install -m 600` pattern. No more umask-race window.

- **`update.sh`**
  - Same `APP_DIR` explicit-path change.
  - Same `sudo install -d -m 700` line right after flock acquisition. Runs on every deploy — no-op when perms already correct, tightens them on first run after merge.
  - `.env` writing already correct; unchanged.

### Workflow YAMLs

- **`init_deploy.yml`**: `~/matkassen` references changed to `/home/ubuntu/matkassen`; added `sudo install -d -m 700 -o ubuntu -g ubuntu` before `git clone` so the repo lands in an already-hardened directory (git clone into an empty pre-existing dir is supported).
- **`continuous_deployment.yml`**: `APP_DIR=~/matkassen` → `APP_DIR=\"/home/ubuntu/matkassen\"` at both staging and production SSH blocks.

## Behavior change

Zero behavior change for normal deploys. The only observable difference is `ls -ld /home/ubuntu/matkassen` now shows `drwx------` instead of `drwxrwxr-x` after the first post-merge deploy.

## Blast-radius reduction

On any VPS with multiple non-root users, this closes the "unlink-and-replace `.env`" path. Matkassen today is single-user, so the immediate reduction is theoretical — but the alternative is relying on "we won't add another user," which is exactly the posture that drifts over time.

## Tested

- `bash -n deploy.sh update.sh` passes.
- Grep for `~/matkassen` / `APP_DIR=~` in source shows only explanatory comments, no live references.
- No way to exercise end-to-end without a real VPS deploy, but the changes are small, the syntax is clean, and codex went through each decision.

## First deploy after merge

Expected: `update.sh` runs `install -d -m 700` on the already-existing `/home/ubuntu/matkassen`, which tightens it in place. `ls -ld` on the VPS afterward should show `drwx------`. If it doesn't, the `install` line either didn't execute or is running under a different user than expected — investigate.

Rollback if needed: revert + redeploy, the dir goes back to 775 on the next run (since nothing would be hardening it anymore). No data touched, no services affected.