### PR TITLE
[codex] Reduce Dependabot npm update cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,9 @@
 # (non-CVE) version updates for the two ecosystems where staying
 # current matters: github-actions and npm.
 #
-# Both use weekly grouping to keep PR volume manageable for a single
-# operator: one PR per week per ecosystem (or per group within an
-# ecosystem) instead of one PR per dependency.
+# GitHub Actions stay on a weekly cadence so deployment tooling updates
+# can be exercised promptly. npm routine updates are monthly because a
+# single group can cover broad application and test-runtime behavior.
 
 version: 2
 updates:
@@ -27,17 +27,18 @@ updates:
               patterns:
                   - "*"
 
-    # npm: large dependency tree. Split into two groups so the easy
-    # bumps stay easy and the risky ones get a focused review:
-    #   - "minor-and-patch": bundled into one weekly PR. Usually pass
-    #     CI cleanly; merge after green build.
+    # npm: large dependency tree. Handle updates in two paths so easier
+    # bumps are reviewed together and risky ones get focused review:
+    #   - "minor-and-patch": bundled into one monthly PR. Even routine
+    #     packages can span application behavior, so review and stage
+    #     before merging.
     #   - Major bumps fall outside the group → one PR per major. These
     #     are the ones that may have breaking changes and warrant
     #     reading release notes / running staging before merge.
     - package-ecosystem: "npm"
       directory: "/"
       schedule:
-          interval: "weekly"
+          interval: "monthly"
       groups:
           minor-and-patch:
               update-types:


### PR DESCRIPTION
## Motivation

Routine npm Dependabot updates currently arrive weekly, but the grouped PR can span application runtime dependencies, rendering and i18n behavior, sanitization, and test tooling at the same time. That creates frequent review work without making those broad batches safe to merge casually.

## Approach

Routine npm version updates now run monthly instead of weekly. The existing minor-and-patch grouping remains in place so maintenance is still consolidated, while leaving enough review time for staging verification before a broad application dependency batch is accepted.

| Update type | Cadence / behavior | Reason |
| --- | --- | --- |
| GitHub Actions routine updates | Weekly, grouped | Deployment tooling updates should be exercised promptly through staging. |
| npm minor and patch routine updates | Monthly, grouped | These can affect broad runtime behavior and benefit from fewer, deliberate review windows. |
| npm major routine updates | Separate PRs, unchanged | Breaking changes still need individual review. |
| Security vulnerability updates | Unchanged | This only adjusts scheduled routine version updates; security alerts and security update handling are not reduced. |

Existing open Dependabot PRs are not implicitly approved by this policy change and should still be reviewed or closed separately.

## Verification

- Confirmed the diff only changes `.github/dependabot.yml`.
- Ran Prettier checking on the updated YAML successfully.
- Attempted `pnpm run validate`; the isolated worktree has no `node_modules`, and Next attempted an install rather than reaching repository validation. Full validation is left to the PR checks.