### PR TITLE
chore(ops): extract .env writer into shared helper, fix latent prod drift

### DIFF
--- a/.github/workflows/init_deploy.yml
+++ b/.github/workflows/init_deploy.yml
@@ -85,10 +85,15 @@ jobs:
                         export ANONYMIZATION_INACTIVE_DURATION="1 year"
                         export ORG_SYNC_SCHEDULE="0 3 * * *"
                         export DB_BACKUP_PASSPHRASE="${{ secrets.DB_BACKUP_PASSPHRASE }}"
-                        # OpenStack Swift (env_auth) for backups - hardcoded non-sensitive values
+                        # OpenStack Swift (env_auth) for backups - hardcoded non-sensitive values.
+                        # All five hardcoded vars are explicit (not relying on deploy.sh's
+                        # defaults) so the workflow is self-documenting and matches
+                        # continuous_deployment.yml's exports.
                         export OS_AUTH_TYPE=v3applicationcredential
                         export OS_AUTH_URL=https://ops.elastx.cloud:5000/v3
                         export OS_REGION_NAME=se-sto
+                        export OS_INTERFACE=public
+                        export OS_IDENTITY_API_VERSION=3
                         export OS_APPLICATION_CREDENTIAL_ID="${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}"
                         export OS_APPLICATION_CREDENTIAL_SECRET="${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}"
                         export SWIFT_CONTAINER="${{ secrets.SWIFT_CONTAINER }}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -212,78 +212,14 @@ DATABASE_URL="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@db:5432/$POSTGRES_DB"
 # For external tools (like Drizzle Studio)
 DATABASE_URL_EXTERNAL="postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@localhost:5432/$POSTGRES_DB"
 
-# Create the .env file atomically with mode 600.
-# Same pattern as update.sh: write to a temp file, then `install -m 600`
-# moves it into place in a single step. Shell redirection alone would
-# create the file with umask-default perms (typically 644) before any
-# chmod could tighten it — a small race window where secrets land in a
-# world-readable file.
+# Create the .env file via the shared helper. Atomic write with mode 600.
+# See scripts/write-env.sh for the .env contract and validation logic.
+# Helper also writes Swift/OpenStack vars on production (deploy.sh used to
+# omit them — see PR description for the latent bug this closes).
 echo "Creating .env file..."
-tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
-
-{
-  printf 'AUTH_GITHUB_ID="%s"\n' "$AUTH_GITHUB_ID"
-  printf 'AUTH_GITHUB_SECRET="%s"\n' "$AUTH_GITHUB_SECRET"
-  printf 'AUTH_GITHUB_APP_ID="%s"\n' "$AUTH_GITHUB_APP_ID"
-  printf 'AUTH_GITHUB_APP_PRIVATE_KEY="%s"\n' "$AUTH_GITHUB_APP_PRIVATE_KEY"
-  printf 'AUTH_GITHUB_APP_INSTALLATION_ID="%s"\n' "$AUTH_GITHUB_APP_INSTALLATION_ID"
-  printf 'AUTH_REDIRECT_PROXY_URL="https://%s/api/auth"\n' "$DOMAIN_NAME"
-  printf 'AUTH_SECRET="%s"\n' "$AUTH_SECRET"
-  printf 'AUTH_TRUST_HOST=true\n'
-  printf 'AUTH_URL="https://%s/api/auth"\n' "$DOMAIN_NAME"
-  printf 'DATABASE_URL="%s"\n' "$DATABASE_URL"
-  printf 'DATABASE_URL_EXTERNAL="%s"\n' "$DATABASE_URL_EXTERNAL"
-  printf 'EMAIL="%s"\n' "$EMAIL"
-  printf 'GITHUB_ORG="%s"\n' "$GITHUB_ORG"
-  printf 'POSTGRES_DB="%s"\n' "$POSTGRES_DB"
-  printf 'POSTGRES_PASSWORD="%s"\n' "$POSTGRES_PASSWORD"
-  printf 'POSTGRES_USER="%s"\n' "$POSTGRES_USER"
-  printf 'ENV_NAME="%s"\n' "${ENV_NAME:-staging}"
-  # SMS configuration (conditional - only if credentials are provided)
-  if [ -n "${HELLO_SMS_USERNAME:-}" ]; then
-    printf 'HELLO_SMS_USERNAME="%s"\n' "$HELLO_SMS_USERNAME"
-  fi
-  if [ -n "${HELLO_SMS_PASSWORD:-}" ]; then
-    printf 'HELLO_SMS_PASSWORD="%s"\n' "$HELLO_SMS_PASSWORD"
-  fi
-  printf 'HELLO_SMS_TEST_MODE="%s"\n' "${HELLO_SMS_TEST_MODE:-true}"
-  printf 'SMS_SEND_INTERVAL="%s"\n' "${SMS_SEND_INTERVAL:-5 minutes}"
-  # SMS callback webhook secret (required for HelloSMS status callbacks in production)
-  if [ -n "${SMS_CALLBACK_SECRET:-}" ]; then
-    printf 'SMS_CALLBACK_SECRET="%s"\n' "${SMS_CALLBACK_SECRET}"
-  fi
-  # Logging configuration
-  printf 'LOG_LEVEL="%s"\n' "${LOG_LEVEL:-info}"
-  # White-label configuration (required in production)
-  printf 'NEXT_PUBLIC_BRAND_NAME="%s"\n' "${BRAND_NAME}"
-  printf 'NEXT_PUBLIC_BASE_URL="https://%s"\n' "$DOMAIN_NAME"
-  # SMS sender name (optional - defaults to BRAND_NAME if not set)
-  if [ -n "${SMS_SENDER:-}" ]; then
-    printf 'NEXT_PUBLIC_SMS_SENDER="%s"\n' "${SMS_SENDER}"
-  fi
-  # Anonymization scheduler configuration (always enabled for GDPR compliance)
-  printf 'ANONYMIZATION_SCHEDULE="%s"\n' "${ANONYMIZATION_SCHEDULE:-0 2 * * 0}"
-  printf 'ANONYMIZATION_INACTIVE_DURATION="%s"\n' "${ANONYMIZATION_INACTIVE_DURATION:-1 year}"
-  # SMS health report schedule (daily at 8 AM Stockholm time)
-  printf 'SMS_REPORT_SCHEDULE="%s"\n' "${SMS_REPORT_SCHEDULE:-0 8 * * *}"
-  # Org membership sync schedule (daily at 3 AM Stockholm time)
-  printf 'ORG_SYNC_SCHEDULE="%s"\n' "${ORG_SYNC_SCHEDULE:-0 3 * * *}"
-  # Slack notifications (optional - alerts only sent when ENV_NAME=production)
-  if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
-    printf 'SLACK_BOT_TOKEN="%s"\n' "${SLACK_BOT_TOKEN}"
-  fi
-  if [ -n "${SLACK_CHANNEL_ID:-}" ]; then
-    printf 'SLACK_CHANNEL_ID="%s"\n' "${SLACK_CHANNEL_ID}"
-  fi
-  # Database backup encryption (GDPR compliance - production only)
-  if [ "${ENV_NAME:-staging}" = "production" ]; then
-    printf 'DB_BACKUP_PASSPHRASE="%s"\n' "${DB_BACKUP_PASSPHRASE}"
-  fi
-} > "$tmp"
-
-# Install atomically with mode 600 (rw-------)
-install -m 600 "$tmp" "$APP_DIR/.env"
-[ -f "$APP_DIR/.env" ] || { echo "ERROR: Failed to create .env file"; exit 1; }
+# shellcheck source=scripts/write-env.sh
+source "$APP_DIR/scripts/write-env.sh"
+write_env_file "$APP_DIR/.env"
 
 # Install Nginx
 sudo apt install nginx -y

