### PR TITLE
Fix household parcel validation to only validate changed future parcels

### DIFF
--- a/__tests__/app/households/parcels/actions.test.ts
+++ b/__tests__/app/households/parcels/actions.test.ts
@@ -12,6 +12,8 @@ import type { FoodParcels } from "@/app/[locale]/households/enroll/types";
 // Track database operations for verification
 let insertedParcels: any[] = [];
 let deleteCalled = false;
+let existingFutureParcels: any[] = [];
+let softDeletedParcelIds: string[] = [];
 
 // Mock the database module
 vi.mock("@/app/db/drizzle", () => {
@@ -28,7 +30,7 @@ vi.mock("@/app/db/drizzle", () => {
         }),
         select: vi.fn(() => ({
             from: vi.fn(() => ({
-                where: vi.fn(() => Promise.resolve([])), // No existing parcels by default
+                where: vi.fn(() => Promise.resolve(existingFutureParcels)),
             })),
         })),
         insert: vi.fn((table: any) => ({
@@ -86,6 +88,17 @@ vi.mock("@/app/[locale]/schedule/actions", () => ({
     recomputeOutsideHoursCount: vi.fn(async () => {}),
 }));
 
+vi.mock("@/app/utils/parcels/state-transitions", () => ({
+    createParcels: vi.fn(async (_tx: unknown, args: { parcels: any[] }) => {
+        insertedParcels.push(...args.parcels);
+        return [];
+    }),
+    softDeleteParcelLenient: vi.fn(async (_tx: unknown, args: { parcelId: string }) => {
+        softDeletedParcelIds.push(args.parcelId);
+        return { skipped: false };
+    }),
+}));
+
 describe("updateHouseholdParcels - Same-day parcel handling", () => {
     const testHouseholdId = "test-household-123";
     const testLocationId = "test-location-456";
@@ -93,6 +106,8 @@ describe("updateHouseholdParcels - Same-day parcel handling", () => {
     beforeEach(() => {
         // Reset tracking arrays
         insertedParcels = [];
+        existingFutureParcels = [];
+        softDeletedParcelIds = [];
         vi.clearAllMocks();
     });
 
@@ -388,10 +403,9 @@ describe("updateHouseholdParcels - Same-day parcel handling", () => {
             const result = await updateHouseholdParcels(testHouseholdId, parcelsData);
 
             expect(result.success).toBe(true);
-            // Both parcels should be inserted:
-            // 1. The past parcel (has id, allowed to be updated)
-            // 2. The future parcel (new, in the future)
-            expect(insertedParcels).toHaveLength(2);
+            // Historical persisted parcels are kept in the submitted form data for display,
+            // but they are not part of the editable future schedule and must not be reinserted.
+            expect(insertedParcels).toHaveLength(1);
             // Find the future parcel (should be the one with future time)
             const futureParcel = insertedParcels.find(
                 p => p.pickup_date_time_earliest.getTime() === futureStart.getTime(),
@@ -403,7 +417,7 @@ describe("updateHouseholdParcels - Same-day parcel handling", () => {
         }
     });
 
-    it("should treat persisted parcels with past pickup times as existing during validation", async () => {
+    it("should skip schedule validation for persisted parcels with past pickup times", async () => {
         const { updateHouseholdParcels } =
             await import("@/app/[locale]/households/[id]/parcels/actions");
         const scheduleActions = await import("@/app/[locale]/schedule/actions");
@@ -421,13 +435,6 @@ describe("updateHouseholdParcels - Same-day parcel handling", () => {
             const pastEnd = new Date(now);
             pastEnd.setHours(14, 0, 0, 0);
 
-            validateParcelAssignmentsMock.mockImplementationOnce(async parcels => {
-                expect(parcels).toHaveLength(1);
-                expect(parcels[0].id).toBe("existing-parcel-id");
-                expect(parcels[0].pickupEndTime <= now).toBe(true);
-                return { success: true, errors: [] };
-            });
-
             const parcelsData: FoodParcels = {
                 pickupLocationId: testLocationId,
                 parcels: [
@@ -443,9 +450,162 @@ describe("updateHouseholdParcels - Same-day parcel handling", () => {
             const result = await updateHouseholdParcels(testHouseholdId, parcelsData);
 
             expect(result.success).toBe(true);
+            expect(validateParcelAssignmentsMock).not.toHaveBeenCalled();
+            expect(insertedParcels).toHaveLength(0);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("should not validate or reinsert unchanged future parcels", async () => {
+        const { updateHouseholdParcels } =
+            await import("@/app/[locale]/households/[id]/parcels/actions");
+        const scheduleActions = await import("@/app/[locale]/schedule/actions");
+        const validateParcelAssignmentsMock = vi.mocked(scheduleActions.validateParcelAssignments);
+
+        const now = new Date();
+        now.setHours(10, 0, 0, 0);
+
+        vi.useFakeTimers();
+        vi.setSystemTime(now);
+
+        try {
+            const futureStart = new Date(now);
+            futureStart.setDate(futureStart.getDate() + 1);
+            futureStart.setHours(12, 0, 0, 0);
+            const futureEnd = new Date(futureStart);
+            futureEnd.setMinutes(futureEnd.getMinutes() + 30);
+
+            existingFutureParcels = [
+                {
+                    id: "existing-future-parcel",
+                    locationId: testLocationId,
+                    earliest: futureStart,
+                    latest: futureEnd,
+                },
+            ];
+
+            const parcelsData: FoodParcels = {
+                pickupLocationId: testLocationId,
+                parcels: [
+                    {
+                        id: "existing-future-parcel",
+                        pickupDate: futureStart,
+                        pickupEarliestTime: futureStart,
+                        pickupLatestTime: futureEnd,
+                    },
+                ],
+            };
+
+            const result = await updateHouseholdParcels(testHouseholdId, parcelsData);
+
+            expect(result.success).toBe(true);
+            expect(validateParcelAssignmentsMock).not.toHaveBeenCalled();
+            expect(insertedParcels).toHaveLength(0);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("should validate changed existing future parcels with their existing id", async () => {
+        const { updateHouseholdParcels } =
+            await import("@/app/[locale]/households/[id]/parcels/actions");
+        const scheduleActions = await import("@/app/[locale]/schedule/actions");
+        const validateParcelAssignmentsMock = vi.mocked(scheduleActions.validateParcelAssignments);
+
+        const now = new Date();
+        now.setHours(10, 0, 0, 0);
+
+        vi.useFakeTimers();
+        vi.setSystemTime(now);
+
+        try {
+            const originalStart = new Date(now);
+            originalStart.setDate(originalStart.getDate() + 1);
+            originalStart.setHours(12, 0, 0, 0);
+            const originalEnd = new Date(originalStart);
+            originalEnd.setMinutes(originalEnd.getMinutes() + 30);
+
+            const changedStart = new Date(originalStart);
+            changedStart.setHours(13, 0, 0, 0);
+            const changedEnd = new Date(changedStart);
+            changedEnd.setMinutes(changedEnd.getMinutes() + 30);
+
+            existingFutureParcels = [
+                {
+                    id: "existing-future-parcel",
+                    locationId: testLocationId,
+                    earliest: originalStart,
+                    latest: originalEnd,
+                },
+            ];
+
+            validateParcelAssignmentsMock.mockImplementationOnce(async parcels => {
+                expect(parcels).toHaveLength(1);
+                expect(parcels[0].id).toBe("existing-future-parcel");
+                expect(parcels[0].pickupStartTime).toEqual(changedStart);
+                return { success: true, errors: [] };
+            });
+
+            const parcelsData: FoodParcels = {
+                pickupLocationId: testLocationId,
+                parcels: [
+                    {
+                        id: "existing-future-parcel",
+                        pickupDate: changedStart,
+                        pickupEarliestTime: changedStart,
+                        pickupLatestTime: changedEnd,
+                    },
+                ],
+            };
+
+            const result = await updateHouseholdParcels(testHouseholdId, parcelsData);
+
+            expect(result.success).toBe(true);
             expect(validateParcelAssignmentsMock).toHaveBeenCalledTimes(1);
-            const callArgs = validateParcelAssignmentsMock.mock.calls[0][0];
-            expect(callArgs[0].id).toBe("existing-parcel-id");
+            expect(insertedParcels).toHaveLength(1);
+            expect(softDeletedParcelIds).toEqual(["existing-future-parcel"]);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("should soft-delete future parcels removed from the desired schedule", async () => {
+        const { updateHouseholdParcels } =
+            await import("@/app/[locale]/households/[id]/parcels/actions");
+
+        const now = new Date();
+        now.setHours(10, 0, 0, 0);
+
+        vi.useFakeTimers();
+        vi.setSystemTime(now);
+
+        try {
+            const removedStart = new Date(now);
+            removedStart.setDate(removedStart.getDate() + 1);
+            removedStart.setHours(12, 0, 0, 0);
+            const removedEnd = new Date(removedStart);
+            removedEnd.setMinutes(removedEnd.getMinutes() + 30);
+
+            existingFutureParcels = [
+                {
+                    id: "removed-future-parcel",
+                    locationId: testLocationId,
+                    earliest: removedStart,
+                    latest: removedEnd,
+                },
+            ];
+
+            const parcelsData: FoodParcels = {
+                pickupLocationId: testLocationId,
+                parcels: [],
+            };
+
+            const result = await updateHouseholdParcels(testHouseholdId, parcelsData);
+
+            expect(result.success).toBe(true);
+            expect(insertedParcels).toHaveLength(0);
+            expect(softDeletedParcelIds).toEqual(["removed-future-parcel"]);
         } finally {
             vi.useRealTimers();
         }
@@ -506,6 +666,68 @@ describe("updateHouseholdParcels - Same-day parcel handling", () => {
                 );
             }
             expect(insertedParcels).toHaveLength(0);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("should ignore stale historical parcels and validate only the newly added future parcel", async () => {
+        const { updateHouseholdParcels } =
+            await import("@/app/[locale]/households/[id]/parcels/actions");
+        const scheduleActions = await import("@/app/[locale]/schedule/actions");
+        const validateParcelAssignmentsMock = vi.mocked(scheduleActions.validateParcelAssignments);
+
+        const now = new Date("2026-05-05T10:00:00Z");
+        vi.useFakeTimers();
+        vi.setSystemTime(now);
+
+        try {
+            const historicalParcels = [
+                new Date("2026-02-10T12:00:00Z"),
+                new Date("2026-02-24T12:00:00Z"),
+                new Date("2026-03-10T12:00:00Z"),
+            ].map((start, index) => {
+                const end = new Date(start);
+                end.setHours(14, 0, 0, 0);
+
+                return {
+                    id: `historical-${index}`,
+                    pickupDate: start,
+                    pickupEarliestTime: start,
+                    pickupLatestTime: end,
+                };
+            });
+
+            const futureStart = new Date("2026-05-15T12:00:00Z");
+            const futureEnd = new Date("2026-05-15T14:00:00Z");
+
+            validateParcelAssignmentsMock.mockImplementationOnce(async parcels => {
+                expect(parcels).toHaveLength(1);
+                expect(parcels[0].id).toBeUndefined();
+                expect(parcels[0].pickupStartTime).toEqual(futureStart);
+                expect(parcels[0].pickupEndTime).toEqual(futureEnd);
+                return { success: true, errors: [] };
+            });
+
+            const parcelsData: FoodParcels = {
+                pickupLocationId: testLocationId,
+                parcels: [
+                    ...historicalParcels,
+                    {
+                        pickupDate: futureStart,
+                        pickupEarliestTime: futureStart,
+                        pickupLatestTime: futureEnd,
+                    },
+                ],
+            };
+
+            const result = await updateHouseholdParcels(testHouseholdId, parcelsData);
+
+            expect(result.success).toBe(true);
+            expect(validateParcelAssignmentsMock).toHaveBeenCalledTimes(1);
+            expect(insertedParcels).toHaveLength(1);
+            expect(insertedParcels[0].pickup_date_time_earliest).toEqual(futureStart);
+            expect(softDeletedParcelIds).toHaveLength(0);
         } finally {
             vi.useRealTimers();
         }

--- a/__tests__/app/households/parcels/location-change.test.ts
+++ b/__tests__/app/households/parcels/location-change.test.ts
@@ -238,9 +238,9 @@ describe("updateHouseholdParcels - Location Changes", () => {
 
             expect(result.success).toBe(true);
 
-            // Parcel should be inserted (upsert will skip due to conflict, which is correct)
-            expect(insertedParcels).toHaveLength(1);
-            expect(insertedParcels[0].pickup_location_id).toBe(locationA);
+            // Unchanged future parcels are already in the desired state, so the
+            // diff-based action should neither reinsert nor delete them.
+            expect(insertedParcels).toHaveLength(0);
 
             // The existing parcel should NOT be marked for deletion
             // because it matches the desired state (same location + times)
@@ -386,10 +386,10 @@ describe("updateHouseholdParcels - Location Changes", () => {
 
             expect(result.success).toBe(true);
 
-            // Should insert 2 parcels at location A
-            expect(insertedParcels).toHaveLength(2);
+            // The unchanged location A parcel is already in the desired state.
+            // Only the location B -> A change should be inserted.
+            expect(insertedParcels).toHaveLength(1);
             expect(insertedParcels[0].pickup_location_id).toBe(locationA);
-            expect(insertedParcels[1].pickup_location_id).toBe(locationA);
 
             // The parcel at location B with slot2 times should be deleted
             // because desired key is "locationA-slot2times" but existing is "locationB-slot2times"

--- a/__tests__/app/households/parcels/past-parcel-prevention.test.ts
+++ b/__tests__/app/households/parcels/past-parcel-prevention.test.ts
@@ -206,9 +206,9 @@ describe("Past Parcel Prevention - Backend Validation", () => {
         // Should succeed (existing parcels can be updated)
         expect(result.success).toBe(true);
 
-        // Should insert/update the parcel
-        expect(insertedParcels.length).toBe(1);
-        expect(insertedParcels[0].pickup_date_time_earliest).toEqual(pastTime);
+        // Historical persisted parcels are allowed to remain in form data,
+        // but they are not part of the editable future schedule.
+        expect(insertedParcels.length).toBe(0);
 
         vi.useRealTimers();
     });

--- a/app/[locale]/households/[id]/parcels/actions.ts
+++ b/app/[locale]/households/[id]/parcels/actions.ts
@@ -24,6 +24,8 @@ export const updateHouseholdParcels = protectedAdminHouseholdAction(
             // Start transaction to ensure all related data is updated atomically
             await db.transaction(async tx => {
                 const now = new Date();
+                const parcelKey = (locationId: string, earliest: Date, latest: Date) =>
+                    `${locationId}-${earliest.toISOString()}-${latest.toISOString()}`;
 
                 // Validate that NEW parcels are not in the past
                 // (Existing parcels can remain even if they become past)
@@ -50,69 +52,12 @@ export const updateHouseholdParcels = protectedAdminHouseholdAction(
                     );
                 }
 
-                // Create new food parcels based on the updated schedule
-                if (parcelsData.parcels && parcelsData.parcels.length > 0) {
-                    // Validate all parcel assignments before creating any
-                    const { validateParcelAssignments } =
-                        await import("@/app/[locale]/schedule/actions");
-
-                    const parcelsToValidate = parcelsData.parcels
-                        .filter(parcel => parcel.pickupLatestTime > now || parcel.id) // Future parcels OR existing parcels being updated
-                        .map(parcel => ({
-                            id: parcel.id,
-                            householdId: household.id,
-                            locationId: parcelsData.pickupLocationId,
-                            pickupDate: new Date(parcel.pickupDate),
-                            pickupStartTime: parcel.pickupEarliestTime,
-                            pickupEndTime: parcel.pickupLatestTime,
-                        }));
-
-                    if (parcelsToValidate.length > 0) {
-                        const validationResult = await validateParcelAssignments(
-                            parcelsToValidate,
-                            tx,
-                        );
-
-                        if (!validationResult.success) {
-                            // Throw to trigger transaction rollback
-                            throw new ParcelValidationError(
-                                "Parcel validation failed",
-                                validationResult.errors || [],
-                            );
-                        }
-                    }
-
-                    // Filter to only future parcels (but allow existing parcels to be updated even if past)
-                    const parcelsToSave = parcelsData.parcels
-                        .filter(parcel => parcel.pickupLatestTime > now || parcel.id)
-                        .map(parcel => ({
-                            household_id: household.id,
-                            pickup_location_id: parcelsData.pickupLocationId,
-                            pickup_date_time_earliest: parcel.pickupEarliestTime,
-                            pickup_date_time_latest: parcel.pickupLatestTime,
-                            is_picked_up: false,
-                        }));
-
-                    // Route through the parcel state-transitions helper so all
-                    // mutations of food_parcels go through one place.
-                    const { createParcels } = await import("@/app/utils/parcels/state-transitions");
-                    await createParcels(tx, { parcels: parcelsToSave, session });
-                }
-
-                // Delete parcels that are no longer in the desired schedule
-                // This handles cases where the user removed parcels or changed locations
-                // We do this AFTER the insert to avoid a window where no parcels exist
-                // Key includes location to properly handle location changes
-                const desiredParcelKeys = new Set(
-                    parcelsData.parcels
-                        .filter(p => p.pickupLatestTime > now)
-                        .map(
-                            p =>
-                                `${parcelsData.pickupLocationId}-${p.pickupEarliestTime.toISOString()}-${p.pickupLatestTime.toISOString()}`,
-                        ),
+                const desiredFutureParcels = parcelsData.parcels.filter(
+                    parcel => parcel.pickupLatestTime > now,
                 );
 
-                // Get all existing future parcels for this household
+                // Get all existing future parcels for this household. Historical rows are displayed
+                // by the form, but they are not part of the editable future schedule.
                 const existingFutureParcels = await tx
                     .select({
                         id: foodParcels.id,
@@ -129,14 +74,79 @@ export const updateHouseholdParcels = protectedAdminHouseholdAction(
                         ),
                     );
 
+                const existingFutureKeys = new Set(
+                    existingFutureParcels.map(p => parcelKey(p.locationId, p.earliest, p.latest)),
+                );
+
+                const parcelsToCreate = desiredFutureParcels.filter(
+                    parcel =>
+                        !existingFutureKeys.has(
+                            parcelKey(
+                                parcelsData.pickupLocationId,
+                                parcel.pickupEarliestTime,
+                                parcel.pickupLatestTime,
+                            ),
+                        ),
+                );
+
+                // Create new/changed future food parcels based on the updated schedule.
+                // Unchanged future rows and historical rows are not revalidated.
+                if (parcelsToCreate.length > 0) {
+                    const { validateParcelAssignments } =
+                        await import("@/app/[locale]/schedule/actions");
+
+                    const parcelsToValidate = parcelsToCreate.map(parcel => ({
+                        id: parcel.id,
+                        householdId: household.id,
+                        locationId: parcelsData.pickupLocationId,
+                        pickupDate: new Date(parcel.pickupDate),
+                        pickupStartTime: parcel.pickupEarliestTime,
+                        pickupEndTime: parcel.pickupLatestTime,
+                    }));
+
+                    const validationResult = await validateParcelAssignments(parcelsToValidate, tx);
+
+                    if (!validationResult.success) {
+                        // Throw to trigger transaction rollback
+                        throw new ParcelValidationError(
+                            "Parcel validation failed",
+                            validationResult.errors || [],
+                        );
+                    }
+
+                    const parcelsToSave = parcelsToCreate.map(parcel => ({
+                        household_id: household.id,
+                        pickup_location_id: parcelsData.pickupLocationId,
+                        pickup_date_time_earliest: parcel.pickupEarliestTime,
+                        pickup_date_time_latest: parcel.pickupLatestTime,
+                        is_picked_up: false,
+                    }));
+
+                    // Route through the parcel state-transitions helper so all
+                    // mutations of food_parcels go through one place.
+                    const { createParcels } = await import("@/app/utils/parcels/state-transitions");
+                    await createParcels(tx, { parcels: parcelsToSave, session });
+                }
+
+                // Delete parcels that are no longer in the desired schedule
+                // This handles cases where the user removed parcels or changed locations
+                // We do this AFTER the insert to avoid a window where no parcels exist
+                // Key includes location to properly handle location changes
+                const desiredParcelKeys = new Set(
+                    desiredFutureParcels.map(p =>
+                        parcelKey(
+                            parcelsData.pickupLocationId,
+                            p.pickupEarliestTime,
+                            p.pickupLatestTime,
+                        ),
+                    ),
+                );
+
                 // Soft delete parcels that are not in the desired schedule
                 // This preserves audit trail, keeps public QR code links working,
                 // and handles SMS cancellation intelligently
                 const parcelsToDelete = existingFutureParcels.filter(
-                    p =>
-                        !desiredParcelKeys.has(
-                            `${p.locationId}-${p.earliest.toISOString()}-${p.latest.toISOString()}`,
-                        ),
+                    p => !desiredParcelKeys.has(parcelKey(p.locationId, p.earliest, p.latest)),
                 );
 
                 if (parcelsToDelete.length > 0) {

--- a/app/[locale]/households/enroll/components/FoodParcelsForm.tsx
+++ b/app/[locale]/households/enroll/components/FoodParcelsForm.tsx
@@ -68,6 +68,8 @@ interface FoodParcelsFormProps {
     }>;
 }
 
+type ParcelValidationError = NonNullable<FoodParcelsFormProps["validationErrors"]>[number];
+
 export default function FoodParcelsForm({
     data,
     updateData,
@@ -1037,6 +1039,112 @@ export default function FoodParcelsForm({
         setBulkTimeError(null);
     };
 
+    const numberDetail = (value: unknown): number | null => {
+        const parsed =
+            typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+
+        return Number.isFinite(parsed) ? parsed : null;
+    };
+
+    const formatValidationErrorMessage = (error: ParcelValidationError): string => {
+        const details = error.details ?? {};
+        const date = typeof details.date === "string" ? details.date : "";
+        const timeSlot = typeof details.timeSlot === "string" ? details.timeSlot : "";
+        const current = numberDetail(details.current);
+        const maximum = numberDetail(details.maximum);
+
+        if (
+            (error.code === "MAX_DAILY_CAPACITY_REACHED" || error.code === "CAPACITY_REACHED") &&
+            date &&
+            current !== null &&
+            maximum !== null
+        ) {
+            return t("validationErrors.capacityReachedDetailed", {
+                date,
+                current,
+                maximum,
+            });
+        }
+
+        if (error.code === "MAX_DAILY_CAPACITY_REACHED" || error.code === "CAPACITY_REACHED") {
+            return t("validationErrors.capacityReached");
+        }
+
+        if (
+            (error.code === "MAX_SLOT_CAPACITY_REACHED" ||
+                error.code === "SLOT_CAPACITY_REACHED") &&
+            date &&
+            timeSlot &&
+            current !== null &&
+            maximum !== null
+        ) {
+            return t("validationErrors.slotCapacityReachedDetailed", {
+                date,
+                timeSlot,
+                current,
+                maximum,
+            });
+        }
+
+        if (error.code === "MAX_SLOT_CAPACITY_REACHED" || error.code === "SLOT_CAPACITY_REACHED") {
+            return t("validationErrors.slotCapacityReached");
+        }
+
+        if (
+            (error.code === "HOUSEHOLD_DOUBLE_BOOKING" ||
+                error.code === "DOUBLE_BOOKING" ||
+                error.code === "TIME_SLOT_CONFLICT") &&
+            date
+        ) {
+            return t("validationErrors.doubleBookingDetailed", { date });
+        }
+
+        if (
+            error.code === "HOUSEHOLD_DOUBLE_BOOKING" ||
+            error.code === "DOUBLE_BOOKING" ||
+            error.code === "TIME_SLOT_CONFLICT"
+        ) {
+            return t("validationErrors.doubleBooking");
+        }
+
+        if (error.code === "OUTSIDE_OPERATING_HOURS" || error.code === "OUTSIDE_OPENING_HOURS") {
+            return t("validationErrors.outsideOperatingHours");
+        }
+
+        if (error.code === "PAST_TIME_SLOT" || error.code === "PAST_PICKUP_TIME") {
+            return t("validationErrors.pastTimeSlot");
+        }
+
+        if (error.code === "LOCATION_NOT_FOUND") {
+            return t("validationErrors.locationNotFound");
+        }
+
+        if (error.code === "PARCEL_NOT_FOUND") {
+            return t("validationErrors.parcelNotFound");
+        }
+
+        return error.code
+            ? t("validationErrors.unknownWithCode", { code: error.code })
+            : t("validationErrors.unknown");
+    };
+
+    const validationErrorSummaries = Array.from(
+        (validationErrors ?? [])
+            .reduce((summaries, error) => {
+                const message = formatValidationErrorMessage(error);
+                const existing = summaries.get(message);
+
+                if (existing) {
+                    existing.count += 1;
+                } else {
+                    summaries.set(message, { message, count: 1 });
+                }
+
+                return summaries;
+            }, new Map<string, { message: string; count: number }>())
+            .values(),
+    );
+
     return (
         <Card withBorder p="md" radius="md">
             <Title order={3} mb="md">
@@ -1090,41 +1198,13 @@ export default function FoodParcelsForm({
                                 {t("validationErrors.title", { default: "Validation Errors" })}
                             </Text>
                         </Group>
-                        {validationErrors.map(error => {
-                            // Map error codes to i18n keys
-                            let errorMessage = error.message;
-
-                            // Try to translate based on error code
-                            const errorCodeMap: Record<
-                                string,
-                                | "validationErrors.pastTimeSlot"
-                                | "validationErrors.capacityReached"
-                                | "validationErrors.slotCapacityReached"
-                                | "validationErrors.doubleBooking"
-                                | "validationErrors.outsideOperatingHours"
-                            > = {
-                                PAST_TIME_SLOT: "validationErrors.pastTimeSlot",
-                                PAST_PICKUP_TIME: "validationErrors.pastTimeSlot",
-                                CAPACITY_REACHED: "validationErrors.capacityReached",
-                                SLOT_CAPACITY_REACHED: "validationErrors.slotCapacityReached",
-                                DOUBLE_BOOKING: "validationErrors.doubleBooking",
-                                OUTSIDE_OPENING_HOURS: "validationErrors.outsideOperatingHours",
-                            };
-
-                            if (error.code && errorCodeMap[error.code]) {
-                                // Type is safe because errorCodeMap values are string literal types
-                                // that match the translation keys
-                                errorMessage = t(errorCodeMap[error.code]);
-                            }
-
+                        {validationErrorSummaries.map(({ message, count }) => {
                             return (
-                                <Text
-                                    key={`${error.field}-${error.code}`}
-                                    size="sm"
-                                    c="red"
-                                    ml="lg"
-                                >
-                                    • {errorMessage}
+                                <Text key={message} size="sm" c="red" ml="lg">
+                                    • {message}
+                                    {count > 1
+                                        ? ` ${t("validationErrors.repeated", { count })}`
+                                        : ""}
                                 </Text>
                             );
                         })}

--- a/components/ParcelManagementForm/ParcelManagementForm.tsx
+++ b/components/ParcelManagementForm/ParcelManagementForm.tsx
@@ -117,12 +117,8 @@ export function ParcelManagementForm({
 
                     // Show error toast
                     notifications.show({
-                        title: tParcel("actions.back").includes("Tillbaka")
-                            ? "Kunde inte spara"
-                            : "Could not save",
-                        message: tParcel("actions.back").includes("Tillbaka")
-                            ? "Paket kunde inte sparas på grund av valideringsfel"
-                            : "Parcels could not be saved due to validation errors",
+                        title: tParcel("validation.title"),
+                        message: tParcel("validation.description"),
                         color: "red",
                         icon: <IconAlertCircle size="1rem" />,
                         autoClose: 5000,

--- a/messages/en.json
+++ b/messages/en.json
@@ -406,10 +406,18 @@
         "validationErrors": {
             "title": "Validation Errors",
             "capacityReached": "Location capacity exceeded for selected date",
+            "capacityReachedDetailed": "Location capacity is full on {date}: {current} of {maximum} parcels are already booked",
             "slotCapacityReached": "Time slot is fully booked",
+            "slotCapacityReachedDetailed": "Time slot {timeSlot} on {date} is fully booked: {current} of {maximum} parcels are already booked",
             "doubleBooking": "Household already has a parcel scheduled for this date",
+            "doubleBookingDetailed": "Household already has a parcel scheduled for {date}",
             "outsideOperatingHours": "Selected time is outside operating hours",
-            "pastTimeSlot": "Cannot schedule pickup in the past"
+            "pastTimeSlot": "Cannot schedule pickup in the past",
+            "locationNotFound": "Pickup location could not be found",
+            "parcelNotFound": "Parcel could not be found",
+            "unknown": "The selected parcel schedule could not be saved",
+            "unknownWithCode": "The selected parcel schedule could not be saved. Validation code: {code}",
+            "repeated": "({count} times)"
         }
     },
     "review": {

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -406,10 +406,18 @@
         "validationErrors": {
             "title": "Valideringsfel",
             "capacityReached": "Platsens kapacitet överskriden för valt datum",
+            "capacityReachedDetailed": "Platsens kapacitet är full den {date}: {current} av {maximum} matkassar är redan bokade",
             "slotCapacityReached": "Tidssloten är fullbokad",
+            "slotCapacityReachedDetailed": "Tidssloten {timeSlot} den {date} är fullbokad: {current} av {maximum} matkassar är redan bokade",
             "doubleBooking": "Hushållet har redan en matkasse schemalagd för detta datum",
+            "doubleBookingDetailed": "Hushållet har redan en matkasse schemalagd den {date}",
             "outsideOperatingHours": "Vald tid är utanför öppettider",
-            "pastTimeSlot": "Kan inte schemalägga upphämtning i det förflutna"
+            "pastTimeSlot": "Kan inte schemalägga upphämtning i det förflutna",
+            "locationNotFound": "Hämtplatsen kunde inte hittas",
+            "parcelNotFound": "Matkassen kunde inte hittas",
+            "unknown": "Det valda matkasseschemat kunde inte sparas",
+            "unknownWithCode": "Det valda matkasseschemat kunde inte sparas. Valideringskod: {code}",
+            "repeated": "({count} gånger)"
         }
     },
     "review": {


### PR DESCRIPTION
## Summary

Fixes the household parcel save flow so historical parcels and unchanged future parcels do not get revalidated when staff adds, moves, or removes food parcels.

The previous flow treated every submitted parcel with an `id` as something to validate and recreate. That meant old picked-up/no-show parcels could still trigger capacity validation for dates that are already full, blocking unrelated future changes such as adding a new food parcel on a selectable date.

This PR changes the household parcel action to diff the desired future parcel set against currently persisted future parcels:

- new or changed future parcels are validated and inserted
- unchanged future parcels are left as-is and not revalidated
- future parcels removed from the form are soft-deleted
- historical parcels are ignored by the save diff so they cannot block future scheduling

It also improves validation feedback in the UI:

- validation toasts use i18n instead of hardcoded language checks
- server validation error codes are mapped to clearer English and Swedish messages
- duplicate validation messages are consolidated while still showing all distinct errors

## Coverage

Added and updated regression coverage for the real household parcel scenarios:

- adding a new future parcel while stale historical parcels exist
- a prod-like case with multiple historical parcels plus a new May 15 parcel
- unchanged future parcels not being revalidated or recreated
- changed future parcels validating only the replacement
- removed future parcels being soft-deleted
- location-change behavior only inserting the changed parcel
- existing historical parcels not causing inserts, while newly submitted past parcels remain rejected

## Validation

- `pnpm test __tests__/app/households/parcels/actions.test.ts __tests__/app/households/parcels/location-change.test.ts __tests__/app/households/parcels/past-parcel-prevention.test.ts`
- `pnpm run validate`
- pre-push hook: `pnpm test` and `pnpm run validate` passed on the rebased branch: 150 test files, 1618 tests passed, 1 skipped