### PR TITLE
fix(deps): patch postcss XSS and uuid bounds-check vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         "eslint-config-next": "15.5.14",
         "happy-dom": "^20.8.9",
         "jsdom": "^26.1.0",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.10",
         "postcss-preset-mantine": "^1.18.0",
         "postcss-simple-vars": "^7.0.1",
         "prettier": "3.7.4",
@@ -114,7 +114,9 @@
             "yaml": ">=2.8.3",
             "brace-expansion": ">=5.0.5",
             "picomatch": ">=4.0.4",
-            "dompurify": ">=3.4.0"
+            "dompurify": ">=3.4.0",
+            "postcss": ">=8.5.10",
+            "uuid": ">=14.0.0"
         }
     },
     "packageManager": "pnpm@10.29.3+sha512.498e1fb4cca5aa06c1dcf2611e6fafc50972ffe7189998c409e90de74566444298ffe43e6cd2acdc775ba1aa7cc5e092a8b7054c811ba8c5770f84693d33d2dc"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,8 @@ overrides:
   brace-expansion: '>=5.0.5'
   picomatch: '>=4.0.4'
   dompurify: '>=3.4.0'
+  postcss: '>=8.5.10'
+  uuid: '>=14.0.0'
 
 importers:
 
@@ -170,7 +172,7 @@ importers:
         version: 8.50.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^5.1.2
-        version: 5.1.2(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.20.6))
+        version: 5.1.2(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.20.6))
       '@vitest/ui':
         specifier: ^4.1.3
         version: 4.1.3(vitest@4.1.3)
@@ -190,14 +192,14 @@ importers:
         specifier: ^26.1.0
         version: 26.1.0
       postcss:
-        specifier: ^8.5.6
-        version: 8.5.6
+        specifier: '>=8.5.10'
+        version: 8.5.10
       postcss-preset-mantine:
         specifier: ^1.18.0
-        version: 1.18.0(postcss@8.5.6)
+        version: 1.18.0(postcss@8.5.10)
       postcss-simple-vars:
         specifier: ^7.0.1
-        version: 7.0.1(postcss@8.5.6)
+        version: 7.0.1(postcss@8.5.10)
       prettier:
         specifier: 3.7.4
         version: 3.7.4
@@ -206,10 +208,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.2
-        version: 7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.20.6)
+        version: 7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.20.6)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/ui@4.1.3)(happy-dom@20.8.9)(jsdom@26.1.0)(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.20.6))
+        version: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/ui@4.1.3)(happy-dom@20.8.9)(jsdom@26.1.0)(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.20.6))
 
 packages:
 
@@ -3626,24 +3628,24 @@ packages:
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: ^8.4.21
+      postcss: '>=8.5.10'
 
   postcss-mixins@12.1.2:
     resolution: {integrity: sha512-90pSxmZVfbX9e5xCv7tI5RV1mnjdf16y89CJKbf/hD7GyOz1FCxcYMl8ZYA8Hc56dbApTKKmU9HfvgfWdCxlwg==}
     engines: {node: ^20.0 || ^22.0 || >=24.0}
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: '>=8.5.10'
 
   postcss-nested@7.0.2:
     resolution: {integrity: sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==}
     engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: '>=8.5.10'
 
   postcss-preset-mantine@1.18.0:
     resolution: {integrity: sha512-sP6/s1oC7cOtBdl4mw/IRKmKvYTuzpRrH/vT6v9enMU/EQEQ31eQnHcWtFghOXLH87AAthjL/Q75rLmin1oZoA==}
     peerDependencies:
-      postcss: '>=8.0.0'
+      postcss: '>=8.5.10'
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -3653,14 +3655,10 @@ packages:
     resolution: {integrity: sha512-5GLLXaS8qmzHMOjVxqkk1TZPf1jMqesiI7qLhnlyERalG0sMbHIbJqrcnrpmZdKCLglHnRHoEBB61RtGTsj++A==}
     engines: {node: '>=14.0'}
     peerDependencies:
-      postcss: ^8.2.1
+      postcss: '>=8.5.10'
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -4076,7 +4074,7 @@ packages:
     resolution: {integrity: sha512-ctS5RYCBVvPoZAnzIaX5QSShK8ZiZxD5HUqSxlusvEMC+QZQIPCPOIJg6aceFX+K2rf4+SH89eu++h1Zmsr2nw==}
     engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.3.3
+      postcss: '>=8.5.10'
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4284,8 +4282,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   victory-vendor@37.3.6:
@@ -5984,7 +5982,7 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@5.1.2(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.20.6))':
+  '@vitejs/plugin-react@5.1.2(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.20.6))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -5992,7 +5990,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.20.6)
+      vite: 7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.20.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -6005,13 +6003,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.3(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.20.6))':
+  '@vitest/mocker@4.1.3(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.20.6))':
     dependencies:
       '@vitest/spy': 4.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.20.6)
+      vite: 7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.20.6)
 
   '@vitest/pretty-format@4.1.3':
     dependencies:
