### PR TITLE
fix(backups): avoid false rclone upload failure alert

### DIFF
--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -241,7 +241,10 @@ log "Encrypted dump complete. Size: $BACKUP_SIZE"
 
 BACKUP_STAGE="rclone upload"
 log "Uploading backup to Elastx Object Store container: $SWIFT_CONTAINER"
-log "rclone version: $(rclone version --check=false | head -1)"
+RCLONE_VERSION_OUTPUT=$(rclone version --check=false 2>/dev/null || true)
+RCLONE_VERSION=${RCLONE_VERSION_OUTPUT%%$'\n'*}
+[ -n "$RCLONE_VERSION" ] || RCLONE_VERSION="unknown"
+log "rclone version: $RCLONE_VERSION"
 
 EXPIRY_SECONDS=$((RETENTION_DAYS * 24 * 60 * 60))
 


### PR DESCRIPTION
## Summary

Fixes a false Slack failure alert from the nightly encrypted backup job.

The backup script logged the rclone version with `rclone version --check=false | head -1` while running under `set -euo pipefail` with a global `ERR` trap. When `head` closes the pipe after the first line, `rclone version` can exit with SIGPIPE (`141`). Bash then triggers the `ERR` trap and sends a misleading Slack message saying the backup aborted during `rclone upload`, even though the upload and full-restore validation later succeed.

This change captures the rclone version output safely, extracts the first line using bash string expansion, and falls back to `unknown` if version detection fails.

## Validation

- `bash -n scripts/backup-db.sh`
- Pre-push hook ran tests and validation until `format-check`; it failed because unrelated untracked `server-build/` files in the local worktree are not formatted. This PR branch only changes `scripts/backup-db.sh`, and CI will run in a clean checkout.