--- a/scripts/write-env.sh
+++ b/scripts/write-env.sh
@@ -1,0 +1,158 @@
+# Shared .env file writer. Sourced by deploy.sh and update.sh.
+#
+# Usage (from either deploy.sh or update.sh, after all required env vars
+# have been exported):
+#
+#     source "$SCRIPT_DIR/scripts/write-env.sh"
+#     write_env_file "$APP_DIR/.env"
+#
+# Design notes:
+# - Helper writes the full .env. Both deploy.sh and update.sh produce
+#   identical .env content for a given (ENV_NAME, exported-vars) input.
+#   Previously deploy.sh silently omitted Swift/OS vars on production;
+#   that was a latent bug that only surfaced if the backup container
+#   restarted between init_deploy and the first subsequent update.sh.
+# - Uses atomic temp-file + `install -m 600` so .env is never briefly
+#   readable by anyone other than its owner during the write.
+# - Validates vars required by the .env contract up front. Callers keep
+#   their script-specific validation (Slack optionality, rotation
+#   cadence policy, etc.).
+# - Does NOT set shell options (`set -e`, `set -u`, ...) or install
+#   EXIT traps — those would leak into the caller's shell and clobber
+#   the caller's own trap chain. All cleanup is explicit.
+
+_write_env_require() {
+    # Fails if the named env var is unset or empty.
+    local name=$1
+    local val="${!name:-}"
+    if [ -z "$val" ]; then
+        echo "ERROR (write_env_file): $name is required but is unset or empty" >&2
+        return 1
+    fi
+}
+
+write_env_file() {
+    local target=${1:-}
+    if [ -z "$target" ]; then
+        echo "ERROR: write_env_file requires a target path argument" >&2
+        return 1
+    fi
+
+    # ENV_NAME defaults to "staging" when unset. Matches deploy.sh's
+    # prior default; update.sh previously defaulted to "" which produced
+    # an empty ENV_NAME line in .env — the new default is an
+    # improvement for both paths.
+    local env_name=${ENV_NAME:-staging}
+
+    # Vars required for any environment's .env contract. Validating
+    # before any file I/O means we fail before a partial .env exists.
+    local req
+    for req in \
+        AUTH_GITHUB_ID AUTH_GITHUB_SECRET \
+        AUTH_GITHUB_APP_ID AUTH_GITHUB_APP_PRIVATE_KEY AUTH_GITHUB_APP_INSTALLATION_ID \
+        AUTH_SECRET \
+        DOMAIN_NAME EMAIL GITHUB_ORG \
+        DATABASE_URL DATABASE_URL_EXTERNAL \
+        POSTGRES_DB POSTGRES_PASSWORD POSTGRES_USER \
+        BRAND_NAME
+    do
+        _write_env_require "$req" || return 1
+    done
+
+    # Production-only .env contract additions. On staging these are
+    # intentionally not exported by the CD workflow (backups disabled).
+    if [ "$env_name" = "production" ]; then
+        for req in \
+            DB_BACKUP_PASSPHRASE \
+            OS_AUTH_TYPE OS_AUTH_URL OS_REGION_NAME OS_INTERFACE OS_IDENTITY_API_VERSION \
+            OS_APPLICATION_CREDENTIAL_ID OS_APPLICATION_CREDENTIAL_SECRET \
+            SWIFT_CONTAINER SWIFT_PREFIX
+        do
+            _write_env_require "$req" || return 1
+        done
+    fi
+
+    local tmp rc=0
+    tmp=$(mktemp) || {
+        echo "ERROR (write_env_file): mktemp failed" >&2
+        return 1
+    }
+
+    {
+        printf 'AUTH_GITHUB_ID="%s"\n' "$AUTH_GITHUB_ID"
+        printf 'AUTH_GITHUB_SECRET="%s"\n' "$AUTH_GITHUB_SECRET"
+        printf 'AUTH_GITHUB_APP_ID="%s"\n' "$AUTH_GITHUB_APP_ID"
+        printf 'AUTH_GITHUB_APP_PRIVATE_KEY="%s"\n' "$AUTH_GITHUB_APP_PRIVATE_KEY"
+        printf 'AUTH_GITHUB_APP_INSTALLATION_ID="%s"\n' "$AUTH_GITHUB_APP_INSTALLATION_ID"
+        printf 'AUTH_REDIRECT_PROXY_URL="https://%s/api/auth"\n' "$DOMAIN_NAME"
+        printf 'AUTH_SECRET="%s"\n' "$AUTH_SECRET"
+        printf 'AUTH_TRUST_HOST=true\n'
+        printf 'AUTH_URL="https://%s/api/auth"\n' "$DOMAIN_NAME"
+        printf 'DATABASE_URL="%s"\n' "$DATABASE_URL"
+        printf 'DATABASE_URL_EXTERNAL="%s"\n' "$DATABASE_URL_EXTERNAL"
+        printf 'EMAIL="%s"\n' "$EMAIL"
+        printf 'GITHUB_ORG="%s"\n' "$GITHUB_ORG"
+        printf 'POSTGRES_DB="%s"\n' "$POSTGRES_DB"
+        printf 'POSTGRES_PASSWORD="%s"\n' "$POSTGRES_PASSWORD"
+        printf 'POSTGRES_USER="%s"\n' "$POSTGRES_USER"
+        printf 'ENV_NAME="%s"\n' "$env_name"
+        # SMS credentials (conditional — only if provided)
+        if [ -n "${HELLO_SMS_USERNAME:-}" ]; then
+            printf 'HELLO_SMS_USERNAME="%s"\n' "$HELLO_SMS_USERNAME"
+        fi
+        if [ -n "${HELLO_SMS_PASSWORD:-}" ]; then
+            printf 'HELLO_SMS_PASSWORD="%s"\n' "$HELLO_SMS_PASSWORD"
+        fi
+        printf 'HELLO_SMS_TEST_MODE="%s"\n' "${HELLO_SMS_TEST_MODE:-true}"
+        printf 'SMS_SEND_INTERVAL="%s"\n' "${SMS_SEND_INTERVAL:-5 minutes}"
+        # SMS callback webhook secret (required for HelloSMS status callbacks in production)
+        if [ -n "${SMS_CALLBACK_SECRET:-}" ]; then
+            printf 'SMS_CALLBACK_SECRET="%s"\n' "$SMS_CALLBACK_SECRET"
+        fi
+        printf 'LOG_LEVEL="%s"\n' "${LOG_LEVEL:-info}"
+        # White-label configuration
+        printf 'NEXT_PUBLIC_BRAND_NAME="%s"\n' "$BRAND_NAME"
+        printf 'NEXT_PUBLIC_BASE_URL="https://%s"\n' "$DOMAIN_NAME"
+        # SMS sender name (optional — defaults to BRAND_NAME if not set)
+        if [ -n "${SMS_SENDER:-}" ]; then
+            printf 'NEXT_PUBLIC_SMS_SENDER="%s"\n' "$SMS_SENDER"
+        fi
+        # Anonymization scheduler configuration (always enabled for GDPR compliance)
+        printf 'ANONYMIZATION_SCHEDULE="%s"\n' "${ANONYMIZATION_SCHEDULE:-0 2 * * 0}"
+        printf 'ANONYMIZATION_INACTIVE_DURATION="%s"\n' "${ANONYMIZATION_INACTIVE_DURATION:-1 year}"
+        # SMS health report schedule (daily at 8 AM Stockholm)
+        printf 'SMS_REPORT_SCHEDULE="%s"\n' "${SMS_REPORT_SCHEDULE:-0 8 * * *}"
+        # Org membership sync schedule (daily at 3 AM Stockholm)
+        printf 'ORG_SYNC_SCHEDULE="%s"\n' "${ORG_SYNC_SCHEDULE:-0 3 * * *}"
+        # Slack notifications (optional — alerts only sent when ENV_NAME=production)
+        if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
+            printf 'SLACK_BOT_TOKEN="%s"\n' "$SLACK_BOT_TOKEN"
+        fi
+        if [ -n "${SLACK_CHANNEL_ID:-}" ]; then
+            printf 'SLACK_CHANNEL_ID="%s"\n' "$SLACK_CHANNEL_ID"
+        fi
+        # Production-only: backup encryption + Swift/OpenStack credentials.
+        # Bundled together because the backup container needs all of them
+        # to start; omitting any one leaves the container unable to
+        # authenticate to Elastx after a restart.
+        if [ "$env_name" = "production" ]; then
+            printf 'DB_BACKUP_PASSPHRASE="%s"\n' "$DB_BACKUP_PASSPHRASE"
+            printf 'OS_AUTH_TYPE="%s"\n' "$OS_AUTH_TYPE"
+            printf 'OS_AUTH_URL="%s"\n' "$OS_AUTH_URL"
+            printf 'OS_REGION_NAME="%s"\n' "$OS_REGION_NAME"
+            printf 'OS_INTERFACE="%s"\n' "$OS_INTERFACE"
+            printf 'OS_IDENTITY_API_VERSION="%s"\n' "$OS_IDENTITY_API_VERSION"
+            printf 'OS_APPLICATION_CREDENTIAL_ID="%s"\n' "$OS_APPLICATION_CREDENTIAL_ID"
+            printf 'OS_APPLICATION_CREDENTIAL_SECRET="%s"\n' "$OS_APPLICATION_CREDENTIAL_SECRET"
+            printf 'SWIFT_CONTAINER="%s"\n' "$SWIFT_CONTAINER"
+            printf 'SWIFT_PREFIX="%s"\n' "$SWIFT_PREFIX"
+        fi
+    } > "$tmp" || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        install -m 600 "$tmp" "$target" || rc=$?
+    fi
+
+    rm -f "$tmp"
+    return "$rc"
+}

