### PR TITLE
Normalize household and staff names before saving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 
 # production
 /build
+/server-build
 
 # misc
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 .next/
 node_modules/
 out/
+server-build/
 
 # Drizzle generated files
 migrations/**/*.sql

--- a/__tests__/app/utils/person-name.test.ts
+++ b/__tests__/app/utils/person-name.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+    containsSuspiciousNameContent,
+    normalizePersonName,
+    normalizePersonNameForComparison,
+    normalizePersonNameForDisplay,
+} from "@/app/utils/person-name";
+
+describe("person-name normalization", () => {
+    it("trims and collapses whitespace", () => {
+        expect(normalizePersonNameForDisplay("  Abd\t\tAlmohammad  ")).toBe("Abd Almohammad");
+    });
+
+    it("normalizes Unicode to NFC", () => {
+        expect(normalizePersonNameForDisplay("Agne\u0301")).toBe("Agn\u00e9");
+    });
+
+    it("preserves case and name punctuation", () => {
+        expect(normalizePersonNameForDisplay("  de Souza-O'Neill Jr.  ")).toBe(
+            "de Souza-O'Neill Jr.",
+        );
+    });
+
+    it("rejects empty names after normalization", () => {
+        expect(normalizePersonName(" \t\n ")).toEqual({ success: false, reason: "empty" });
+    });
+
+    it("rejects invisible format characters", () => {
+        expect(normalizePersonName("Anna\u200BSvensson")).toEqual({
+            success: false,
+            reason: "invalid_characters",
+        });
+    });
+
+    it("normalizes names for comparison", () => {
+        expect(normalizePersonNameForComparison("  ERIKSSON ")).toBe("eriksson");
+    });
+
+    it("flags digits as suspicious without rejecting them", () => {
+        expect(containsSuspiciousNameContent("Akbarzada 0763479824")).toBe(true);
+        expect(normalizePersonName("Akbarzada 0763479824")).toEqual({
+            success: true,
+            value: "Akbarzada 0763479824",
+        });
+    });
+});

