### PR TITLE
ci: enable Dependabot version updates for github-actions and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+# Dependabot configuration.
+#
+# Vulnerability alerts at the repo level already cover security CVEs
+# across all ecosystems automatically. This config adds routine
+# (non-CVE) version updates for the two ecosystems where staying
+# current matters: github-actions and npm.
+#
+# Both use weekly grouping to keep PR volume manageable for a single
+# operator: one PR per week per ecosystem (or per group within an
+# ecosystem) instead of one PR per dependency.
+
+version: 2
+updates:
+    # GitHub Actions: small list of ~10 pinned action SHAs. Grouped into
+    # one weekly PR. Major bumps are NOT separated — the immediate
+    # motivating case is the June 2026 Node 24 forced switch, which
+    # manifests as v4→v5 majors on several actions (actions/checkout
+    # etc.) and we want those in the weekly bundle. When a major bump
+    # arrives, review more carefully (release notes + staging-as-canary
+    # ladder) before merging.
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      groups:
+          github-actions:
+              patterns:
+                  - "*"
+
+    # npm: large dependency tree. Split into two groups so the easy
+    # bumps stay easy and the risky ones get a focused review:
+    #   - "minor-and-patch": bundled into one weekly PR. Usually pass
+    #     CI cleanly; merge after green build.
+    #   - Major bumps fall outside the group → one PR per major. These
+    #     are the ones that may have breaking changes and warrant
+    #     reading release notes / running staging before merge.
+    - package-ecosystem: "npm"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      groups:
+          minor-and-patch:
+              update-types:
+                  - "minor"
+                  - "patch"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` to enable Dependabot **version updates** for two ecosystems:
- `github-actions` (~10 pinned action SHAs)
- `npm` (full dependency tree)

Both use weekly grouping to keep PR volume manageable for a single operator.

## Why

Repo-level vulnerability alerts already cover security CVEs automatically. That handles "a known vulnerability published, you need to patch." It does NOT handle:

- Non-CVE bugfixes in libraries you depend on
- Compatibility fixes for newer Node/Next.js/etc.
- Version-drift debt that compounds over time (18-month-old Next.js is harder to upgrade than three smaller hops)
- The June 2026 forced switch to Node 24, which will affect every action currently pinned at v3/v4 in this repo

This adds a low-touch maintenance loop: Dependabot watches both ecosystems, opens grouped PRs weekly, you review and merge.

## Configuration choices

### github-actions

- **Single grouped PR per week** bundling all ~10 pinned actions.
- **Major bumps NOT separated** — the immediate motivating case (Node 24 deprecation) requires v4→v5 majors on several actions (`actions/checkout` etc.). Bundling them is what we want, not 10 individual PRs.
- When a major shows up, read the release notes + run the standard staging-as-canary ladder before merging.

### npm

- **Two PR streams**, split by risk:
  - **\`minor-and-patch\` group** → one weekly PR with all minor + patch updates. Usually passes CI clean; merge after green build.
  - **Major bumps fall outside the group** → one PR per major. These may have breaking changes; review release notes and run the staging-as-canary ladder before merging.

This keeps review effort proportionate to risk: most weekly PRs are trivial green-CI merges, and the rare major-bump PR is the one that gets focused attention.

## Expected volume after this lands

- **First Dependabot run** (whenever scheduled, typically within 24h of merge):
  - One github-actions PR bumping the ~10 pinned actions
  - One \`minor-and-patch\` npm PR with the current minor+patch backlog
  - Possibly several major-bump npm PRs (for any that have accumulated)

- **Steady state**: ~2 weekly grouped PRs + occasional major-bump PRs.

## Why npm is included (rejected the alternative)

I initially drafted this without npm, on the theory that the dependency tree is large and weekly version-bump PRs would be noise for a one-operator NGO. After feedback, I think that framing was too conservative.

The grouping makes the noise manageable, the maintenance hygiene benefit is real, and npm-skipped means you only learn about libraries when CVEs fire — which is reactive, not preventive. Including npm is the right call for an actively-maintained project.

If npm PRs end up being too noisy in practice, the config is one PR away from being trimmed (e.g. limiting to certain top-level packages, or extending the schedule to monthly).

## Verification

- It's YAML, no executable code. Schema is the standard Dependabot v2 spec.
- No existing Dependabot config to conflict with — the file is new.
- Repo-level vulnerability alerts (already enabled) are unaffected — they live separately.