@@ -6040,7 +6038,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/ui@4.1.3)(happy-dom@20.8.9)(jsdom@26.1.0)(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.20.6))
+      vitest: 4.1.3(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/ui@4.1.3)(happy-dom@20.8.9)(jsdom@26.1.0)(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.20.6))
 
   '@vitest/utils@4.1.3':
     dependencies:
@@ -7537,7 +7535,7 @@ snapshots:
       roughjs: 4.6.6
       stylis: 4.3.6
       ts-dedent: 2.2.0
-      uuid: 11.1.0
+      uuid: 14.0.0
 
   micromatch@4.0.8:
     dependencies:
@@ -7603,7 +7601,7 @@ snapshots:
       '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001787
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
@@ -7857,46 +7855,40 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-js@4.0.1(postcss@8.5.6):
+  postcss-js@4.0.1(postcss@8.5.10):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-mixins@12.1.2(postcss@8.5.6):
+  postcss-mixins@12.1.2(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
-      postcss-js: 4.0.1(postcss@8.5.6)
-      postcss-simple-vars: 7.0.1(postcss@8.5.6)
-      sugarss: 5.0.1(postcss@8.5.6)
+      postcss: 8.5.10
+      postcss-js: 4.0.1(postcss@8.5.10)
+      postcss-simple-vars: 7.0.1(postcss@8.5.10)
+      sugarss: 5.0.1(postcss@8.5.10)
       tinyglobby: 0.2.15
 
-  postcss-nested@7.0.2(postcss@8.5.6):
+  postcss-nested@7.0.2(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.1
 
-  postcss-preset-mantine@1.18.0(postcss@8.5.6):
+  postcss-preset-mantine@1.18.0(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
-      postcss-mixins: 12.1.2(postcss@8.5.6)
-      postcss-nested: 7.0.2(postcss@8.5.6)
+      postcss: 8.5.10
+      postcss-mixins: 12.1.2(postcss@8.5.10)
+      postcss-nested: 7.0.2(postcss@8.5.10)
 
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-simple-vars@7.0.1(postcss@8.5.6):
+  postcss-simple-vars@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -8390,9 +8382,9 @@ snapshots:
 
   stylis@4.3.6: {}
 
-  sugarss@5.0.1(postcss@8.5.6):
+  sugarss@5.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
   supports-color@7.2.0:
     dependencies:
@@ -8609,7 +8601,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@11.1.0: {}
+  uuid@14.0.0: {}
 
   victory-vendor@37.3.6:
     dependencies:
@@ -8628,25 +8620,25 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.20.6):
+  vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.20.6):
     dependencies:
       esbuild: 0.27.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.10
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.0.3
       fsevents: 2.3.3
       jiti: 1.21.7
-      sugarss: 5.0.1(postcss@8.5.6)
+      sugarss: 5.0.1(postcss@8.5.10)
       tsx: 4.20.6
 
-  vitest@4.1.3(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/ui@4.1.3)(happy-dom@20.8.9)(jsdom@26.1.0)(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.20.6)):
+  vitest@4.1.3(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(@vitest/ui@4.1.3)(happy-dom@20.8.9)(jsdom@26.1.0)(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.20.6)):
     dependencies:
       '@vitest/expect': 4.1.3
-      '@vitest/mocker': 4.1.3(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.20.6))
+      '@vitest/mocker': 4.1.3(vite@7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.20.6))
       '@vitest/pretty-format': 4.1.3
       '@vitest/runner': 4.1.3
       '@vitest/snapshot': 4.1.3
@@ -8663,7 +8655,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.6))(tsx@4.20.6)
+      vite: 7.3.2(@types/node@25.0.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.10))(tsx@4.20.6)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
## Why

Two moderate Dependabot alerts on `pnpm-lock.yaml`:

| # | Package | Vulnerable | Patched | Issue |
|---|---|---|---|---|
| 77 | `uuid` | `< 14.0.0` | `14.0.0` | Missing buffer bounds check in v3/v5/v6 when `buf` is provided |
| 78 | `postcss` | `< 8.5.10` | `8.5.10` | XSS via unescaped `</style>` in CSS stringify output |

## What

**`postcss`** appeared twice in the tree:
- Direct devDep at `8.5.6` → bumped to `^8.5.10` in `package.json`.
- Transitive `8.4.31` pinned by `next@15.5.15`. Added a `pnpm.overrides` entry `"postcss": ">=8.5.10"` so the Next-bundled copy also resolves past the patch line.

**`uuid`** came in only transitively at `11.1.0` from `mermaid@11.14.0`. Added `"uuid": ">=14.0.0"` to `pnpm.overrides`.

After the change the lockfile contains exactly one copy of each package: `postcss@8.5.10` and `uuid@14.0.0`.

## Compatibility

uuid v14 is ESM-only and a major version bump from v11. Verified safe here because mermaid is the only consumer and it imports just `{ v4 }`. `v4`:

- is still a top-level named export in v14 (`dist/index.js` re-exports it),
- is **not** the function affected by the CVE (the bug is in `v3`/`v5`/`v6` when called with a `buf` argument).

postcss `8.5.10` is a patch release; same CJS/ESM shape and same peer surface as `8.5.6`.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm build` — succeeds
- `pnpm test:unit` — 1067/1067 passing