--- a/__tests__/app/utils/user-profile.test.ts
+++ b/__tests__/app/utils/user-profile.test.ts
@@ -23,8 +23,8 @@ describe("user-profile", () => {
         it("should document input validation", () => {
             /**
              * REQUIRED FIELDS:
-             * - first_name: must be non-empty after trim, max 100 chars
-             * - last_name: must be non-empty after trim, max 100 chars
+             * - first_name: must be non-empty after name normalization, max 100 chars
+             * - last_name: must be non-empty after name normalization, max 100 chars
              *
              * OPTIONAL FIELDS:
              * - email: if provided, must match RFC-like regex, max 255 chars
@@ -32,7 +32,7 @@ describe("user-profile", () => {
              *
              * VALIDATION ORDER:
              * 1. Auth check (session must have githubUsername)
-             * 2. Trim first_name and last_name
+             * 2. Normalize first_name and last_name (NFC, trim, collapse whitespace)
              * 3. Check non-empty
              * 4. Check max length (100 for names)
              * 5. Validate email format if provided

--- a/__tests__/integration/households/person-name-normalization.integration.test.ts
+++ b/__tests__/integration/households/person-name-normalization.integration.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { getTestDb } from "../../db/test-db";
+import {
+    createTestHousehold,
+    createTestUser,
+    resetHouseholdCounter,
+    resetUserCounter,
+} from "../../factories";
+import { households, users } from "@/app/db/schema";
+import type { FormData, HouseholdCreateData } from "@/app/[locale]/households/enroll/types";
+
+type MockSession = { user: { githubUsername: string; name: string; role: "admin" } };
+const mockSession: MockSession = {
+    user: { githubUsername: "test-user", name: "Test User", role: "admin" },
+};
+
+vi.mock("@/app/utils/auth/protected-action", () => ({
+    protectedAction: (fn: (...args: unknown[]) => unknown) => {
+        return async (...args: unknown[]) => fn(mockSession, ...args);
+    },
+    protectedAdminAction: (fn: (...args: unknown[]) => unknown) => {
+        return async (...args: unknown[]) => fn(mockSession, ...args);
+    },
+    protectedReadAction: (fn: (...args: unknown[]) => unknown) => {
+        return async (...args: unknown[]) => fn(mockSession, ...args);
+    },
+    protectedAdminHouseholdAction: (fn: (...args: unknown[]) => unknown) => {
+        return async (householdId: string, ...args: unknown[]) => {
+            const db = await getTestDb();
+            const [household] = await db
+                .select()
+                .from(households)
+                .where(eq(households.id, householdId))
+                .limit(1);
+
+            return fn(mockSession, household, ...args);
+        };
+    },
+}));
+
+vi.mock("next/cache", () => ({
+    unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+    revalidatePath: vi.fn(),
+    revalidateTag: vi.fn(),
+}));
+
+vi.mock("@/app/utils/logger", () => ({
+    logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    logError: vi.fn(),
+}));
+
+vi.mock("@/app/utils/sms/sms-service", () => ({
+    createSmsRecord: vi.fn(),
+}));
+
+beforeEach(async () => {
+    resetHouseholdCounter();
+    resetUserCounter();
+    await createTestUser({
+        github_username: mockSession.user.githubUsername,
+        display_name: mockSession.user.name,
+    });
+});
+
+function buildEnrollmentData(responsibleUserId: string): HouseholdCreateData {
+    return {
+        headOfHousehold: {
+            firstName: "  Marie-janette\t\t",
+            lastName: "  Agne\u0301   Eriksson  ",
+            phoneNumber: "0700001234",
+            locale: "sv",
+        },
+        smsConsent: false,
+        responsibleUserId,
+        primaryPickupLocationId: null,
+        members: [],
+        dietaryRestrictions: [],
+        additionalNeeds: [],
+        pets: [],
+        foodParcels: {
+            pickupLocationId: "",
+            parcels: [],
+        },
+    };
+}
+
+function buildUpdateData(household: typeof households.$inferSelect): FormData {
+    return {
+        household: {
+            first_name: "  Abd\t\tAlmohammad  ",
+            last_name: "  Kravchenko  ",
+            phone_number: household.phone_number.replace("+46", "0"),
+            locale: household.locale,
+            primary_pickup_location_id: household.primary_pickup_location_id,
+            responsible_user_id: household.responsible_user_id,
+        },
+        members: [],
+        dietaryRestrictions: [],
+        additionalNeeds: [],
+        pets: [],
+        foodParcels: {
+            pickupLocationId: "",
+            parcels: [],
+        },
+        comments: [],
+    };
+}
+
+describe("person-name normalization on persisted writes", () => {
+    it("normalizes household names during enrollment", async () => {
+        const db = await getTestDb();
+        const [responsibleUser] = await db
+            .select({ id: users.id })
+            .from(users)
+            .where(eq(users.github_username, mockSession.user.githubUsername))
+            .limit(1);
+
+        const { enrollHousehold } = await import("@/app/[locale]/households/enroll/actions");
+        const result = await enrollHousehold(buildEnrollmentData(responsibleUser.id));
+
+        expect(result.success).toBe(true);
+        if (!result.success) return;
+
+        const [stored] = await db
+            .select({
+                first_name: households.first_name,
+                last_name: households.last_name,
+            })
+            .from(households)
+            .where(eq(households.id, result.data.householdId));
+
+        expect(stored).toEqual({
+            first_name: "Marie-janette",
+            last_name: "Agn\u00e9 Eriksson",
+        });
+    });
+
+    it("normalizes household names during edit", async () => {
+        const db = await getTestDb();
+        const household = await createTestHousehold({
+            first_name: "Original",
+            last_name: "Name",
+        });
+
+        const { updateHousehold } = await import("@/app/[locale]/households/[id]/edit/actions");
+        const result = await updateHousehold(household.id, buildUpdateData(household));
+
+        if (!result.success) {
+            throw new Error(result.error.message);
+        }
+        expect(result.success).toBe(true);
+
+        const [stored] = await db
+            .select({
+                first_name: households.first_name,
+                last_name: households.last_name,
+            })
+            .from(households)
+            .where(eq(households.id, household.id));
+
+        expect(stored).toEqual({
+            first_name: "Abd Almohammad",
+            last_name: "Kravchenko",
+        });
+    });
+
+    it("normalizes user profile names", async () => {
+        const db = await getTestDb();
+        const { saveUserProfile } = await import("@/app/utils/user-profile");
+
+        const result = await saveUserProfile({
+            first_name: "  Lena\tMaria ",
+            last_name: " Lamberg\n",
+        });
+
+        expect(result.success).toBe(true);
+
+        const [stored] = await db
+            .select({
+                first_name: users.first_name,
+                last_name: users.last_name,
+            })
+            .from(users)
+            .where(eq(users.github_username, mockSession.user.githubUsername));
+
+        expect(stored).toEqual({
+            first_name: "Lena Maria",
+            last_name: "Lamberg",
+        });
+    });
+
+    it("rejects invisible name characters before persisting", async () => {
+        const db = await getTestDb();
+        const before = await db.select({ id: households.id }).from(households);
+        const [responsibleUser] = await db
+            .select({ id: users.id })
+            .from(users)
+            .where(eq(users.github_username, mockSession.user.githubUsername))
+            .limit(1);
+
+        const { enrollHousehold } = await import("@/app/[locale]/households/enroll/actions");
+        const data = buildEnrollmentData(responsibleUser.id);
+        data.headOfHousehold.firstName = "Anna\u200BSvensson";
+
+        const result = await enrollHousehold(data);
+        const after = await db.select({ id: households.id }).from(households);
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.message).toBe("validation.firstNameInvalidCharacters");
+        }
+        expect(after).toHaveLength(before.length);
+    });
+});

--- a/app/[locale]/households/[id]/edit/actions.ts
+++ b/app/[locale]/households/[id]/edit/actions.ts
@@ -33,6 +33,7 @@ import { formatUserDisplayName } from "@/app/utils/format-user-display-name";
 import { normalizePhoneToE164, validatePhoneInput } from "@/app/utils/validation/phone-validation";
 import { OptionNotAvailableError, ensurePickupLocationExists } from "@/app/db/validation-helpers";
 import { ParcelValidationError } from "@/app/utils/errors/validation-errors";
+import { normalizePersonName } from "@/app/utils/person-name";
 import {
     applyHouseholdParcelScheduleChanges,
     runHouseholdParcelPostCommitEffects,
@@ -53,6 +54,19 @@ type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 function dedupeIds(ids: string[]): string[] {
     return [...new Set(ids.filter(Boolean))];
+}
+
+function nameValidationMessage(
+    field: "firstName" | "lastName",
+    reason: "empty" | "invalid_characters",
+) {
+    if (reason === "invalid_characters") {
+        return field === "firstName"
+            ? "validation.firstNameInvalidCharacters"
+            : "validation.lastNameInvalidCharacters";
+    }
+
+    return field === "firstName" ? "validation.firstNameLength" : "validation.lastNameLength";
 }
 
 async function ensureSelectableDietaryRestrictions(
@@ -409,6 +423,30 @@ export const updateHousehold = protectedAdminHouseholdAction(
                 });
             }
 
+            const firstName = normalizePersonName(data.household.first_name);
+            if (!firstName.success || firstName.value.length < 2) {
+                return failure({
+                    code: "VALIDATION_ERROR",
+                    message: nameValidationMessage(
+                        "firstName",
+                        firstName.success ? "empty" : firstName.reason,
+                    ),
+                    field: "first_name",
+                });
+            }
+
+            const lastName = normalizePersonName(data.household.last_name);
+            if (!lastName.success || lastName.value.length < 2) {
+                return failure({
+                    code: "VALIDATION_ERROR",
+                    message: nameValidationMessage(
+                        "lastName",
+                        lastName.success ? "empty" : lastName.reason,
+                    ),
+                    field: "last_name",
+                });
+            }
+
             // Check if phone number changed and validate no duplicates
             const newPhoneE164 = normalizePhoneToE164(data.household.phone_number);
 
@@ -479,8 +517,8 @@ export const updateHousehold = protectedAdminHouseholdAction(
                 await tx
                     .update(households)
                     .set({
-                        first_name: data.household.first_name,
-                        last_name: data.household.last_name,
+                        first_name: firstName.value,
+                        last_name: lastName.value,
                         phone_number: newPhoneE164,
                         locale: data.household.locale,
                         primary_pickup_location_id: primaryLocationId,

--- a/app/[locale]/households/components/HouseholdsTable.tsx
+++ b/app/[locale]/households/components/HouseholdsTable.tsx
@@ -27,6 +27,7 @@ import { useRouter } from "@/app/i18n/navigation";
 import { getLanguageName as getLanguageNameFromLocale } from "@/app/constants/languages";
 import { useLocale } from "next-intl";
 import { formatPhoneForDisplay } from "@/app/utils/validation/phone-validation";
+import { normalizePersonNameForComparison } from "@/app/utils/person-name";
 
 export interface Household {
     id: string;
@@ -215,23 +216,21 @@ export default function HouseholdsTable({ households }: { households: Household[
 
         // Apply text search
         if (search.trim()) {
-            const searchLower = search.toLowerCase();
+            const searchLower = normalizePersonNameForComparison(search);
+            const includesSearch = (value: string) =>
+                normalizePersonNameForComparison(value).includes(searchLower);
             filtered = filtered.filter(household => {
                 return (
-                    household.first_name.toLowerCase().includes(searchLower) ||
-                    household.last_name.toLowerCase().includes(searchLower) ||
+                    includesSearch(household.first_name) ||
+                    includesSearch(household.last_name) ||
                     household.phone_number.toLowerCase().includes(searchLower) ||
                     household.locale.toLowerCase().includes(searchLower) ||
                     (household.nextParcelDate &&
-                        formatDateTime(household.nextParcelDate)
-                            .toLowerCase()
-                            .includes(searchLower)) ||
+                        includesSearch(formatDateTime(household.nextParcelDate))) ||
                     (household.firstParcelDate &&
-                        formatDate(household.firstParcelDate)
-                            .toLowerCase()
-                            .includes(searchLower)) ||
+                        includesSearch(formatDate(household.firstParcelDate))) ||
                     (household.lastParcelDate &&
-                        formatDate(household.lastParcelDate).toLowerCase().includes(searchLower))
+                        includesSearch(formatDate(household.lastParcelDate)))
                 );
             });
         }
@@ -256,19 +255,29 @@ export default function HouseholdsTable({ households }: { households: Household[
                 }
             } else {
                 // Handle string comparisons
-                const aString = aValue?.toString().toLowerCase() || "";
-                const bString = bValue?.toString().toLowerCase() || "";
+                const aString = normalizePersonNameForComparison(aValue?.toString() || "");
+                const bString = normalizePersonNameForComparison(bValue?.toString() || "");
+                const comparison = aString.localeCompare(bString, currentLocale);
 
                 if (direction === "asc") {
-                    return aString > bString ? 1 : -1;
+                    return comparison;
                 } else {
-                    return aString < bString ? 1 : -1;
+                    return -comparison;
                 }
             }
         });
 
         return sorted;
-    }, [search, locationFilter, creatorFilter, sortStatus, households, formatDate, formatDateTime]);
+    }, [
+        search,
+        locationFilter,
+        creatorFilter,
+        sortStatus,
+        households,
+        formatDate,
+        formatDateTime,
+        currentLocale,
+    ]);
 
     return (
         <>

--- a/app/[locale]/households/enroll/actions.ts
+++ b/app/[locale]/households/enroll/actions.ts
@@ -34,6 +34,7 @@ import { normalizePhoneToE164, validatePhoneInput } from "@/app/utils/validation
 import { createSmsRecord } from "@/app/utils/sms/sms-service";
 import { formatEnrolmentSms } from "@/app/utils/sms/templates";
 import type { SupportedLocale } from "@/app/utils/locale-detection";
+import { normalizePersonName } from "@/app/utils/person-name";
 
 import {
     HouseholdCreateData,
@@ -49,6 +50,19 @@ type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 function dedupeIds(ids: string[]): string[] {
     return [...new Set(ids.filter(Boolean))];
+}
+
+function nameValidationMessage(
+    field: "firstName" | "lastName",
+    reason: "empty" | "invalid_characters",
+) {
+    if (reason === "invalid_characters") {
+        return field === "firstName"
+            ? "validation.firstNameInvalidCharacters"
+            : "validation.lastNameInvalidCharacters";
+    }
+
+    return field === "firstName" ? "validation.firstNameLength" : "validation.lastNameLength";
 }
 
 async function ensureResponsibleUserIsAssignable(
@@ -169,6 +183,30 @@ export const enrollHousehold = protectedAdminAction(
                 });
             }
 
+            const firstName = normalizePersonName(data.headOfHousehold.firstName);
+            if (!firstName.success || firstName.value.length < 2) {
+                return failure({
+                    code: "VALIDATION_ERROR",
+                    message: nameValidationMessage(
+                        "firstName",
+                        firstName.success ? "empty" : firstName.reason,
+                    ),
+                    field: "first_name",
+                });
+            }
+
+            const lastName = normalizePersonName(data.headOfHousehold.lastName);
+            if (!lastName.success || lastName.value.length < 2) {
+                return failure({
+                    code: "VALIDATION_ERROR",
+                    message: nameValidationMessage(
+                        "lastName",
+                        lastName.success ? "empty" : lastName.reason,
+                    ),
+                    field: "last_name",
+                });
+            }
+
             // Store locationId for recompute after transaction
             const locationId = data.foodParcels?.pickupLocationId;
 
@@ -200,8 +238,8 @@ export const enrollHousehold = protectedAdminAction(
                 const [household] = await tx
                     .insert(households)
                     .values({
-                        first_name: data.headOfHousehold.firstName,
-                        last_name: data.headOfHousehold.lastName,
+                        first_name: firstName.value,
+                        last_name: lastName.value,
                         phone_number: normalizePhoneToE164(data.headOfHousehold.phoneNumber),
                         locale: data.headOfHousehold.locale || "sv",
                         created_by: session.user?.githubUsername ?? null,

--- a/app/utils/person-name.ts
+++ b/app/utils/person-name.ts
@@ -1,0 +1,33 @@
+const WHITESPACE_RUN = /[\s\p{Zs}]+/gu;
+const DISALLOWED_NAME_CHARACTERS = /[\p{Cc}\p{Cf}]/u;
+const SUSPICIOUS_NAME_CONTENT = /\p{N}/u;
+
+export type PersonNameNormalizationResult =
+    | { success: true; value: string }
+    | { success: false; reason: "empty" | "invalid_characters" };
+
+export function normalizePersonName(value: string): PersonNameNormalizationResult {
+    const normalized = normalizePersonNameForDisplay(value);
+
+    if (!normalized) {
+        return { success: false, reason: "empty" };
+    }
+
+    if (DISALLOWED_NAME_CHARACTERS.test(normalized)) {
+        return { success: false, reason: "invalid_characters" };
+    }
+
+    return { success: true, value: normalized };
+}
+
+export function normalizePersonNameForDisplay(value: string): string {
+    return value.normalize("NFC").replace(WHITESPACE_RUN, " ").trim();
+}
+
+export function normalizePersonNameForComparison(value: string): string {
+    return normalizePersonNameForDisplay(value).toLowerCase();
+}
+
+export function containsSuspiciousNameContent(value: string): boolean {
+    return SUSPICIOUS_NAME_CONTENT.test(normalizePersonNameForDisplay(value));
+}

--- a/app/utils/user-profile.ts
+++ b/app/utils/user-profile.ts
@@ -7,6 +7,7 @@ import { protectedAction } from "@/app/utils/auth/protected-action";
 import { success, failure, type ActionResult } from "@/app/utils/auth/action-result";
 import { logError } from "@/app/utils/logger";
 import { normalizePhoneToE164, isValidE164 } from "@/app/utils/validation/phone-validation";
+import { normalizePersonName } from "@/app/utils/person-name";
 
 export interface UserProfile {
     first_name: string | null;
@@ -75,17 +76,27 @@ export const saveUserProfile = protectedAction(
                 return failure({ code: "AUTH_ERROR", message: "User not authenticated" });
             }
 
-            const firstName = data.first_name.trim();
-            const lastName = data.last_name.trim();
+            const firstName = normalizePersonName(data.first_name);
+            const lastName = normalizePersonName(data.last_name);
 
-            if (!firstName || !lastName) {
+            if (
+                (!firstName.success && firstName.reason === "empty") ||
+                (!lastName.success && lastName.reason === "empty")
+            ) {
                 return failure({
                     code: "VALIDATION_ERROR",
                     message: "First name and last name are required",
                 });
             }
 
-            if (firstName.length > 100 || lastName.length > 100) {
+            if (!firstName.success || !lastName.success) {
+                return failure({
+                    code: "VALIDATION_ERROR",
+                    message: "profile.notifications.nameInvalidCharacters",
+                });
+            }
+
+            if (firstName.value.length > 100 || lastName.value.length > 100) {
                 return failure({
                     code: "VALIDATION_ERROR",
                     message: "Name must be 100 characters or less",
@@ -140,8 +151,8 @@ export const saveUserProfile = protectedAction(
             await db
                 .update(users)
                 .set({
-                    first_name: firstName,
-                    last_name: lastName,
+                    first_name: firstName.value,
+                    last_name: lastName.value,
                     email: emailValue,
                     phone: phoneValue,
                 })

--- a/components/ProfileCompletionGuard/ProfileCompletionGuard.tsx
+++ b/components/ProfileCompletionGuard/ProfileCompletionGuard.tsx
@@ -79,6 +79,9 @@ export function ProfileCompletionGuard() {
 
     function validationMessage(code: string, serverMessage: string): string {
         if (code === "VALIDATION_ERROR") {
+            if (serverMessage === "profile.notifications.nameInvalidCharacters") {
+                return t("notifications.nameInvalidCharacters");
+            }
             if (serverMessage.includes("phone")) return t("notifications.invalidPhone");
             if (serverMessage.includes("Invalid email")) return t("notifications.invalidEmail");
             if (serverMessage.includes("Email must")) return t("notifications.invalidEmail");

--- a/messages/en.json
+++ b/messages/en.json
@@ -269,6 +269,8 @@
         "validation": {
             "firstNameLength": "First name must be at least 2 characters",
             "lastNameLength": "Last name must be at least 2 characters",
+            "firstNameInvalidCharacters": "First name contains invalid characters",
+            "lastNameInvalidCharacters": "Last name contains invalid characters",
             "phoneNumberFormat": "Enter a valid Swedish phone number (7-10 digits)",
             "swedishNumbersOnly": "Only Swedish phone numbers (+46) are supported",
             "phoneNumberInUse": "This phone number is already registered with another household",
@@ -824,6 +826,8 @@
             "title": "Validation Error",
             "firstNameLength": "First name must be at least 2 characters",
             "lastNameLength": "Last name must be at least 2 characters",
+            "firstNameInvalidCharacters": "First name contains invalid characters",
+            "lastNameInvalidCharacters": "Last name contains invalid characters",
             "phoneNumberFormat": "Enter a valid mobile number (9-10 digits)",
             "phoneDuplicate": "This phone number is already registered to another household",
             "phoneDuplicateWithInfo": "This phone number belongs to: {name} - {phone} (ID: {id})",
@@ -1945,7 +1949,8 @@
             "invalidEmail": "Please enter a valid email address",
             "invalidPhone": "Please enter a valid Swedish phone number (+467... or 07...)",
             "nameTooLong": "Name must be 100 characters or less",
-            "nameRequired": "First name and last name are required"
+            "nameRequired": "First name and last name are required",
+            "nameInvalidCharacters": "Name contains invalid characters"
         }
     }
 }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -269,6 +269,8 @@
         "validation": {
             "firstNameLength": "Förnamn måste vara minst 2 tecken",
             "lastNameLength": "Efternamn måste vara minst 2 tecken",
+            "firstNameInvalidCharacters": "Förnamnet innehåller ogiltiga tecken",
+            "lastNameInvalidCharacters": "Efternamnet innehåller ogiltiga tecken",
             "phoneNumberFormat": "Ange ett giltigt svenskt telefonnummer (7-10 siffror)",
             "swedishNumbersOnly": "Endast svenska telefonnummer (+46) stöds",
             "phoneNumberInUse": "Detta telefonnummer är redan registrerat hos ett annat hushåll",
@@ -824,6 +826,8 @@
             "title": "Valideringsfel",
             "firstNameLength": "Förnamn måste vara minst 2 tecken",
             "lastNameLength": "Efternamn måste vara minst 2 tecken",
+            "firstNameInvalidCharacters": "Förnamnet innehåller ogiltiga tecken",
+            "lastNameInvalidCharacters": "Efternamnet innehåller ogiltiga tecken",
             "phoneNumberFormat": "Ange ett giltigt mobilnummer (9-10 siffror)",
             "phoneDuplicate": "Detta telefonnummer är redan registrerat till ett annat hushåll",
             "phoneDuplicateWithInfo": "Detta telefonnummer tillhör: {name} - {phone} (ID: {id})",
@@ -1945,7 +1949,8 @@
             "invalidEmail": "Ange en giltig e-postadress",
             "invalidPhone": "Ange ett giltigt svenskt telefonnummer (+467... eller 07...)",
             "nameTooLong": "Namnet får vara högst 100 tecken",
-            "nameRequired": "Förnamn och efternamn krävs"
+            "nameRequired": "Förnamn och efternamn krävs",
+            "nameInvalidCharacters": "Namnet innehåller ogiltiga tecken"
         }
     }
 }


### PR DESCRIPTION
Hidden whitespace in household names can change how the households table behaves: a surname like ` Eriksson` sorts before `Abasi`, even though the rendered text looks normal. The underlying issue is that names were saved exactly as entered, while table sorting compared the raw stored strings.

This change normalizes person names at the write boundary for household enrollment, household editing, and staff profile saves. The normalization is intentionally conservative: it trims leading/trailing whitespace, collapses whitespace runs, and normalizes Unicode to NFC. It does not change casing, punctuation, accents, apostrophes, hyphens, or digits, because those can all be legitimate parts of real names.

| Input issue | Behavior |
| --- | --- |
| Leading/trailing spaces | Removed before saving |
| Multiple spaces, tabs, or newlines between name parts | Collapsed to one regular space |
| Decomposed accents | Stored as NFC-composed text |
| Zero-width/control characters | Rejected instead of stored |
| Digits in names | Preserved, only flagged by helper for later/manual review |

Existing production rows are not modified by this PR. The table search and sort logic now compares normalized values, so old rows with hidden whitespace no longer produce surprising ordering while any data cleanup is handled separately.

The generated `server-build/` directory is also ignored by Git and Prettier. It was already local generated output, and without ignoring it, validation can fail on files that are not part of the source tree.