### PR TITLE
Keep staging demo data from being anonymized

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -106,7 +106,7 @@ jobs:
                       export HELLO_SMS_TEST_MODE="true"
                       export SMS_SEND_INTERVAL="30 seconds"
                       export ANONYMIZATION_SCHEDULE="*/15 * * * *"
-                      export ANONYMIZATION_INACTIVE_DURATION="5 minutes"
+                      export ANONYMIZATION_INACTIVE_DURATION="365 days"
                       export ORG_SYNC_SCHEDULE="0 3 * * *"
                       # SMS credentials not needed in staging (test mode only)
                       # Backups disabled on staging by policy (no db-backup related secrets exported)

--- a/.github/workflows/init_deploy.yml
+++ b/.github/workflows/init_deploy.yml
@@ -111,7 +111,7 @@ jobs:
                         export HELLO_SMS_TEST_MODE="true"
                         export SMS_SEND_INTERVAL="30 seconds"
                         export ANONYMIZATION_SCHEDULE="*/15 * * * *"
-                        export ANONYMIZATION_INACTIVE_DURATION="5 minutes"
+                        export ANONYMIZATION_INACTIVE_DURATION="365 days"
                         export ORG_SYNC_SCHEDULE="0 3 * * *"
                         # SMS credentials not needed in staging (test mode only)
                         # Backups disabled on staging by policy (no DB_BACKUP_PASSPHRASE exported)


### PR DESCRIPTION
## Why

Staging should be useful for testing real scheduling workflows without copying production data. We now have fake staging-only demo households, locations, and 2026 parcels, but the staging deploy workflows still configured anonymization with a 5-minute inactivity window.

That short window was useful when staging should clean itself aggressively, but it now works against the goal: every staging deploy would rewrite the VPS env file back to 5 minutes and make the background job remove or anonymize fake test data before it can be used.

## Design

This changes the staging inactivity window to 365 days in both deploy entry points:

| Deploy path | Staging anonymization window |
| --- | --- |
| Continuous deployment | 365 days |
| Initial deploy | 365 days |

The cron schedule stays frequent. That keeps the anonymization job exercised in staging, while making the eligibility threshold long enough that fake demo data remains stable across ordinary testing.

## Operational context

The live staging VPS has already been updated to the same 365-day setting and the web container was recreated. The staging health endpoint reports the scheduler as healthy with anonymizationInactiveDuration set to 365 days.

Staging has also been seeded directly with clearly fake stg... demo data covering multiple handout locations, households, parcels throughout 2026, mixed-location parcels, a full-capacity date, historical pickup/no-show/unresolved examples, and fake failed SMS data.