### PR TITLE
Tighten CI/CD deployment verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,5 +102,7 @@ DB_BACKUP_PASSPHRASE="generate_strong_random_passphrase_min_32_chars"
 # AUTH_URL="https://yourdomain.com/api/auth" # Auth.js canonical URL
 # AUTH_REDIRECT_PROXY_URL="https://yourdomain.com/api/auth" # Auth.js redirect proxy
 # DATABASE_URL_EXTERNAL="postgres://user:pass@host:5432/db" # External DB access URL
+# APP_IMAGE_TAG="latest" # App image tag for Docker Compose; CI/CD sets sha-* tags
+# DB_BACKUP_IMAGE_TAG="latest" # Backup image tag for Docker Compose; CI/CD sets sha-* tags
 # EMAIL="admin@yourdomain.com" # Admin email for SSL certificates (Certbot)
 # ENV_NAME="production" # Environment identifier (production/staging)

--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -41,7 +41,7 @@ jobs:
                   images: ghcr.io/${{ matrix.image_name }}
                   tags: |
                       type=raw,value=latest,enable={{is_default_branch}}
-                      type=sha,prefix=sha-,format=short
+                      type=sha,prefix=sha-,format=long
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -66,6 +66,9 @@ jobs:
     deploy-to-staging:
         needs: publish-images
         runs-on: ubuntu-latest
+        concurrency:
+            group: deploy-staging
+            cancel-in-progress: false
         environment:
             name: staging
             url: https://staging.matcentralen.com
@@ -91,6 +94,9 @@ jobs:
                       # for managed/external DBs. Leave unset for the current
                       # trusted-network Docker DB.
                       export DATABASE_SSL="${{ secrets.DATABASE_SSL }}"
+                      export DEPLOY_SHA="${{ github.sha }}"
+                      export APP_IMAGE_TAG="sha-${DEPLOY_SHA}"
+                      export DB_BACKUP_IMAGE_TAG="sha-${DEPLOY_SHA}"
                       export EMAIL="${{ secrets.EMAIL }}"
                       export AUTH_GITHUB_ID="${{ secrets.AUTH_GITHUB_ID }}"
                       export AUTH_GITHUB_SECRET="${{ secrets.AUTH_GITHUB_SECRET }}"
@@ -123,16 +129,24 @@ jobs:
                       fi
                       cd "$APP_DIR"
 
-                      # Force-align the repo to origin/main regardless of the branch
-                      # that happens to be checked out on the VPS. `git reset --hard HEAD`
-                      # followed by `git pull origin main` silently fails to update when
-                      # HEAD is on a diverged branch — that's how staging ended up stuck
-                      # on an old feature branch for ~a week.
-                      echo "Aligning VPS repo to origin/main..."
-                      git fetch --prune origin main
-                      git checkout --force -B main origin/main
+                      # Force-align the repo to this workflow's exact commit regardless
+                      # of the branch that happens to be checked out on the VPS. This
+                      # keeps the checked-out repo in lockstep with the immutable sha-*
+                      # image tags built by this run, even if a newer main push exists.
+                      echo "Aligning VPS repo to ${DEPLOY_SHA}..."
+                      if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+                          git fetch --prune --unshallow origin main
+                      else
+                          git fetch --prune origin main
+                      fi
+                      git checkout --force -B main "$DEPLOY_SHA"
                       git clean -fd
-                      echo "HEAD: $(git rev-parse HEAD)  (workflow SHA: ${{ github.sha }})"
+                      ACTUAL_SHA="$(git rev-parse HEAD)"
+                      if [ "$ACTUAL_SHA" != "$DEPLOY_SHA" ]; then
+                          echo "❌ VPS checkout mismatch: got $ACTUAL_SHA, expected $DEPLOY_SHA"
+                          exit 1
+                      fi
+                      echo "HEAD: $ACTUAL_SHA  (workflow SHA: $DEPLOY_SHA)"
 
                       # Run the update.sh script which will apply migrations.
                       # `set -euo pipefail` above means a non-zero exit terminates the
@@ -141,12 +155,79 @@ jobs:
                       ./update.sh
                       echo "✅ Successfully deployed all updates."
 