--- a/update.sh
+++ b/update.sh
@@ -70,89 +70,15 @@ if [ "${ENV_NAME:-}" = "production" ]; then
     echo "✅ All required production environment variables are set"
 fi
 
-# Create the .env file atomically with proper permissions
+# Create the .env file via the shared helper. Atomic write with mode 600.
+# See scripts/write-env.sh for the .env contract and validation logic.
+# The production-only req[] check above is update.sh-specific policy
+# (e.g. "Slack is required in production for this script") — kept here
+# rather than moving into the helper, which treats Slack as optional.
 echo "Creating .env file..."
-tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
-
-# Start with core application variables
-{
-    printf 'AUTH_GITHUB_ID="%s"\n' "${AUTH_GITHUB_ID}"
-    printf 'AUTH_GITHUB_SECRET="%s"\n' "${AUTH_GITHUB_SECRET}"
-    printf 'AUTH_GITHUB_APP_ID="%s"\n' "${AUTH_GITHUB_APP_ID}"
-    printf 'AUTH_GITHUB_APP_PRIVATE_KEY="%s"\n' "${AUTH_GITHUB_APP_PRIVATE_KEY}"
-    printf 'AUTH_GITHUB_APP_INSTALLATION_ID="%s"\n' "${AUTH_GITHUB_APP_INSTALLATION_ID}"
-    printf 'AUTH_REDIRECT_PROXY_URL="https://%s/api/auth"\n' "${DOMAIN_NAME}"
-    printf 'AUTH_SECRET="%s"\n' "${AUTH_SECRET}"
-    printf 'AUTH_TRUST_HOST=true\n'
-    printf 'AUTH_URL="https://%s/api/auth"\n' "${DOMAIN_NAME}"
-    printf 'DATABASE_URL="%s"\n' "${DATABASE_URL}"
-    printf 'DATABASE_URL_EXTERNAL="%s"\n' "${DATABASE_URL_EXTERNAL}"
-    printf 'EMAIL="%s"\n' "${EMAIL}"
-    printf 'GITHUB_ORG="%s"\n' "${GITHUB_ORG}"
-    printf 'POSTGRES_DB="%s"\n' "${POSTGRES_DB}"
-    printf 'POSTGRES_PASSWORD="%s"\n' "${POSTGRES_PASSWORD}"
-    printf 'POSTGRES_USER="%s"\n' "${POSTGRES_USER}"
-    printf 'ENV_NAME="%s"\n' "${ENV_NAME:-}"
-    # SMS configuration (conditional - only if credentials are provided)
-    if [ -n "${HELLO_SMS_USERNAME:-}" ]; then
-        printf 'HELLO_SMS_USERNAME="%s"\n' "${HELLO_SMS_USERNAME}"
-    fi
-    if [ -n "${HELLO_SMS_PASSWORD:-}" ]; then
-        printf 'HELLO_SMS_PASSWORD="%s"\n' "${HELLO_SMS_PASSWORD}"
-    fi
-    printf 'HELLO_SMS_TEST_MODE="%s"\n' "${HELLO_SMS_TEST_MODE:-true}"
-    printf 'SMS_SEND_INTERVAL="%s"\n' "${SMS_SEND_INTERVAL:-5 minutes}"
-    # SMS callback webhook secret (required for HelloSMS status callbacks in production)
-    if [ -n "${SMS_CALLBACK_SECRET:-}" ]; then
-        printf 'SMS_CALLBACK_SECRET="%s"\n' "${SMS_CALLBACK_SECRET}"
-    fi
-    # Logging configuration
-    printf 'LOG_LEVEL="%s"\n' "${LOG_LEVEL:-info}"
-    # White-label configuration (required in production)
-    printf 'NEXT_PUBLIC_BRAND_NAME="%s"\n' "${BRAND_NAME}"
-    printf 'NEXT_PUBLIC_BASE_URL="https://%s"\n' "${DOMAIN_NAME}"
-    # SMS sender name (optional - defaults to BRAND_NAME if not set)
-    if [ -n "${SMS_SENDER:-}" ]; then
-        printf 'NEXT_PUBLIC_SMS_SENDER="%s"\n' "${SMS_SENDER}"
-    fi
-    # Anonymization scheduler configuration (always enabled for GDPR compliance)
-    printf 'ANONYMIZATION_SCHEDULE="%s"\n' "${ANONYMIZATION_SCHEDULE:-0 2 * * 0}"
-    printf 'ANONYMIZATION_INACTIVE_DURATION="%s"\n' "${ANONYMIZATION_INACTIVE_DURATION:-1 year}"
-    # SMS health report schedule (daily at 8 AM Stockholm time)
-    printf 'SMS_REPORT_SCHEDULE="%s"\n' "${SMS_REPORT_SCHEDULE:-0 8 * * *}"
-    # Org membership sync schedule (daily at 3 AM Stockholm time)
-    printf 'ORG_SYNC_SCHEDULE="%s"\n' "${ORG_SYNC_SCHEDULE:-0 3 * * *}"
-    # Slack notifications (optional - alerts only sent when ENV_NAME=production)
-    if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
-        printf 'SLACK_BOT_TOKEN="%s"\n' "${SLACK_BOT_TOKEN}"
-    fi
-    if [ -n "${SLACK_CHANNEL_ID:-}" ]; then
-        printf 'SLACK_CHANNEL_ID="%s"\n' "${SLACK_CHANNEL_ID}"
-    fi
-} > "$tmp"
-
-# Add production-only backup configuration
-if [ "${ENV_NAME:-}" = "production" ]; then
-    # Database backup encryption (GDPR compliance - production only)
-    printf 'DB_BACKUP_PASSPHRASE="%s"\n' "${DB_BACKUP_PASSPHRASE}" >> "$tmp"
-    {
-        printf 'OS_AUTH_TYPE="%s"\n' "${OS_AUTH_TYPE}"
-        printf 'OS_AUTH_URL="%s"\n' "${OS_AUTH_URL}"
-        printf 'OS_REGION_NAME="%s"\n' "${OS_REGION_NAME}"
-        printf 'OS_INTERFACE="%s"\n' "${OS_INTERFACE}"
-        printf 'OS_IDENTITY_API_VERSION="%s"\n' "${OS_IDENTITY_API_VERSION}"
-        printf 'OS_APPLICATION_CREDENTIAL_ID="%s"\n' "${OS_APPLICATION_CREDENTIAL_ID}"
-        printf 'OS_APPLICATION_CREDENTIAL_SECRET="%s"\n' "${OS_APPLICATION_CREDENTIAL_SECRET}"
-        printf 'SWIFT_CONTAINER="%s"\n' "${SWIFT_CONTAINER}"
-        printf 'SWIFT_PREFIX="%s"\n' "${SWIFT_PREFIX}"
-    } >> "$tmp"
-fi
-
-# Install atomically with secure permissions (0600 = rw--------)
-install -m 600 "$tmp" "$APP_DIR/.env"
-
-# Verify .env file was created successfully
-[ -f "$APP_DIR/.env" ] || { echo "ERROR: Failed to create .env file"; exit 1; }
+# shellcheck source=scripts/write-env.sh
+source "$APP_DIR/scripts/write-env.sh"
+write_env_file "$APP_DIR/.env"
 
 # Check if migration files exist in the repository
 if [ -z "$(ls -A "$APP_DIR/migrations" 2>/dev/null)" ]; then


