### PR TITLE
Preserve parcel ids when moving household parcels

### DIFF
--- a/__tests__/app/households/parcels/actions.test.ts
+++ b/__tests__/app/households/parcels/actions.test.ts
@@ -14,6 +14,7 @@ let insertedParcels: any[] = [];
 let deleteCalled = false;
 let existingFutureParcels: any[] = [];
 let softDeletedParcelIds: string[] = [];
+let updatedParcels: any[] = [];
 
 // Mock the database module
 vi.mock("@/app/db/drizzle", () => {
@@ -44,6 +45,14 @@ vi.mock("@/app/db/drizzle", () => {
                     })),
                 };
             }),
+        })),
+        update: vi.fn(() => ({
+            set: vi.fn((values: any) => ({
+                where: vi.fn(() => {
+                    updatedParcels.push(values);
+                    return Promise.resolve();
+                }),
+            })),
         })),
         execute: vi.fn(async () => {
             // Mock execute for any raw SQL queries
@@ -99,6 +108,10 @@ vi.mock("@/app/utils/parcels/state-transitions", () => ({
     }),
 }));
 
+vi.mock("@/app/utils/sms/sms-service", () => ({
+    queuePickupUpdatedSms: vi.fn(async () => ({ success: true })),
+}));
+
 describe("updateHouseholdParcels - Same-day parcel handling", () => {
     const testHouseholdId = "test-household-123";
     const testLocationId = "test-location-456";
@@ -108,6 +121,7 @@ describe("updateHouseholdParcels - Same-day parcel handling", () => {
         insertedParcels = [];
         existingFutureParcels = [];
         softDeletedParcelIds = [];
+        updatedParcels = [];
         vi.clearAllMocks();
     });
 
@@ -507,11 +521,13 @@ describe("updateHouseholdParcels - Same-day parcel handling", () => {
         }
     });
 
-    it("should validate changed existing future parcels with their existing id", async () => {
+    it("should validate and update changed existing future parcels with their existing id", async () => {
         const { updateHouseholdParcels } =
             await import("@/app/[locale]/households/[id]/parcels/actions");
         const scheduleActions = await import("@/app/[locale]/schedule/actions");
+        const smsService = await import("@/app/utils/sms/sms-service");
         const validateParcelAssignmentsMock = vi.mocked(scheduleActions.validateParcelAssignments);
+        const queuePickupUpdatedSmsMock = vi.mocked(smsService.queuePickupUpdatedSms);
 
         const now = new Date();
         now.setHours(10, 0, 0, 0);
@@ -563,8 +579,15 @@ describe("updateHouseholdParcels - Same-day parcel handling", () => {
 
             expect(result.success).toBe(true);
             expect(validateParcelAssignmentsMock).toHaveBeenCalledTimes(1);
-            expect(insertedParcels).toHaveLength(1);
-            expect(softDeletedParcelIds).toEqual(["existing-future-parcel"]);
+            expect(insertedParcels).toHaveLength(0);
+            expect(updatedParcels).toHaveLength(1);
+            expect(updatedParcels[0]).toMatchObject({
+                pickup_location_id: testLocationId,
+                pickup_date_time_earliest: changedStart,
+                pickup_date_time_latest: changedEnd,
+            });
+            expect(softDeletedParcelIds).toHaveLength(0);
+            expect(queuePickupUpdatedSmsMock).toHaveBeenCalledWith("existing-future-parcel");
         } finally {
             vi.useRealTimers();
         }

--- a/__tests__/app/households/parcels/location-change.test.ts
+++ b/__tests__/app/households/parcels/location-change.test.ts
@@ -15,6 +15,7 @@ import type { FoodParcels } from "@/app/[locale]/households/enroll/types";
 let insertedParcels: any[] = [];
 let deletedParcelIds: string[] = [];
 let existingParcels: any[] = [];
+let updatedParcels: any[] = [];
 
 // Mock the database module with location-aware logic
 vi.mock("@/app/db/drizzle", () => {
@@ -30,10 +31,11 @@ vi.mock("@/app/db/drizzle", () => {
             }),
         })),
         update: vi.fn(() => ({
-            set: vi.fn(() => ({
+            set: vi.fn((values: any) => ({
                 where: vi.fn((condition: any) => {
                     // Mock soft delete via update - track the operation
                     // In real implementation, this would set deleted_at and deleted_by_user_id
+                    updatedParcels.push(values);
                     return Promise.resolve();
                 }),
             })),
@@ -124,6 +126,7 @@ describe("updateHouseholdParcels - Location Changes", () => {
         insertedParcels = [];
         deletedParcelIds = [];
         existingParcels = [];
+        updatedParcels = [];
         vi.clearAllMocks();
     });
 
@@ -163,6 +166,7 @@ describe("updateHouseholdParcels - Location Changes", () => {
                 pickupLocationId: locationB, // Changed from A to B
                 parcels: [
                     {
+                        id: "existing-parcel-123",
                         pickupDate: tomorrow,
                         pickupEarliestTime: pickupStart,
                         pickupLatestTime: pickupEnd,
@@ -176,16 +180,13 @@ describe("updateHouseholdParcels - Location Changes", () => {
             // Verify the result was successful
             expect(result.success).toBe(true);
 
-            // Verify new parcel was inserted with location B
-            expect(insertedParcels).toHaveLength(1);
-            expect(insertedParcels[0].pickup_location_id).toBe(locationB);
-            expect(insertedParcels[0].pickup_date_time_earliest).toEqual(pickupStart);
-            expect(insertedParcels[0].pickup_date_time_latest).toEqual(pickupEnd);
-
-            // The key insight: The old parcel at location A should be identified for deletion
-            // because the deletion logic now includes location in the key
-            // (We can't easily verify the delete was called with the right ID in this mock setup,
-            // but the logic builds desiredParcelKeys with location included)
+            // Existing future parcels keep their ID when moved, so sent reminders
+            // can produce pickup_updated SMS instead of cancellation semantics.
+            expect(insertedParcels).toHaveLength(0);
+            expect(updatedParcels).toHaveLength(1);
+            expect(updatedParcels[0].pickup_location_id).toBe(locationB);
+            expect(updatedParcels[0].pickup_date_time_earliest).toEqual(pickupStart);
+            expect(updatedParcels[0].pickup_date_time_latest).toEqual(pickupEnd);
         } finally {
             vi.useRealTimers();
         }
@@ -227,6 +228,7 @@ describe("updateHouseholdParcels - Location Changes", () => {
                 pickupLocationId: locationA, // Same location
                 parcels: [
                     {
+                        id: "existing-parcel-123",
                         pickupDate: tomorrow,
                         pickupEarliestTime: pickupStart,
                         pickupLatestTime: pickupEnd,
@@ -241,6 +243,7 @@ describe("updateHouseholdParcels - Location Changes", () => {
             // Unchanged future parcels are already in the desired state, so the
             // diff-based action should neither reinsert nor delete them.
             expect(insertedParcels).toHaveLength(0);
+            expect(updatedParcels).toHaveLength(0);
 
             // The existing parcel should NOT be marked for deletion
             // because it matches the desired state (same location + times)
@@ -294,11 +297,13 @@ describe("updateHouseholdParcels - Location Changes", () => {
                 pickupLocationId: locationB,
                 parcels: [
                     {
+                        id: "parcel-1",
                         pickupDate: tomorrow,
                         pickupEarliestTime: slot1Start,
                         pickupLatestTime: slot1End,
                     },
                     {
+                        id: "parcel-2",
                         pickupDate: tomorrow,
                         pickupEarliestTime: slot2Start,
                         pickupLatestTime: slot2End,
@@ -310,12 +315,11 @@ describe("updateHouseholdParcels - Location Changes", () => {
 
             expect(result.success).toBe(true);
 
-            // Should insert 2 new parcels at location B
-            expect(insertedParcels).toHaveLength(2);
-            expect(insertedParcels[0].pickup_location_id).toBe(locationB);
-            expect(insertedParcels[1].pickup_location_id).toBe(locationB);
-
-            // Both old parcels at location A should be identified for deletion
+            // Should update both existing parcels in place.
+            expect(insertedParcels).toHaveLength(0);
+            expect(updatedParcels).toHaveLength(2);
+            expect(updatedParcels[0].pickup_location_id).toBe(locationB);
+            expect(updatedParcels[1].pickup_location_id).toBe(locationB);
         } finally {
             vi.useRealTimers();
         }
@@ -370,11 +374,13 @@ describe("updateHouseholdParcels - Location Changes", () => {
                 pickupLocationId: locationA,
                 parcels: [
                     {
+                        id: "parcel-1",
                         pickupDate: tomorrow,
                         pickupEarliestTime: slot1Start,
                         pickupLatestTime: slot1End,
                     },
                     {
+                        id: "parcel-2",
                         pickupDate: dayAfterTomorrow,
                         pickupEarliestTime: slot2Start,
                         pickupLatestTime: slot2End,
@@ -387,12 +393,10 @@ describe("updateHouseholdParcels - Location Changes", () => {
             expect(result.success).toBe(true);
 
             // The unchanged location A parcel is already in the desired state.
-            // Only the location B -> A change should be inserted.
-            expect(insertedParcels).toHaveLength(1);
-            expect(insertedParcels[0].pickup_location_id).toBe(locationA);
-
-            // The parcel at location B with slot2 times should be deleted
-            // because desired key is "locationA-slot2times" but existing is "locationB-slot2times"
+            // Only the location B -> A change should be updated in place.
+            expect(insertedParcels).toHaveLength(0);
+            expect(updatedParcels).toHaveLength(1);
+            expect(updatedParcels[0].pickup_location_id).toBe(locationA);
         } finally {
             vi.useRealTimers();
         }

--- a/app/[locale]/households/[id]/parcels/actions.ts
+++ b/app/[locale]/households/[id]/parcels/actions.ts
@@ -18,6 +18,8 @@ import { logError } from "@/app/utils/logger";
 export const updateHouseholdParcels = protectedAdminHouseholdAction(
     async (session, household, parcelsData: FoodParcels): Promise<ActionResult<void>> => {
         try {
+            const updatedParcelIds: string[] = [];
+
             // Auth and household verification already done by protectedHouseholdAction
             const locationId = parcelsData.pickupLocationId;
 
@@ -78,7 +80,9 @@ export const updateHouseholdParcels = protectedAdminHouseholdAction(
                     existingFutureParcels.map(p => parcelKey(p.locationId, p.earliest, p.latest)),
                 );
 
-                const parcelsToCreate = desiredFutureParcels.filter(
+                const existingFutureById = new Map(existingFutureParcels.map(p => [p.id, p]));
+
+                const parcelsToChange = desiredFutureParcels.filter(
                     parcel =>
                         !existingFutureKeys.has(
                             parcelKey(
@@ -89,13 +93,21 @@ export const updateHouseholdParcels = protectedAdminHouseholdAction(
                         ),
                 );
 
+                const parcelsToUpdate = parcelsToChange.filter(
+                    parcel => parcel.id && existingFutureById.has(parcel.id),
+                );
+                const parcelsToCreate = parcelsToChange.filter(
+                    parcel => !parcel.id || !existingFutureById.has(parcel.id),
+                );
+                const parcelsToValidate = [...parcelsToUpdate, ...parcelsToCreate];
+
                 // Create new/changed future food parcels based on the updated schedule.
                 // Unchanged future rows and historical rows are not revalidated.
-                if (parcelsToCreate.length > 0) {
+                if (parcelsToValidate.length > 0) {
                     const { validateParcelAssignments } =
                         await import("@/app/[locale]/schedule/actions");
 
-                    const parcelsToValidate = parcelsToCreate.map(parcel => ({
+                    const validationInput = parcelsToValidate.map(parcel => ({
                         id: parcel.id,
                         householdId: household.id,
                         locationId: parcelsData.pickupLocationId,
@@ -104,7 +116,7 @@ export const updateHouseholdParcels = protectedAdminHouseholdAction(
                         pickupEndTime: parcel.pickupLatestTime,
                     }));
 
-                    const validationResult = await validateParcelAssignments(parcelsToValidate, tx);
+                    const validationResult = await validateParcelAssignments(validationInput, tx);
 
                     if (!validationResult.success) {
                         // Throw to trigger transaction rollback
@@ -113,7 +125,24 @@ export const updateHouseholdParcels = protectedAdminHouseholdAction(
                             validationResult.errors || [],
                         );
                     }
+                }
 
+                if (parcelsToUpdate.length > 0) {
+                    for (const parcel of parcelsToUpdate) {
+                        await tx
+                            .update(foodParcels)
+                            .set({
+                                pickup_location_id: parcelsData.pickupLocationId,
+                                pickup_date_time_earliest: parcel.pickupEarliestTime,
+                                pickup_date_time_latest: parcel.pickupLatestTime,
+                            })
+                            .where(eq(foodParcels.id, parcel.id!));
+
+                        updatedParcelIds.push(parcel.id!);
+                    }
+                }
+
+                if (parcelsToCreate.length > 0) {
                     const parcelsToSave = parcelsToCreate.map(parcel => ({
                         household_id: household.id,
                         pickup_location_id: parcelsData.pickupLocationId,
@@ -142,11 +171,15 @@ export const updateHouseholdParcels = protectedAdminHouseholdAction(
                     ),
                 );
 
+                const updatedParcelIdSet = new Set(updatedParcelIds);
+
                 // Soft delete parcels that are not in the desired schedule
                 // This preserves audit trail, keeps public QR code links working,
                 // and handles SMS cancellation intelligently
                 const parcelsToDelete = existingFutureParcels.filter(
-                    p => !desiredParcelKeys.has(parcelKey(p.locationId, p.earliest, p.latest)),
+                    p =>
+                        !updatedParcelIdSet.has(p.id) &&
+                        !desiredParcelKeys.has(parcelKey(p.locationId, p.earliest, p.latest)),
                 );
 
                 if (parcelsToDelete.length > 0) {
@@ -203,6 +236,19 @@ export const updateHouseholdParcels = protectedAdminHouseholdAction(
                     householdId: household.id,
                 });
                 // Non-fatal: The count will be corrected by the next schedule operation
+            }
+
+            if (updatedParcelIds.length > 0) {
+                try {
+                    const { queuePickupUpdatedSms } = await import("@/app/utils/sms/sms-service");
+                    await Promise.allSettled(updatedParcelIds.map(id => queuePickupUpdatedSms(id)));
+                } catch (e) {
+                    logError("Failed to queue pickup_updated SMS after parcel update", e, {
+                        parcelIds: updatedParcelIds,
+                        householdId: household.id,
+                    });
+                    // Non-fatal: The parcel update succeeded, SMS is a nice-to-have
+                }
             }
 
             return success(undefined);


### PR DESCRIPTION
## Summary

Follow-up to #397. The stale-history validation fix is merged, but changed existing future parcels in the household parcel form should be true moves, not replacement rows.

This updates the household parcel save diff so existing future parcels with ids are updated in place when their location or pickup time changes. New parcels are still inserted, unchanged future parcels are still skipped, and removed future parcels are still soft-deleted.

Preserving the parcel id keeps SMS/public-link semantics correct: if a pickup reminder was already sent, the existing `queuePickupUpdatedSms` flow can send a pickup-updated SMS for the same parcel instead of treating the old parcel as cancelled and the moved parcel as a separate new pickup.

## Coverage

- changed existing future parcel validates with its existing id, updates in place, does not insert/delete, and queues pickup-updated SMS
- location-change cases now cover existing parcel ids and assert in-place updates
- unchanged future parcels still do not insert/update/delete

## Validation

- `pnpm test __tests__/app/households/parcels/actions.test.ts __tests__/app/households/parcels/location-change.test.ts __tests__/app/households/parcels/past-parcel-prevention.test.ts`
- `pnpm run validate`
- pre-push hook: `pnpm test` and `pnpm run validate` passed: 150 test files, 1618 tests passed, 1 skipped