+            - name: Verify staging deployment
+              run: |
+                  set -euo pipefail
+
+                  require_healthy() {
+                      local domain="$1"
+                      local url="https://${domain}/api/health"
+                      local body=""
+                      local health_status=""
+
+                      for attempt in $(seq 1 30); do
+                          if body=$(curl -fsS --max-time 10 "$url"); then
+                              health_status=$(printf '%s' "$body" | python3 -c 'import json, sys; print(json.load(sys.stdin).get("status", ""))' 2>/dev/null || true)
+                              if [ "$health_status" = "healthy" ]; then
+                                  echo "✅ ${url} is healthy"
+                                  return 0
+                              fi
+                              echo "Health status for ${url}: ${health_status:-unparseable} (attempt ${attempt}/30)"
+                          else
+                              echo "Health request failed for ${url} (attempt ${attempt}/30)"
+                          fi
+                          sleep 2
+                      done
+
+                      echo "❌ ${url} did not become healthy"
+                      echo "Last response: ${body}"
+                      return 1
+                  }
+
+                  verify_domain() {
+                      local domain="$1"
+                      local base_url="https://${domain}"
+                      local root_code
+                      local redirect_code
+                      local redirect_location
+                      local headers
+
+                      require_healthy "$domain"
+
+                      root_code=$(curl -fsSL -o /dev/null -w '%{http_code}' --max-time 20 "$base_url")
+                      if [ "$root_code" != "200" ]; then
+                          echo "❌ ${base_url} returned ${root_code}, expected 200"
+                          return 1
+                      fi
+                      echo "✅ ${base_url} resolves with 200"
+
+                      redirect_code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://${domain}/api/health")
+                      redirect_location=$(curl -sS -D - -o /dev/null --max-time 10 "http://${domain}/api/health" | awk 'BEGIN { IGNORECASE=1 } /^Location:/ { print $2; exit }' | tr -d '\r')
+                      if [ "$redirect_code" != "301" ] || [ "$redirect_location" != "https://${domain}/api/health" ]; then
+                          echo "❌ HTTP redirect for ${domain} returned ${redirect_code} -> ${redirect_location}"
+                          return 1
+                      fi
+                      echo "✅ HTTP redirect for ${domain} is correct"
+
+                      headers=$(curl -sS -D - -o /dev/null --max-time 10 "${base_url}/api/health")
+                      if ! printf '%s\n' "$headers" | grep -qi '^Strict-Transport-Security: '; then
+                          echo "❌ Missing HSTS header for ${domain}"
+                          return 1
+                      fi
+                      echo "✅ HSTS header present for ${domain}"
+                  }
+
+                  verify_domain "staging.matcentralen.com"
+
     manual-deploy-to-production:
         needs: deploy-to-staging
         environment:
             name: production
             url: https://matcentralen.com
         runs-on: ubuntu-latest
+        concurrency:
+            group: deploy-production
+            cancel-in-progress: false
         steps:
             - name: Deploy to production
               uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
@@ -167,6 +248,9 @@ jobs:
                       # for managed/external DBs. Leave unset for the current
                       # trusted-network Docker DB.
                       export DATABASE_SSL="${{ secrets.DATABASE_SSL }}"
+                      export DEPLOY_SHA="${{ github.sha }}"
+                      export APP_IMAGE_TAG="sha-${DEPLOY_SHA}"
+                      export DB_BACKUP_IMAGE_TAG="sha-${DEPLOY_SHA}"
                       export EMAIL="${{ secrets.EMAIL }}"
                       export AUTH_GITHUB_ID="${{ secrets.AUTH_GITHUB_ID }}"
                       export AUTH_GITHUB_SECRET="${{ secrets.AUTH_GITHUB_SECRET }}"
@@ -216,14 +300,103 @@ jobs:
                       fi
                       cd "$APP_DIR"
 
-                      # Force-align the repo to origin/main regardless of the branch
-                      # that happens to be checked out on the VPS (see staging block).
-                      echo "Aligning VPS repo to origin/main..."
-                      git fetch --prune origin main
-                      git checkout --force -B main origin/main
+                      # With immutable image tags, approving an old production
+                      # deployment would intentionally deploy that older commit.
+                      # This workflow is for normal forward deploys, not
+                      # rollbacks, so refuse stale manual approvals.
+                      echo "Checking production approval freshness..."
+                      LATEST_MAIN_SHA="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
+                      if [ "$LATEST_MAIN_SHA" != "$DEPLOY_SHA" ]; then
+                          echo "❌ Refusing stale production deploy."
+                          echo "Workflow SHA: $DEPLOY_SHA"
+                          echo "Current main: $LATEST_MAIN_SHA"
+                          echo "Start a fresh deployment from the current main branch, or use an explicit rollback workflow."
+                          exit 1
+                      fi
+                      echo "✅ Production approval targets current main."
+
+                      # Force-align the repo to the exact workflow commit so repo state
+                      # matches the immutable sha-* image tags built by this run.
+                      echo "Aligning VPS repo to ${DEPLOY_SHA}..."
+                      if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+                          git fetch --prune --unshallow origin main
+                      else
+                          git fetch --prune origin main
+                      fi
+                      git checkout --force -B main "$DEPLOY_SHA"
                       git clean -fd