### PR DESCRIPTION
## What

Extracts the duplicated `.env` writing logic from `deploy.sh` and `update.sh` into a sourced shell helper at `scripts/write-env.sh`. Both scripts now do:

```bash
source "$APP_DIR/scripts/write-env.sh"
write_env_file "$APP_DIR/.env"
```

Net diff: ~140 lines removed from the two scripts, one ~140-line helper added. Single source of truth for the `.env` contract.

## Why now

PR #382 aligned the two scripts on the atomic temp-file + `install -m 600` pattern. The duplication remained — and with it, the drift surface that originally caused deploy.sh's weakness. This eliminates the duplication permanently.

## Side effects worth calling out

### 1. Latent drift fix on production init_deploy

`deploy.sh` previously omitted Swift/OpenStack vars from `.env` on production runs:
- `DB_BACKUP_PASSPHRASE`, `OS_AUTH_TYPE`, `OS_AUTH_URL`, `OS_REGION_NAME`, `OS_INTERFACE`, `OS_IDENTITY_API_VERSION`, `OS_APPLICATION_CREDENTIAL_ID`, `OS_APPLICATION_CREDENTIAL_SECRET`, `SWIFT_CONTAINER`, `SWIFT_PREFIX`

The backup container worked initially after `init_deploy` because `deploy.sh` passed those vars inline to `docker compose up -d`. But if the container ever restarted before the next routine `update.sh`, the `.env`-loaded recreation would fail to authenticate to Elastx. Latent failure mode that would have surfaced months later as "backups stopped working after some Docker restart."

