### PR TITLE
Keep nginx running across deploys to avoid full outage on abort

### DIFF
--- a/docs/database-guide.md
+++ b/docs/database-guide.md
@@ -124,6 +124,45 @@ This runs all pending migrations against the database.
 docker exec -it matkassen-db psql -U matkassen -d matkassen -c "\d households"
 ```
 
+## Deploy-Window Backward Compatibility
+
+Schema migrations run _during_ deployment, while nginx keeps serving
+traffic from the new web container. There is a window — from when the
+new container becomes healthy until `drizzle-kit migrate` finishes —
+where the new code runs against the old schema. This window can be up
+to 5 minutes for slow migrations (the timeout in `update.sh`).
+
+**Rule: every migration must be additive and backward-compatible with the
+previous deploy's code.** Specifically:
+
+Safe in a single migration:
+
+- Add a new column that is nullable, or has a default value
+- Add a new table, index, function, or view
+- Drop a column _only if_ the previous deploy already stopped reading and
+  writing it
+
+Will break users mid-deploy if shipped in a single migration:
+
+- Drop or rename a column the previous deploy's code still reads
+- Add `NOT NULL` to an existing column without a default
+- Change a column's type (`ALTER COLUMN ... TYPE`)
+- Drop or rename a table the previous deploy's code still references
+
+For breaking changes, use the **expand → migrate → contract** pattern
+across two deploys:
+
+1. **Expand:** add the new column/table alongside the old one. Code
+   reads old, writes both. Deploy.
+2. **Migrate (data):** backfill the new column from the old one. Run
+   as a separate migration or background job once expand is in prod.
+3. **Contract:** switch code to read the new, stop writing the old,
+   then drop the old in a follow-up migration. Deploy.
+
+This rule is enforced socially today; a future PR may add a CI guard
+that greps generated SQL for destructive DDL. The corresponding
+deploy-side logic lives in `update.sh` near the migration step.
+
 ## Custom Migrations
 
 For seed data, complex DDL, or data transformations:

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -5,9 +5,15 @@
 # Rate limiting zone (must be in http context)
 limit_req_zone $binary_remote_addr zone=app:10m rate=50r/s;
 
-# Upstream configuration for Next.js app with health checks and failover
+# Upstream configuration for Next.js app with health checks and failover.
+# fail_timeout=5s keeps the upstream-blacklist window short during deploys:
+# when the web container is recreated, port 3000 is briefly unbound, and
+# nginx may rack up max_fails connection-refused errors. With fail_timeout
+# at 5s (down from the default 30s), the upstream recovers within seconds
+# of the new container coming up, instead of users seeing 30s of guaranteed
+# 502s after the container is back.
 upstream nextjs_backend {
-    server ${NEXTJS_UPSTREAM}:3000 max_fails=3 fail_timeout=30s;
+    server ${NEXTJS_UPSTREAM}:3000 max_fails=3 fail_timeout=5s;
     keepalive 32;
 }
 

--- a/nginx/shared.conf
+++ b/nginx/shared.conf
@@ -43,5 +43,13 @@ proxy_http_version 1.1;
 proxy_cache_bypass $http_upgrade;
 proxy_buffering off;
 
+# Fail fast on connection-refused (Next.js container being recreated)
+# rather than waiting the default 60s for connect timeout. Combined with
+# proxy_next_upstream below, prepares the upstream block to retry/failover
+# cleanly if a second backend is ever added; today there is one upstream
+# so the practical effect is just the tighter timeout.
+proxy_connect_timeout 2s;
+proxy_next_upstream error timeout http_502 http_503;
+
 # Strip internal nonce header before sending to client
 proxy_hide_header x-nonce;

--- a/update.sh
+++ b/update.sh
@@ -36,10 +36,33 @@ echo "🔒 Deployment lock acquired"
 NGINX_WAS_ACTIVE=0
 sudo systemctl is-active --quiet nginx && NGINX_WAS_ACTIVE=1
 
+# Notify Slack on deploy failure. Token is only exported by the
+# production workflow, so this no-ops on staging and on hosts where
+# the env vars aren't set.
+notify_slack_failure() {
+    local rc=$1
+    [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${SLACK_CHANNEL_ID:-}" ] || return 0
+    local host
+    host=$(hostname)
+    local msg="[matkassen] ❌ Deploy failed (exit ${rc}) on ${host}. Site stays up on previous container; nginx restart attempted by trap. Check GH Actions logs."
+    curl -sS https://slack.com/api/chat.postMessage \
+        -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+        -H "Content-type: application/json; charset=utf-8" \
+        --data "{\"channel\":\"${SLACK_CHANNEL_ID}\",\"text\":\"${msg}\"}" \
+        | grep -q '"ok":true' || true
+}
+
 cleanup() {
+    local rc=$?
     echo "🔓 Releasing deployment lock"
-    if [ "$NGINX_WAS_ACTIVE" -eq 1 ]; then
+    # Use ${VAR:-0} defensively in case an early abort fires the trap
+    # before NGINX_WAS_ACTIVE is initialized (set -u would otherwise
+    # error inside the trap and mask the real exit code).
+    if [ "${NGINX_WAS_ACTIVE:-0}" -eq 1 ]; then
         sudo systemctl is-active --quiet nginx || sudo systemctl start nginx || true
+    fi
+    if [ "$rc" -ne 0 ]; then
+        notify_slack_failure "$rc"
     fi
 }
 trap cleanup EXIT
@@ -105,11 +128,19 @@ echo "Updating nginx configuration..."
 cd "$APP_DIR"
 chmod +x nginx/generate-nginx-config.sh
 
-sudo rm -f /etc/nginx/conf.d/matkassen-http.conf
-sudo rm -f /etc/nginx/sites-enabled/*
-./nginx/generate-nginx-config.sh production "$DOMAIN_NAME www.$DOMAIN_NAME" "$DOMAIN_NAME" | sudo tee /etc/nginx/sites-available/default > /dev/null
-sudo ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
+# Write the new sites-available config first (always complete on disk),
+# then atomically point sites-enabled at it via `ln -sfn`. The replace
+# is a single rename(2) call — no window where sites-enabled is empty,
+# so an unrelated nginx reload during this section can't pick up an
+# empty config. The active nginx process keeps its previous config in
+# memory until the explicit reload further below.
+./nginx/generate-nginx-config.sh production "$DOMAIN_NAME www.$DOMAIN_NAME" "$DOMAIN_NAME" \
+    | sudo tee /etc/nginx/sites-available/default > /dev/null
 sudo cp nginx/shared.conf /etc/nginx/shared.conf
+sudo ln -sfn /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
+
+# Drop legacy config from earlier deploy patterns (no-op once retired).
+sudo rm -f /etc/nginx/conf.d/matkassen-http.conf
 
 echo "Validating nginx configuration..."
 sudo nginx -t
@@ -170,12 +201,17 @@ fi
 
 # Run migrations now that containers are healthy. Nginx has been serving
 # traffic throughout this deploy (to keep the site up on failure), which
-# means there is a brief window where the new web container is healthy
-# but the schema is still on the old version. Schema migrations must
-# therefore be backward-compatible with the previous code for the
-# duration of the deploy window — i.e. additive changes only, no
-# destructive DDL until the next deploy. For breaking schema changes,
-# use the expand → migrate → contract pattern across two deploys.
+# means there is a window where the NEW web container code runs against
+# the OLD schema — for as long as the migration takes (up to the 300s
+# timeout on the docker exec below). New code reading a column that
+# doesn't exist yet returns 5xx for those routes during that window.
+#
+# Rule: schema migrations must be backward-compatible with the previous
+# code for the duration of the deploy window — i.e. additive changes
+# only (new columns nullable or with defaults; new tables; new indexes).
+# For breaking schema changes (drop/rename column, NOT NULL on existing,
+# type changes), split into two deploys: expand → migrate → contract.
+# See docs/database-guide.md for the full rule.
 echo "Waiting for database to be ready..."
 cd "$APP_DIR"
 timeout 60 sudo docker compose exec -T db bash -c "while ! pg_isready -U $POSTGRES_USER -d $POSTGRES_DB; do echo 'Waiting for DB...'; sleep 1; done"
@@ -225,10 +261,15 @@ fi
 # Apply the new nginx configuration: reload if running, start if not.
 # Reload swaps config atomically with no dropped connections. Start (with
 # enable) is the bootstrap path — first ever deploy or recovery from an
-# unexpected stop.
+# unexpected stop. On reload failure, dump the journal so the cause is
+# visible in CI logs (old workers keep serving the previous config).
 echo "Applying nginx configuration..."
 if sudo systemctl is-active --quiet nginx; then
-    sudo systemctl reload nginx
+    if ! sudo systemctl reload nginx; then
+        echo "❌ Nginx reload failed — recent journal entries:"
+        sudo journalctl -u nginx -n 20 --no-pager
+        exit 1
+    fi
     echo "✅ Nginx reloaded with new configuration"
 else
     sudo systemctl start nginx

--- a/update.sh
+++ b/update.sh
@@ -30,9 +30,17 @@ if ! flock -n 200; then
 fi
 echo "🔒 Deployment lock acquired"
 
-# Cleanup function to release lock on exit
+# Capture nginx state so the EXIT trap can restore it if the deploy aborts.
+# Without this, a failed deploy (e.g. healthcheck timeout, migration error)
+# leaves nginx stopped and the site fully down until manual recovery.
+NGINX_WAS_ACTIVE=0
+sudo systemctl is-active --quiet nginx && NGINX_WAS_ACTIVE=1
+
 cleanup() {
     echo "🔓 Releasing deployment lock"
+    if [ "$NGINX_WAS_ACTIVE" -eq 1 ]; then
+        sudo systemctl is-active --quiet nginx || sudo systemctl start nginx || true
+    fi
 }
 trap cleanup EXIT
 
@@ -87,55 +95,22 @@ if [ -z "$(ls -A "$APP_DIR/migrations" 2>/dev/null)" ]; then
   exit 1
 fi
 
-# Generate nginx configuration from template
-echo "Generating nginx configuration..."
+# Generate nginx configuration from template.
+# Nginx stays running throughout the deploy so the site doesn't go fully
+# dark on failure: it keeps serving the old web container (or returns
+# brief 502s during the container recreate window) instead of refusing
+# connections. Files are written in place; nginx picks them up via
+# `systemctl reload` after migrations succeed.
+echo "Updating nginx configuration..."
 cd "$APP_DIR"
 chmod +x nginx/generate-nginx-config.sh
 
-# Ensure clean nginx state before applying new configuration
-echo "Setting up clean nginx configuration..."
-sudo systemctl stop nginx || true
-# Wait for systemd to fully stop nginx
-sleep 2
-# Force kill any lingering nginx processes (use exact match to avoid killing pkill itself)
-sudo pkill -9 -x nginx || true
-# Wait for ports to be fully released
-sleep 2
-# Verify ports 80 and 443 are free (log if not)
-PORT_CHECK_LOG="$(sudo ss -tulpn | grep -E ':80 |:443 ' 2>&1 || true)"
-if [ -n "$PORT_CHECK_LOG" ]; then
-    echo "⚠️ Warning: Ports 80/443 still in use after stopping nginx:"
-    echo "$PORT_CHECK_LOG"
-    echo "Waiting additional 5 seconds for ports to clear..."
-    sleep 5
-
-    # Re-check after wait - log if still in use but continue (retry logic will handle)
-    PORT_CHECK_LOG2="$(sudo ss -tulpn | grep -E ':80 |:443 ' 2>&1 || true)"
-    if [ -n "$PORT_CHECK_LOG2" ]; then
-        echo "⚠️ Warning: Ports STILL in use after 9 seconds total wait:"
-        echo "$PORT_CHECK_LOG2"
-        echo "Continuing deployment - nginx retry logic will handle port conflicts if they persist."
-    else
-        echo "✅ Ports 80/443 are now free"
-    fi
-fi
-
-# Clean slate - remove all existing site configurations
-echo "Removing old nginx configurations..."
 sudo rm -f /etc/nginx/conf.d/matkassen-http.conf
 sudo rm -f /etc/nginx/sites-enabled/*
-
-# Apply fresh configuration
-echo "Generating nginx configuration..."
 ./nginx/generate-nginx-config.sh production "$DOMAIN_NAME www.$DOMAIN_NAME" "$DOMAIN_NAME" | sudo tee /etc/nginx/sites-available/default > /dev/null
-echo "Creating nginx symlink..."
-# Remove existing symlink explicitly (in case wildcard rm failed for any reason)
-sudo rm -f /etc/nginx/sites-enabled/default
 sudo ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
-echo "Copying shared nginx config..."
 sudo cp nginx/shared.conf /etc/nginx/shared.conf
 
-# Test config (but don't start nginx yet - wait for Docker first)
 echo "Validating nginx configuration..."
 sudo nginx -t
 echo "✅ Nginx configuration updated and validated"
@@ -193,10 +168,14 @@ if ! timeout 60 bash -c '
     exit 1
 fi
 
-# Run migrations before opening nginx to public traffic.
-# Containers are healthy at this point (web health check passes with SELECT 1),
-# but nginx is still down so no public requests can reach the new code yet.
-# This ensures the schema is always up to date before any user traffic arrives.
+# Run migrations now that containers are healthy. Nginx has been serving
+# traffic throughout this deploy (to keep the site up on failure), which
+# means there is a brief window where the new web container is healthy
+# but the schema is still on the old version. Schema migrations must
+# therefore be backward-compatible with the previous code for the
+# duration of the deploy window — i.e. additive changes only, no
+# destructive DDL until the next deploy. For breaking schema changes,
+# use the expand → migrate → contract pattern across two deploys.
 echo "Waiting for database to be ready..."
 cd "$APP_DIR"
 timeout 60 sudo docker compose exec -T db bash -c "while ! pg_isready -U $POSTGRES_USER -d $POSTGRES_DB; do echo 'Waiting for DB...'; sleep 1; done"
@@ -243,37 +222,19 @@ if [ "${ENV_NAME:-}" = "production" ]; then
   fi
 fi
 
-# Now start nginx — schema is up to date, safe to accept public traffic
-echo "Starting nginx..."
-NGINX_START_ATTEMPTS=0
-MAX_NGINX_ATTEMPTS=3
-
-while [ $NGINX_START_ATTEMPTS -lt $MAX_NGINX_ATTEMPTS ]; do
-    if sudo systemctl start nginx; then
-        echo "✅ Nginx started successfully"
-        sudo systemctl enable nginx  # Ensure it's enabled
-        break
-    else
-        NGINX_START_ATTEMPTS=$((NGINX_START_ATTEMPTS + 1))
-        echo "⚠️ Nginx failed to start (attempt $NGINX_START_ATTEMPTS/$MAX_NGINX_ATTEMPTS)"
-
-        # Log what's using the ports
-        echo "Checking what's using ports 80/443..."
-        sudo ss -tulpn | grep -E ':80 |:443 ' || echo "No processes found on ports 80/443"
-
-        # Log recent nginx errors
-        echo "Recent nginx logs:"
-        sudo journalctl -u nginx -n 20 --no-pager
-
-        if [ $NGINX_START_ATTEMPTS -lt $MAX_NGINX_ATTEMPTS ]; then
-            echo "Waiting 5 seconds before retry..."
-            sleep 5
-        else
-            echo "❌ Failed to start nginx after $MAX_NGINX_ATTEMPTS attempts"
-            exit 1
-        fi
-    fi
-done
+# Apply the new nginx configuration: reload if running, start if not.
+# Reload swaps config atomically with no dropped connections. Start (with
+# enable) is the bootstrap path — first ever deploy or recovery from an
+# unexpected stop.
+echo "Applying nginx configuration..."
+if sudo systemctl is-active --quiet nginx; then
+    sudo systemctl reload nginx
+    echo "✅ Nginx reloaded with new configuration"
+else
+    sudo systemctl start nginx
+    sudo systemctl enable nginx
+    echo "✅ Nginx started"
+fi
 
 # Cleanup old Docker images and containers (but keep recent build cache)
 echo "Cleaning up old Docker resources..."


### PR DESCRIPTION
## Why

A recent failed production deploy left nginx stopped for ~12 minutes because `update.sh` was stopping nginx upfront and only starting it again after a successful healthcheck. Any abort path between those two steps left the site fully dark until manual recovery.

## Root cause

The upfront nginx stop had no technical justification:

- Nginx runs on the host; web binds `127.0.0.1:3000`. No port conflict possible.
- Cert renewal is handled by a separate cron with its own pre/post hooks (`deploy.sh`), not invoked from `update.sh`.
- The aggressive `pkill -9 -x nginx` + port-clearing logic was defending against a state that doesn't occur.

## What changes

### Outage profile

| | Before | After |
|---|---|---|
| Deploy success | 30–90s site down (full stop → recreate → migrate → start) | ~5–15s of brief 502s during container recreate (`fail_timeout=5s`) |
| Deploy failure (any abort) | **Site fully down until manual recovery** | Site stays responsive on the previous code; trap restarts nginx; Slack alert fires |

### Core deploy resilience (commit 1)

- **Capture nginx state, restore it on EXIT.** New `NGINX_WAS_ACTIVE` variable + cleanup function. Any abort path now restarts nginx if it was running when the deploy began.
- **Drop the upfront stop-then-kill-then-clear-ports block.** Config files are written in place; nginx serves the old config from memory until reloaded.
- **Replace start-with-3-retries with reload-or-start.** Reload swaps config atomically with no dropped connections. Start (with enable) is only the bootstrap path.

### Review-feedback fixes (commit 2)

After review by four reviewers (two codex MCP sessions, two general-purpose agents):

- **Atomic symlink swap.** `ln -sfn` instead of `rm sites-enabled/* + ln -s` closes the brief window where `/etc/nginx/sites-enabled/` would be empty.
- **Defensive `${NGINX_WAS_ACTIVE:-0}` in cleanup.** Guards against an early abort firing the trap before the variable is initialized (would otherwise error under `set -u` and mask the real exit code).
- **Tighter migration-window comment.** The risk is *new code on old schema* (5xx for routes touching unmigrated columns, for up to the 300s migration timeout), not the previously-documented inverse direction.
- **Slack failure notification.** Reuses `SLACK_BOT_TOKEN` already exported in the production deploy job. Fixes the silent-failure mode where a failed deploy leaves the site running on the previous container with only the GH Actions red badge as signal.
- **Reload-failure log dump.** On `systemctl reload nginx` failure, print the journal tail before exiting. Old workers keep serving with the previous config; this surfaces the cause without rollback ambiguity.
- **Recreate-window smoothing.** `fail_timeout` on the upstream block lowered from 30s to 5s — the upstream is back in rotation almost immediately after the new container is up. `proxy_connect_timeout 2s` and `proxy_next_upstream` directives added in `shared.conf`.
- **`docs/database-guide.md`** gets a new "Deploy-Window Backward Compatibility" section spelling out the rule, the safe vs unsafe patterns, and the expand → migrate → contract workflow.

### Same fix applies to staging

`continuous_deployment.yml` runs the same `update.sh` path with `ENV_NAME=staging` — no env-specific guard on the previous stop-nginx logic. Slack notification only fires for production (token only exported there).

### Deferred to a separate PR

A CI guard that greps `migrations/*.sql` for destructive DDL patterns and fails the build with a clear "use expand → contract" message. Pattern selection (DROP COLUMN vs DROP CONSTRAINT vs ALTER COLUMN ... TYPE), false-positive handling, and override mechanism need scoping first.