-                      echo "HEAD: $(git rev-parse HEAD)  (workflow SHA: ${{ github.sha }})"
+                      ACTUAL_SHA="$(git rev-parse HEAD)"
+                      if [ "$ACTUAL_SHA" != "$DEPLOY_SHA" ]; then
+                          echo "❌ VPS checkout mismatch: got $ACTUAL_SHA, expected $DEPLOY_SHA"
+                          exit 1
+                      fi
+                      echo "HEAD: $ACTUAL_SHA  (workflow SHA: $DEPLOY_SHA)"
 
                       chmod +x update.sh
                       ./update.sh
                       echo "✅ Successfully deployed all updates."
+
+            - name: Verify production deployment
+              run: |
+                  set -euo pipefail
+
+                  require_healthy() {
+                      local domain="$1"
+                      local url="https://${domain}/api/health"
+                      local body=""
+                      local health_status=""
+
+                      for attempt in $(seq 1 30); do
+                          if body=$(curl -fsS --max-time 10 "$url"); then
+                              health_status=$(printf '%s' "$body" | python3 -c 'import json, sys; print(json.load(sys.stdin).get("status", ""))' 2>/dev/null || true)
+                              if [ "$health_status" = "healthy" ]; then
+                                  echo "✅ ${url} is healthy"
+                                  return 0
+                              fi
+                              echo "Health status for ${url}: ${health_status:-unparseable} (attempt ${attempt}/30)"
+                          else
+                              echo "Health request failed for ${url} (attempt ${attempt}/30)"
+                          fi
+                          sleep 2
+                      done
+
+                      echo "❌ ${url} did not become healthy"
+                      echo "Last response: ${body}"
+                      return 1
+                  }
+
+                  verify_domain() {
+                      local domain="$1"
+                      local base_url="https://${domain}"
+                      local root_code
+                      local redirect_code
+                      local redirect_location
+                      local headers
+
+                      require_healthy "$domain"
+
+                      root_code=$(curl -fsSL -o /dev/null -w '%{http_code}' --max-time 20 "$base_url")
+                      if [ "$root_code" != "200" ]; then
+                          echo "❌ ${base_url} returned ${root_code}, expected 200"
+                          return 1
+                      fi
+                      echo "✅ ${base_url} resolves with 200"
+
+                      redirect_code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://${domain}/api/health")
+                      redirect_location=$(curl -sS -D - -o /dev/null --max-time 10 "http://${domain}/api/health" | awk 'BEGIN { IGNORECASE=1 } /^Location:/ { print $2; exit }' | tr -d '\r')
+                      if [ "$redirect_code" != "301" ] || [ "$redirect_location" != "https://${domain}/api/health" ]; then
+                          echo "❌ HTTP redirect for ${domain} returned ${redirect_code} -> ${redirect_location}"
+                          return 1
+                      fi
+                      echo "✅ HTTP redirect for ${domain} is correct"
+
+                      headers=$(curl -sS -D - -o /dev/null --max-time 10 "${base_url}/api/health")
+                      if ! printf '%s\n' "$headers" | grep -qi '^Strict-Transport-Security: '; then
+                          echo "❌ Missing HSTS header for ${domain}"
+                          return 1
+                      fi
+                      echo "✅ HSTS header present for ${domain}"
+                  }
+
+                  verify_domain "matcentralen.com"
+                  verify_domain "www.matcentralen.com"