The helper writes all 10 production vars unconditionally → `.env` is correct from minute zero of any production init_deploy.

### 2. `ENV_NAME` default change

Previously `update.sh` wrote `ENV_NAME=""` when the var was unset; `deploy.sh` wrote `ENV_NAME="staging"`. The helper unifies on `staging` (deploy.sh's behavior).

Impact:
- **Production / staging CD deploys**: zero impact. CD workflows always export `ENV_NAME`, so the default never fires.
- **Manual `update.sh` runs without exporting `ENV_NAME`**: `.env` now claims `staging` instead of empty. ENV_NAME-gated logic in the app (e.g. the `ENV_NAME=production` gate on Slack alerts) now treats the host as staging instead of "neither." Defensible — the prior empty-string state was arguably broken.

### 3. Workflow symmetry

Added explicit `OS_INTERFACE=public` and `OS_IDENTITY_API_VERSION=3` exports to `init_deploy.yml`'s production block.

The helper's strict validation passes today because `deploy.sh` has shell-local defaults (`OS_INTERFACE=\"${OS_INTERFACE:-public}\"`, `OS_IDENTITY_API_VERSION=\"3\"`) that the helper sees via `${!name:-}` indirect expansion. But the asymmetry — `init_deploy.yml` relied on those defaults while `continuous_deployment.yml` exported them explicitly — was a fragile implicit dependency. Now both workflows export all 10 prod vars explicitly. (One reviewer initially flagged this as a critical blocker — confirmed false-positive after walking through deploy.sh's defaults — but their underlying observation was fair.)

## Design notes (baked into the helper file)

- **No EXIT trap.** Caught during planning by codex: the previous `tmp=\"\$(mktemp)\"; trap 'rm -f \"\$tmp\"' EXIT` pattern in update.sh's pre-PR-#382 state was clobbering the script's own pre-existing `trap cleanup EXIT`. Helper uses explicit `rm -f \"\$tmp\"` after `install -m 600` instead.
- **No shell options leak.** Helper does not call `set -e/-u/-o pipefail` — those belong to callers, not a sourced library.
- **Two-layer validation.** Helper validates the `.env`-contract vars (required for any environment, plus the production-only block). Callers keep their script-specific policy — e.g. update.sh's \"Slack is required in production\" `req[]` array stays in update.sh, because that's update.sh's deployment policy, not a `.env`-contract concern.
- **Atomic write.** `mktemp` → printf block → `install -m 600` → `rm -f`. Identical to update.sh's pattern in #382, just shared.
- **Indirect expansion in validator.** `_write_env_require` uses `\${!name:-}` to read named vars by name. Bash-only; both callers are `#!/bin/bash`.

## Verification

Local:
- 6 test cases pass: staging output shape, production output shape, missing-required-var fast-fail, missing-prod-var fast-fail, optional-key inclusion-when-set, EXIT-trap preservation across helper call. (Throwaway test, not committed — manual pre-merge gate.)
- `bash -n` passes on all three modified shell files.

Reviewed by:
- **Codex (planning)** — approved location, function shape, Option A scope, no-trap pattern, ENV_NAME default
- **Codex (delta)** — confirmed plan fidelity; flagged ENV_NAME change for PR description (incorporated above)
- **Claude subagent (helper correctness)** — verdict: ship it
- **Claude subagent (E2E + production safety)** — initially flagged a critical blocker (false-positive on `OS_INTERFACE` exports); the underlying asymmetry observation was fair and is addressed in the symmetry fix above

## Test ladder (same as #382's)

1. **Local** ✅ done
2. **Merge → auto staging deploy** runs `update.sh` with new helper (real Ubuntu)
3. **Manually trigger `init_deploy.yml` against staging** to test the fresh-install path with the helper + the new symmetry fix
4. **Approve production deploy**

I'll run the same 6 verification checks against staging and prod after each step lands.