--- a/__tests__/app/households/enroll/components/FoodParcelsForm.test.tsx
+++ b/__tests__/app/households/enroll/components/FoodParcelsForm.test.tsx
@@ -224,6 +224,9 @@ describe("FoodParcelsForm Business Logic Tests", () => {
     let mockUpdateData: any;
 
     beforeEach(() => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        vi.setSystemTime(new Date("2026-05-01T08:00:00Z"));
+
         mockUpdateData = vi.fn(() => {});
 
         // Reset all mocks - cast to any to access mockClear
@@ -315,6 +318,7 @@ describe("FoodParcelsForm Business Logic Tests", () => {
 
     afterEach(() => {
         cleanup();
+        vi.useRealTimers();
     });
 
     /**

--- a/docker-compose.backup.yml
+++ b/docker-compose.backup.yml
@@ -6,7 +6,7 @@ services:
     db-backup:
         profiles:
             - backup
-        image: ghcr.io/vasteras-stadsmission/matkassen-db-backup:latest
+        image: ghcr.io/vasteras-stadsmission/matkassen-db-backup:${DB_BACKUP_IMAGE_TAG:-latest}
         restart: unless-stopped
         environment:
             - POSTGRES_USER=${POSTGRES_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 
 services:
     web:
-        image: ghcr.io/vasteras-stadsmission/matkassen:latest
+        image: ghcr.io/vasteras-stadsmission/matkassen:${APP_IMAGE_TAG:-latest}
         restart: always
         ports:
             - "127.0.0.1:3000:3000"

--- a/scripts/write-env.sh
+++ b/scripts/write-env.sh
@@ -129,6 +129,11 @@ write_env_file() {
         printf 'POSTGRES_PASSWORD="%s"\n' "$POSTGRES_PASSWORD"
         printf 'POSTGRES_USER="%s"\n' "$POSTGRES_USER"
         printf 'ENV_NAME="%s"\n' "$env_name"
+        # Image tags used by Docker Compose. CI/CD exports immutable sha-* tags
+        # so each deploy pulls exactly the images built by that workflow run.
+        # Local/manual deploys default to latest for backwards compatibility.
+        printf 'APP_IMAGE_TAG="%s"\n' "${APP_IMAGE_TAG:-latest}"
+        printf 'DB_BACKUP_IMAGE_TAG="%s"\n' "${DB_BACKUP_IMAGE_TAG:-latest}"
         # SMS credentials (conditional — only if provided)
         if [ -n "${HELLO_SMS_USERNAME:-}" ]; then
             printf 'HELLO_SMS_USERNAME="%s"\n' "$HELLO_SMS_USERNAME"


### PR DESCRIPTION
## Why

The deployment pipeline should prove two things after a merge: the VPS is running the exact artifacts built by that workflow, and the public site is healthy through the real nginx/TLS path. Before this change, deployment correctness was harder to reason about because the VPS pulled mutable `latest` image tags and aligned its checkout to the moving `origin/main` branch.

That is usually fine during quiet deploys, but it becomes ambiguous when multiple `main` pushes happen close together or when a production approval waits for a while. In those cases, a successful deployment log can leave uncertainty about which image actually went live.

## Design

| Concern | Previous behavior | New behavior |
| --- | --- | --- |
| Image identity | Compose pulled `latest` | Compose pulls `sha-${{ github.sha }}` for app and backup images |
| VPS checkout | Checkout followed moving `origin/main` | Checkout pins to the workflow commit and fails on mismatch |
| Deploy overlap | Deploy jobs could overlap | Staging and production deploys cannot overlap; GitHub keeps only the latest pending run per environment |
| Stale prod approvals | An old approval could deploy ambiguous state | Production refuses stale approvals when current `main` has moved on |
| Deploy verification | Container health implied success | Public HTTPS health, root, redirect, and HSTS are checked after deploy |

The production freshness guard is intentionally conservative. Immutable tags make approving an old workflow run equivalent to deploying an older commit. That is rollback behavior, and it should be explicit rather than an accidental side effect of a delayed approval.

## Flow

```text
GitHub Actions build
  -> push app and backup images as sha-<workflow commit>
  -> SSH to VPS
  -> verify production approval still targets current main
  -> checkout the workflow commit
  -> write .env with APP_IMAGE_TAG and DB_BACKUP_IMAGE_TAG
  -> docker compose pull/up exact image tags
  -> run migrations and reload nginx
  -> verify public HTTPS health, redirect, and HSTS
```

## Tradeoffs

This makes deployment stricter. A transient DNS, TLS, or network issue from the GitHub runner can now fail the post-deploy verification step even if the VPS containers are healthy. That is an acceptable tradeoff because the goal of the CD pipeline is not only to start containers; it is to confirm the public service is reachable and serving through the expected HTTPS configuration.

The smoke checks are deliberately narrow. They are deployment wiring checks, not browser-level end-to-end tests. If they fail, the workflow reports a failed deployment after the VPS update has already happened; this PR does not introduce automatic rollback. A rollback path should be designed separately so it can be explicit about which older SHA is being restored.

Manual/local deployments still default to `latest`, so emergency or local compose use remains simple while normal CI/CD deploys become reproducible.
