### PR TITLE
Add audit trail for critical business changes

### DIFF
--- a/__tests__/app/households/parcels/actions.test.ts
+++ b/__tests__/app/households/parcels/actions.test.ts
@@ -11,6 +11,7 @@ import type { FoodParcels } from "@/app/[locale]/households/enroll/types";
 
 // Track database operations for verification
 let insertedParcels: any[] = [];
+let insertedAuditEvents: any[] = [];
 let deleteCalled = false;
 let existingFutureParcels: any[] = [];
 let softDeletedParcelIds: string[] = [];
@@ -85,6 +86,12 @@ vi.mock("@/app/db/drizzle", () => {
         })),
         insert: vi.fn((table: any) => ({
             values: vi.fn((values: any) => {
+                const tableName = table?.[Symbol.for("drizzle:Name")];
+                if (tableName === "audit_log") {
+                    insertedAuditEvents.push(values);
+                    return Promise.resolve();
+                }
+
                 // Store the inserted parcels for verification
                 insertedParcels.push(...values);
                 // Return an object with onConflictDoNothing method for upsert support
@@ -181,6 +188,7 @@ describe("updateHouseholdParcels - Same-day parcel handling", () => {
     beforeEach(() => {
         // Reset tracking arrays
         insertedParcels = [];
+        insertedAuditEvents = [];
         existingFutureParcels = [];
         softDeletedParcelIds = [];
         updatedParcels = [];

--- a/__tests__/app/households/parcels/location-change.test.ts
+++ b/__tests__/app/households/parcels/location-change.test.ts
@@ -13,6 +13,7 @@ import type { FoodParcels } from "@/app/[locale]/households/enroll/types";
 
 // Track database operations for verification
 let insertedParcels: any[] = [];
+let insertedAuditEvents: any[] = [];
 let deletedParcelIds: string[] = [];
 let existingParcels: any[] = [];
 let updatedParcels: any[] = [];
@@ -107,6 +108,12 @@ vi.mock("@/app/db/drizzle", () => {
         })),
         insert: vi.fn((table: any) => ({
             values: vi.fn((values: any) => {
+                const tableName = table?.[Symbol.for("drizzle:Name")];
+                if (tableName === "audit_log") {
+                    insertedAuditEvents.push(values);
+                    return Promise.resolve();
+                }
+
                 // Store the inserted parcels for verification
                 insertedParcels.push(...values);
                 // Return an object with onConflictDoNothing method
@@ -181,6 +188,7 @@ describe("updateHouseholdParcels - Location Changes", () => {
     beforeEach(() => {
         // Reset tracking arrays
         insertedParcels = [];
+        insertedAuditEvents = [];
         deletedParcelIds = [];
         existingParcels = [];
         updatedParcels = [];

--- a/__tests__/app/parcels/softDeleteParcel.test.ts
+++ b/__tests__/app/parcels/softDeleteParcel.test.ts
@@ -13,6 +13,7 @@ import type { Session } from "next-auth";
 
 // Track database operations for verification
 let insertedSms: any[] = [];
+let insertedAuditEvents: any[] = [];
 let updatedSms: any[] = [];
 let updatedParcels: any[] = [];
 let mockParcelData: any = null;
@@ -136,8 +137,14 @@ vi.mock("@/app/db/drizzle", () => {
                 }),
             })),
         })),
-        insert: vi.fn(() => ({
+        insert: vi.fn((table: any) => ({
             values: vi.fn((values: any) => {
+                const tableName = table?.[Symbol.for("drizzle:Name")];
+                if (tableName === "audit_log") {
+                    insertedAuditEvents.push(values);
+                    return Promise.resolve();
+                }
+
                 insertedSms.push(values);
                 return Promise.resolve();
             }),
@@ -202,6 +209,7 @@ describe("softDeleteParcel", () => {
     beforeEach(() => {
         // Reset tracking arrays
         insertedSms = [];
+        insertedAuditEvents = [];
         updatedSms = [];
         updatedParcels = [];
         mockParcelData = null;

--- a/__tests__/integration/api/issues-actions.integration.test.ts
+++ b/__tests__/integration/api/issues-actions.integration.test.ts
@@ -18,11 +18,12 @@ import {
     resetSmsCounter,
 } from "../../factories";
 import { TEST_NOW, daysFromTestNow } from "../../test-time";
-import { foodParcels, outgoingSms } from "@/app/db/schema";
+import { auditLog, foodParcels, outgoingSms } from "@/app/db/schema";
 import { eq } from "drizzle-orm";
 import { MockSmsGateway } from "@/app/utils/sms/mock-sms-gateway";
 import { setSmsGateway, resetSmsGateway } from "@/app/utils/sms/sms-gateway";
 import { sendSmsRecord, getSmsRecordsReadyForSending } from "@/app/utils/sms/sms-service";
+import { removeHousehold } from "@/app/utils/anonymization/anonymize-household";
 import type { NextRequest } from "next/server";
 
 const ADMIN_USERNAME = "test-admin";
@@ -386,9 +387,73 @@ describe("Issues actions - Route handler integration", () => {
             expect(updated.dismissed_at).toBeInstanceOf(Date);
             expect(updated.dismissed_by_user_id).toBe(ADMIN_USERNAME);
 
+            const [auditRow] = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.entity_id, household.id));
+            expect(auditRow).toMatchObject({
+                actor_username: ADMIN_USERNAME,
+                entity_type: "household",
+                action: "failure_dismissed",
+                summary: "Dismissed SMS failure",
+                details: {
+                    sms_id: sms.id,
+                },
+            });
+
             const after = await getIssues();
             expect(after.failedSms.map((s: { id: string }) => s.id)).not.toContain(sms.id);
             expect(after.counts.failedSms).toBe(0);
+        });
+
+        it("should audit parcel-tied dismissals and prune them when household is anonymized", async () => {
+            const db = await getTestDb();
+            const household = await createTestHousehold({ first_name: "SmsPrune" });
+            const { location } = await createTestLocationWithSchedule();
+            const yesterday = daysFromTestNow(-1);
+            const parcel = await createTestParcel({
+                household_id: household.id,
+                pickup_location_id: location.id,
+                pickup_date_time_earliest: yesterday,
+                pickup_date_time_latest: new Date(yesterday.getTime() + 30 * 60 * 1000),
+            });
+            const sms = await createTestFailedSms({
+                household_id: household.id,
+                parcel_id: parcel.id,
+            });
+
+            const response = await dismissPATCH(
+                makeRequest(`http://localhost/api/admin/sms/${sms.id}/dismiss`, {
+                    method: "PATCH",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ dismissed: true }),
+                }),
+                { params: Promise.resolve({ smsId: sms.id }) },
+            );
+            expect(response.status).toBe(200);
+
+            const [auditRow] = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.entity_id, parcel.id));
+            expect(auditRow).toMatchObject({
+                actor_username: ADMIN_USERNAME,
+                entity_type: "parcel",
+                action: "failure_dismissed",
+                summary: "Dismissed SMS failure",
+                details: {
+                    sms_id: sms.id,
+                },
+            });
+
+            const removal = await removeHousehold(household.id, "privacy-admin");
+            expect(removal.method).toBe("anonymized");
+
+            const auditRowsAfterRemoval = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.entity_id, parcel.id));
+            expect(auditRowsAfterRemoval).toHaveLength(0);
         });
 
         it("should validate request body", async () => {

--- a/__tests__/integration/api/sms-retry.integration.test.ts
+++ b/__tests__/integration/api/sms-retry.integration.test.ts
@@ -24,7 +24,7 @@ import {
     resetSmsCounter,
 } from "../../factories";
 import { TEST_NOW, daysFromTestNow, hoursFromTestNow } from "../../test-time";
-import { outgoingSms } from "@/app/db/schema";
+import { auditLog, outgoingSms } from "@/app/db/schema";
 import { eq } from "drizzle-orm";
 import type { NextRequest } from "next/server";
 
@@ -123,6 +123,23 @@ describe("SMS Retry - Route handler integration", () => {
             expect(newSms.parcel_id).toBe(parcel.id);
             expect(newSms.household_id).toBe(household.id);
             expect(newSms.attempt_count).toBe(0);
+
+            const [auditRow] = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.entity_id, parcel.id));
+            expect(auditRow).toMatchObject({
+                actor_username: ADMIN_USERNAME,
+                entity_type: "parcel",
+                action: "retried",
+                summary: "Retried SMS failure",
+                details: {
+                    sms_id: failedSms.id,
+                    new_sms_id: payload.smsId,
+                    intent: "pickup_reminder",
+                },
+            });
+            expect(JSON.stringify(auditRow.details)).not.toContain(failedSms.text);
         });
 
         it("should work for pickup_updated intent", async () => {
@@ -256,6 +273,23 @@ describe("SMS Retry - Route handler integration", () => {
             expect(newSms.text).toBe(failedSms.text);
             expect(newSms.parcel_id).toBeNull();
             expect(newSms.household_id).toBe(household.id);
+
+            const [auditRow] = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.entity_id, household.id));
+            expect(auditRow).toMatchObject({
+                actor_username: ADMIN_USERNAME,
+                entity_type: "household",
+                action: "retried",
+                summary: "Retried SMS failure",
+                details: {
+                    sms_id: failedSms.id,
+                    new_sms_id: payload.smsId,
+                    intent: "enrolment",
+                },
+            });
+            expect(JSON.stringify(auditRow.details)).not.toContain(failedSms.text);
         });
 
         it("should retry a failed consent_enrolment SMS", async () => {

--- a/__tests__/integration/audit/business-audit.integration.test.ts
+++ b/__tests__/integration/audit/business-audit.integration.test.ts
@@ -156,7 +156,7 @@ describe("business audit logging integration", () => {
         expect(await auditRowsForEntity("parcel", parcel.id)).toHaveLength(0);
     });
 
-    it("prunes previous household and parcel audit rows when a household is anonymized", async () => {
+    it("prunes household and parcel audit rows when a household is anonymized", async () => {
         const db = await getTestDb();
         const household = await createTestHousehold();
         const { location } = await createTestLocationWithSchedule();
@@ -195,18 +195,12 @@ describe("business audit logging integration", () => {
         const result = await removeHousehold(household.id, "privacy-admin");
         expect(result.method).toBe("anonymized");
 
-        const householdRows = await auditRowsForEntity("household", household.id);
-        expect(householdRows).toHaveLength(1);
-        expect(householdRows[0]).toMatchObject({
-            actor_username: "privacy-admin",
-            action: "anonymized",
-            summary: "Anonymized household",
-        });
+        expect(await auditRowsForEntity("household", household.id)).toHaveLength(0);
         expect(await auditRowsForEntity("parcel", parcel.id)).toHaveLength(0);
         expect(await auditRowsForEntity("user_role", "staff-user")).toHaveLength(1);
     });
 
-    it("prunes previous household audit rows when a household with no service history is hard-deleted", async () => {
+    it("prunes household audit rows when a household with no service history is hard-deleted", async () => {
         const db = await getTestDb();
         const household = await createTestHousehold();
 
@@ -227,13 +221,7 @@ describe("business audit logging integration", () => {
             .where(eq(households.id, household.id));
         expect(deletedHousehold).toBeUndefined();
 
-        const householdRows = await auditRowsForEntity("household", household.id);
-        expect(householdRows).toHaveLength(1);
-        expect(householdRows[0]).toMatchObject({
-            actor_username: "cleanup-admin",
-            action: "removed",
-            summary: "Removed household",
-        });
+        expect(await auditRowsForEntity("household", household.id)).toHaveLength(0);
     });
 
     it("records a manual SMS balance-failure requeue without storing message text", async () => {

--- a/__tests__/integration/audit/business-audit.integration.test.ts
+++ b/__tests__/integration/audit/business-audit.integration.test.ts
@@ -1,0 +1,261 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import { getTestDb } from "../../db/test-db";
+import {
+    createTestBalanceFailedSms,
+    createTestHousehold,
+    createTestLocationWithSchedule,
+    createTestParcel,
+    resetHouseholdCounter,
+    resetLocationCounter,
+    resetSmsCounter,
+} from "../../factories";
+import { TEST_NOW } from "../../test-time";
+import { auditLog, foodParcels, households } from "@/app/db/schema";
+import {
+    createParcels,
+    markNoShow,
+    markPickedUp,
+    softDeleteParcelLenient,
+    undoNoShow,
+    undoPickup,
+} from "@/app/utils/parcels/state-transitions";
+import { removeHousehold } from "@/app/utils/anonymization/anonymize-household";
+import { requeueBalanceFailures } from "@/app/utils/sms/sms-service";
+
+function withUser(githubUsername: string) {
+    return { user: { githubUsername } };
+}
+
+async function auditRowsForEntity(entityType: string, entityId: string | null) {
+    const db = await getTestDb();
+    return db
+        .select()
+        .from(auditLog)
+        .where(
+            and(
+                eq(auditLog.entity_type, entityType),
+                entityId === null ? isNull(auditLog.entity_id) : eq(auditLog.entity_id, entityId),
+            ),
+        );
+}
+
+describe("business audit logging integration", () => {
+    beforeEach(() => {
+        resetHouseholdCounter();
+        resetLocationCounter();
+        resetSmsCounter();
+    });
+
+    it("records one compact audit row per parcel lifecycle business action", async () => {
+        const db = await getTestDb();
+        const household = await createTestHousehold();
+        const { location } = await createTestLocationWithSchedule();
+        const session = withUser("parcel-admin");
+
+        const futureStart = new Date(TEST_NOW.getTime() + 24 * 60 * 60 * 1000);
+        const futureEnd = new Date(futureStart.getTime() + 30 * 60 * 1000);
+        const pastStart = new Date(TEST_NOW.getTime() - 24 * 60 * 60 * 1000);
+        const pastEnd = new Date(pastStart.getTime() + 30 * 60 * 1000);
+
+        const createdIds = await db.transaction(tx =>
+            createParcels(tx as any, {
+                session,
+                parcels: [
+                    {
+                        household_id: household.id,
+                        pickup_location_id: location.id,
+                        pickup_date_time_earliest: futureStart,
+                        pickup_date_time_latest: futureEnd,
+                        is_picked_up: false,
+                    },
+                    {
+                        household_id: household.id,
+                        pickup_location_id: location.id,
+                        pickup_date_time_earliest: pastStart,
+                        pickup_date_time_latest: pastEnd,
+                        is_picked_up: false,
+                    },
+                ],
+            }),
+        );
+
+        const [futureParcelId, pastParcelId] = createdIds;
+
+        await db.transaction(async tx => {
+            expect(await markPickedUp(tx as any, { parcelId: futureParcelId, session })).toEqual({
+                ok: true,
+            });
+            expect(await undoPickup(tx as any, { parcelId: futureParcelId, session })).toEqual({
+                ok: true,
+            });
+            expect(await markNoShow(tx as any, { parcelId: pastParcelId, session })).toEqual({
+                ok: true,
+            });
+            expect(await undoNoShow(tx as any, { parcelId: pastParcelId, session })).toEqual({
+                ok: true,
+            });
+            expect(
+                await softDeleteParcelLenient(tx as any, {
+                    parcelId: futureParcelId,
+                    session,
+                }),
+            ).toMatchObject({ skipped: false });
+        });
+
+        const rows = await db
+            .select()
+            .from(auditLog)
+            .where(inArray(auditLog.entity_id, [futureParcelId, pastParcelId]))
+            .orderBy(auditLog.created_at);
+
+        expect(rows).toHaveLength(7);
+        expect(rows.map(row => row.action)).toEqual(
+            expect.arrayContaining([
+                "created",
+                "marked_picked_up",
+                "pickup_undone",
+                "marked_no_show",
+                "no_show_undone",
+                "cancelled",
+            ]),
+        );
+        expect(rows.filter(row => row.action === "created")).toHaveLength(2);
+        expect(rows.every(row => row.actor_username === "parcel-admin")).toBe(true);
+        expect(rows.find(row => row.action === "created")?.details).toMatchObject({
+            household_id: household.id,
+            pickup_location_id: location.id,
+        });
+        expect(rows.find(row => row.action === "marked_picked_up")?.details).toBeNull();
+    });
+
+    it("rolls back parcel state and audit rows when the business transaction fails", async () => {
+        const db = await getTestDb();
+        const household = await createTestHousehold();
+        const { location } = await createTestLocationWithSchedule();
+        const parcel = await createTestParcel({
+            household_id: household.id,
+            pickup_location_id: location.id,
+        });
+
+        await expect(
+            db.transaction(async tx => {
+                await markPickedUp(tx as any, {
+                    parcelId: parcel.id,
+                    session: withUser("rollback-admin"),
+                });
+                throw new Error("simulate downstream validation failure");
+            }),
+        ).rejects.toThrow("simulate downstream validation failure");
+
+        const [afterRollback] = await db
+            .select({ isPickedUp: foodParcels.is_picked_up })
+            .from(foodParcels)
+            .where(eq(foodParcels.id, parcel.id));
+        expect(afterRollback.isPickedUp).toBe(false);
+        expect(await auditRowsForEntity("parcel", parcel.id)).toHaveLength(0);
+    });
+
+    it("prunes previous household and parcel audit rows when a household is anonymized", async () => {
+        const db = await getTestDb();
+        const household = await createTestHousehold();
+        const { location } = await createTestLocationWithSchedule();
+        const pastStart = new Date(TEST_NOW.getTime() - 3 * 24 * 60 * 60 * 1000);
+        const parcel = await createTestParcel({
+            household_id: household.id,
+            pickup_location_id: location.id,
+            pickup_date_time_earliest: pastStart,
+            pickup_date_time_latest: new Date(pastStart.getTime() + 30 * 60 * 1000),
+        });
+
+        await db.insert(auditLog).values([
+            {
+                actor_username: "old-admin",
+                entity_type: "household",
+                entity_id: household.id,
+                action: "updated",
+                summary: "Old household edit",
+            },
+            {
+                actor_username: "old-admin",
+                entity_type: "parcel",
+                entity_id: parcel.id,
+                action: "rescheduled",
+                summary: "Old parcel reschedule",
+            },
+            {
+                actor_username: "old-admin",
+                entity_type: "user_role",
+                entity_id: "staff-user",
+                action: "role_changed",
+                summary: "Unrelated user role audit",
+            },
+        ]);
+
+        const result = await removeHousehold(household.id, "privacy-admin");
+        expect(result.method).toBe("anonymized");
+
+        const householdRows = await auditRowsForEntity("household", household.id);
+        expect(householdRows).toHaveLength(1);
+        expect(householdRows[0]).toMatchObject({
+            actor_username: "privacy-admin",
+            action: "anonymized",
+            summary: "Anonymized household",
+        });
+        expect(await auditRowsForEntity("parcel", parcel.id)).toHaveLength(0);
+        expect(await auditRowsForEntity("user_role", "staff-user")).toHaveLength(1);
+    });
+
+    it("prunes previous household audit rows when a household with no service history is hard-deleted", async () => {
+        const db = await getTestDb();
+        const household = await createTestHousehold();
+
+        await db.insert(auditLog).values({
+            actor_username: "old-admin",
+            entity_type: "household",
+            entity_id: household.id,
+            action: "updated",
+            summary: "Old household edit",
+        });
+
+        const result = await removeHousehold(household.id, "cleanup-admin");
+        expect(result.method).toBe("deleted");
+
+        const [deletedHousehold] = await db
+            .select()
+            .from(households)
+            .where(eq(households.id, household.id));
+        expect(deletedHousehold).toBeUndefined();
+
+        const householdRows = await auditRowsForEntity("household", household.id);
+        expect(householdRows).toHaveLength(1);
+        expect(householdRows[0]).toMatchObject({
+            actor_username: "cleanup-admin",
+            action: "removed",
+            summary: "Removed household",
+        });
+    });
+
+    it("records a manual SMS balance-failure requeue without storing message text", async () => {
+        const db = await getTestDb();
+        const household = await createTestHousehold();
+        await createTestBalanceFailedSms({
+            household_id: household.id,
+            text: "Do not copy this real message body into audit details",
+        });
+        await createTestBalanceFailedSms({ household_id: household.id });
+
+        const count = await requeueBalanceFailures(withUser("sms-admin"));
+        expect(count).toBe(2);
+
+        const rows = await auditRowsForEntity("sms", null);
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            actor_username: "sms-admin",
+            action: "balance_failures_requeued",
+            summary: "Requeued balance-failed SMS",
+        });
+        expect(rows[0].details).toEqual({ count: 2 });
+        expect(JSON.stringify(rows[0].details)).not.toContain("Do not copy");
+    });
+});

--- a/__tests__/integration/audit/business-audit.integration.test.ts
+++ b/__tests__/integration/audit/business-audit.integration.test.ts
@@ -156,6 +156,38 @@ describe("business audit logging integration", () => {
         expect(await auditRowsForEntity("parcel", parcel.id)).toHaveLength(0);
     });
 
+    it("rolls back the business mutation when the audit insert fails", async () => {
+        const db = await getTestDb();
+        const household = await createTestHousehold();
+        const { location } = await createTestLocationWithSchedule();
+        const overlongActor = "x".repeat(101); // audit_log.actor_username is varchar(100)
+        const futureStart = new Date(TEST_NOW.getTime() + 24 * 60 * 60 * 1000);
+        const futureEnd = new Date(futureStart.getTime() + 30 * 60 * 1000);
+
+        await expect(
+            db.transaction(tx =>
+                createParcels(tx as any, {
+                    session: withUser(overlongActor),
+                    parcels: [
+                        {
+                            household_id: household.id,
+                            pickup_location_id: location.id,
+                            pickup_date_time_earliest: futureStart,
+                            pickup_date_time_latest: futureEnd,
+                            is_picked_up: false,
+                        },
+                    ],
+                }),
+            ),
+        ).rejects.toThrow();
+
+        const parcels = await db
+            .select()
+            .from(foodParcels)
+            .where(eq(foodParcels.household_id, household.id));
+        expect(parcels).toHaveLength(0);
+    });
+
     it("prunes household and parcel audit rows when a household is anonymized", async () => {
         const db = await getTestDb();
         const household = await createTestHousehold();

--- a/__tests__/integration/audit/settings-audit.integration.test.ts
+++ b/__tests__/integration/audit/settings-audit.integration.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { and, eq } from "drizzle-orm";
+import { getTestDb } from "../../db/test-db";
+import { auditLog } from "@/app/db/schema";
+import {
+    NOSHOW_CONSECUTIVE_THRESHOLD_KEY,
+    NOSHOW_FOLLOWUP_ENABLED_KEY,
+    NOSHOW_TOTAL_THRESHOLD_KEY,
+} from "@/app/constants/noshow-settings";
+
+const mockSession = {
+    user: {
+        githubUsername: "settings-admin",
+        role: "admin",
+    },
+};
+
+vi.mock("@/app/utils/auth/protected-action", () => ({
+    protectedAdminAction: (fn: (...args: unknown[]) => unknown) => {
+        return async (...args: unknown[]) => fn(mockSession, ...args);
+    },
+}));
+
+vi.mock("next/cache", () => ({
+    revalidatePath: vi.fn(),
+}));
+
+const { updateParcelWarningThreshold } = await import("@/app/[locale]/settings/parcels/actions");
+const { updateNoShowFollowupSettings } = await import("@/app/[locale]/settings/general/actions");
+
+describe("critical settings audit logging integration", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("records compact before/after details when parcel warning threshold changes", async () => {
+        const db = await getTestDb();
+
+        const first = await updateParcelWarningThreshold(4);
+        expect(first.success).toBe(true);
+
+        const second = await updateParcelWarningThreshold(6);
+        expect(second.success).toBe(true);
+
+        const rows = await db
+            .select()
+            .from(auditLog)
+            .where(
+                and(
+                    eq(auditLog.entity_type, "global_setting"),
+                    eq(auditLog.entity_id, "parcel_warning_threshold"),
+                ),
+            );
+
+        expect(rows).toHaveLength(2);
+        expect(rows[0]).toMatchObject({
+            actor_username: "settings-admin",
+            action: "updated",
+            summary: "Updated parcel warning threshold",
+            details: {
+                changes: {
+                    value: {
+                        before: null,
+                        after: "4",
+                    },
+                },
+            },
+        });
+        expect(rows[1].details).toEqual({
+            changes: {
+                value: {
+                    before: "4",
+                    after: "6",
+                },
+            },
+        });
+    });
+
+    it("records one audit row for the no-show follow-up settings business action", async () => {
+        const db = await getTestDb();
+
+        const result = await updateNoShowFollowupSettings({
+            enabled: true,
+            consecutiveThreshold: 2,
+            totalThreshold: 4,
+        });
+
+        expect(result.success).toBe(true);
+
+        const [row] = await db
+            .select()
+            .from(auditLog)
+            .where(
+                and(
+                    eq(auditLog.entity_type, "global_setting"),
+                    eq(auditLog.entity_id, "no_show_followup"),
+                ),
+            );
+
+        expect(row).toMatchObject({
+            actor_username: "settings-admin",
+            action: "updated",
+            summary: "Updated no-show follow-up settings",
+            details: {
+                changes: {
+                    [NOSHOW_FOLLOWUP_ENABLED_KEY]: {
+                        before: null,
+                        after: "true",
+                    },
+                    [NOSHOW_CONSECUTIVE_THRESHOLD_KEY]: {
+                        before: null,
+                        after: "2",
+                    },
+                    [NOSHOW_TOTAL_THRESHOLD_KEY]: {
+                        before: null,
+                        after: "4",
+                    },
+                },
+            },
+        });
+    });
+});

--- a/__tests__/integration/households/household-parcel-scheduling.integration.test.ts
+++ b/__tests__/integration/households/household-parcel-scheduling.integration.test.ts
@@ -13,7 +13,7 @@ import {
     resetLocationCounter,
     resetUserCounter,
 } from "../../factories";
-import { foodParcels } from "@/app/db/schema";
+import { auditLog, foodParcels } from "@/app/db/schema";
 import type { FormData } from "@/app/[locale]/households/enroll/types";
 import { stripSwedishPrefix } from "@/app/utils/validation/phone-validation";
 
@@ -182,6 +182,40 @@ describe("Household parcel scheduling integration", () => {
         expect(activeParcels[0].pickup_date_time_earliest).toEqual(slot.start);
         expect(activeParcels[0].pickup_date_time_latest).toEqual(slot.end);
         expect(mockQueuePickupUpdatedSms).not.toHaveBeenCalled();
+    });
+
+    it("writes household edit audit details with only the fields that changed", async () => {
+        const db = await getTestDb();
+        const household = await createTestHousehold({ locale: "sv" });
+
+        const updateData = buildUpdateData(household, "", []);
+        updateData.household.phone_number = "0700009999";
+        updateData.household.locale = "en";
+
+        const result = await updateHousehold(household.id, updateData);
+        expect(result.success).toBe(true);
+
+        const [auditRow] = await db
+            .select()
+            .from(auditLog)
+            .where(eq(auditLog.entity_id, household.id));
+
+        const details = auditRow.details as {
+            changes: Record<string, { before: unknown; after: unknown }>;
+        };
+        expect(auditRow).toMatchObject({
+            actor_username: "test-admin",
+            entity_type: "household",
+            action: "updated",
+            summary: "Updated household",
+        });
+        expect(Object.keys(details.changes).sort()).toEqual(["locale", "phone_number"]);
+        expect(details.changes.locale).toEqual({ before: "sv", after: "en" });
+        expect(details.changes.phone_number).toEqual({
+            before: household.phone_number,
+            after: "+46700009999",
+        });
+        expect(JSON.stringify(details)).not.toContain("comments");
     });
 
     it("adds a new parcel through the parcel management dialog action", async () => {

--- a/__tests__/integration/schedule/audit-logging.integration.test.ts
+++ b/__tests__/integration/schedule/audit-logging.integration.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../factories";
 import {
     scheduleAuditLog,
+    auditLog,
     pickupLocationSchedules,
     pickupLocationScheduleDays,
     pickupLocations,
@@ -104,6 +105,24 @@ describe("Schedule Audit Logging - Integration Tests", () => {
             expect(logs[0].changed_by).toBe("audit-test-user");
             expect(logs[0].schedule_id).toBeDefined();
             expect(logs[0].changes_summary).toContain("Winter Schedule");
+
+            const scheduleId = logs[0].schedule_id;
+            expect(scheduleId).not.toBeNull();
+            const genericLogs = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.entity_id, scheduleId!));
+            expect(genericLogs).toHaveLength(1);
+            expect(genericLogs[0]).toMatchObject({
+                actor_username: "audit-test-user",
+                entity_type: "schedule",
+                action: "updated",
+                summary: "Updated pickup location opening hours",
+                details: {
+                    pickup_location_id: location.id,
+                    schedule_action: "created",
+                },
+            });
         });
 
         it("should set created_by on the schedule itself", async () => {
@@ -167,6 +186,22 @@ describe("Schedule Audit Logging - Integration Tests", () => {
             expect(logs[0].changed_by).toBe("audit-test-user");
             // Should mention the time change
             expect(logs[0].changes_summary).toBeDefined();
+
+            const genericLogs = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.entity_id, schedule.id));
+            expect(genericLogs).toHaveLength(1);
+            expect(genericLogs[0]).toMatchObject({
+                actor_username: "audit-test-user",
+                entity_type: "schedule",
+                action: "updated",
+                summary: "Updated pickup location opening hours",
+                details: {
+                    pickup_location_id: location.id,
+                    changes_summary: logs[0].changes_summary,
+                },
+            });
         });
 
         it("should set updated_by and updated_at on the schedule", async () => {
@@ -216,6 +251,22 @@ describe("Schedule Audit Logging - Integration Tests", () => {
             expect(logs[0].action).toBe("deleted");
             expect(logs[0].changed_by).toBe("audit-test-user");
             expect(logs[0].pickup_location_id).toBe(location.id);
+
+            const genericLogs = await db
+                .select()
+                .from(auditLog)
+                .where(eq(auditLog.entity_id, schedule.id));
+            expect(genericLogs).toHaveLength(1);
+            expect(genericLogs[0]).toMatchObject({
+                actor_username: "audit-test-user",
+                entity_type: "schedule",
+                action: "updated",
+                summary: "Updated pickup location opening hours",
+                details: {
+                    pickup_location_id: location.id,
+                    schedule_action: "deleted",
+                },
+            });
         });
 
         it("should preserve audit log after schedule is gone", async () => {

--- a/__tests__/integration/settings/users.integration.test.ts
+++ b/__tests__/integration/settings/users.integration.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTestDb } from "../../db/test-db";
 import { createTestUser, resetUserCounter } from "../../factories";
-import { users } from "@/app/db/schema";
+import { auditLog, users } from "@/app/db/schema";
 import { eq } from "drizzle-orm";
 
 vi.mock("next/cache", () => ({
@@ -262,6 +262,25 @@ describe("updateUserRole — anti-lockout guards", () => {
             .from(users)
             .where(eq(users.id, target.id));
         expect(row.role).toBe("admin");
+
+        const [auditRow] = await db
+            .select()
+            .from(auditLog)
+            .where(eq(auditLog.entity_id, target.id));
+        expect(auditRow).toMatchObject({
+            actor_username: "caller-admin",
+            entity_type: "user_role",
+            action: "role_changed",
+            summary: "Changed user role",
+            details: {
+                changes: {
+                    role: {
+                        before: "handout_staff",
+                        after: "admin",
+                    },
+                },
+            },
+        });
     });
 
     it("rejects demoting the last active admin even when a deactivated admin exists", async () => {

--- a/app/[locale]/handout-locations/actions.ts
+++ b/app/[locale]/handout-locations/actions.ts
@@ -22,6 +22,8 @@ import {
     PickupLocationScheduleWithDays,
 } from "./types";
 import { logError } from "@/app/utils/logger";
+import { recordAuditEvent } from "@/app/utils/audit/log";
+import { auditDetailsForChanges, buildChanges } from "@/app/utils/audit/changes";
 
 // Get all locations with their schedules
 export const getLocations = protectedAction(
@@ -189,11 +191,7 @@ export const createLocation = protectedAgreementAction(
 
 // Update an existing location
 export const updateLocation = protectedAgreementAction(
-    async (
-        _: unknown,
-        id: string,
-        locationData: LocationFormInput,
-    ): Promise<ActionResult<void>> => {
+    async (session, id: string, locationData: LocationFormInput): Promise<ActionResult<void>> => {
         // Auth already verified by protectedAction wrapper
 
         try {
@@ -214,7 +212,51 @@ export const updateLocation = protectedAgreementAction(
                 contact_phone_number: locationData.contact_phone_number,
                 default_slot_duration_minutes: locationData.default_slot_duration_minutes,
             };
-            await db.update(pickupLocations).set(locationValues).where(eq(pickupLocations.id, id));
+            await db.transaction(async tx => {
+                const [existingLocation] = await tx
+                    .select({
+                        parcels_max_per_day: pickupLocations.parcels_max_per_day,
+                        max_parcels_per_slot: pickupLocations.max_parcels_per_slot,
+                        default_slot_duration_minutes:
+                            pickupLocations.default_slot_duration_minutes,
+                    })
+                    .from(pickupLocations)
+                    .where(eq(pickupLocations.id, id))
+                    .limit(1);
+
+                await tx
+                    .update(pickupLocations)
+                    .set(locationValues)
+                    .where(eq(pickupLocations.id, id));
+
+                if (existingLocation) {
+                    const changes = buildChanges(
+                        {
+                            parcels_max_per_day: existingLocation.parcels_max_per_day,
+                            max_parcels_per_slot: existingLocation.max_parcels_per_slot,
+                            default_slot_duration_minutes:
+                                existingLocation.default_slot_duration_minutes,
+                        },
+                        {
+                            parcels_max_per_day: locationData.parcels_max_per_day,
+                            max_parcels_per_slot: locationData.max_parcels_per_slot,
+                            default_slot_duration_minutes:
+                                locationData.default_slot_duration_minutes,
+                        },
+                    );
+
+                    if (Object.keys(changes).length > 0) {
+                        await recordAuditEvent(tx, {
+                            session,
+                            entityType: "pickup_location",
+                            entityId: id,
+                            action: "updated",
+                            summary: "Updated pickup location capacity settings",
+                            details: auditDetailsForChanges(changes),
+                        });
+                    }
+                }
+            });
 
             // Get the current locale from headers
             const locale = (await headers()).get("x-locale") || "en";
@@ -337,6 +379,18 @@ export const createSchedule = protectedAgreementAction(
                     action: "created",
                     changed_by: username,
                     changes_summary: `Created schedule "${scheduleData.name}" (${openDays})`,
+                });
+
+                await recordAuditEvent(tx, {
+                    session,
+                    entityType: "schedule",
+                    entityId: schedule.id,
+                    action: "updated",
+                    summary: "Updated pickup location opening hours",
+                    details: {
+                        pickup_location_id: locationId,
+                        schedule_action: "created",
+                    },
                 });
 
                 // Create the return object
@@ -500,6 +554,18 @@ export const updateSchedule = protectedAgreementAction(
                     changes_summary: summary,
                 });
 
+                await recordAuditEvent(tx, {
+                    session,
+                    entityType: "schedule",
+                    entityId: scheduleId,
+                    action: "updated",
+                    summary: "Updated pickup location opening hours",
+                    details: {
+                        pickup_location_id: locationId,
+                        changes_summary: summary,
+                    },
+                });
+
                 // Create the return object
                 updatedSchedule = {
                     ...schedule,
@@ -567,6 +633,18 @@ export const deleteSchedule = protectedAgreementAction(
                         action: "deleted",
                         changed_by: username,
                         changes_summary: `Deleted schedule "${scheduleRow.name}"`,
+                    });
+
+                    await recordAuditEvent(tx, {
+                        session,
+                        entityType: "schedule",
+                        entityId: scheduleId,
+                        action: "updated",
+                        summary: "Updated pickup location opening hours",
+                        details: {
+                            pickup_location_id: scheduleRow.pickup_location_id,
+                            schedule_action: "deleted",
+                        },
                     });
                 }
 

--- a/app/[locale]/households/[id]/edit/actions.ts
+++ b/app/[locale]/households/[id]/edit/actions.ts
@@ -39,6 +39,8 @@ import {
     runHouseholdParcelPostCommitEffects,
     type HouseholdParcelScheduleChangeSummary,
 } from "@/app/utils/parcels/apply-parcel-schedule-changes";
+import { recordAuditEvent } from "@/app/utils/audit/log";
+import { auditDetailsForChanges, buildChanges } from "@/app/utils/audit/changes";
 
 export interface HouseholdUpdateResult {
     success: boolean;
@@ -54,6 +56,17 @@ type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 function dedupeIds(ids: string[]): string[] {
     return [...new Set(ids.filter(Boolean))];
+}
+
+function normalizedList(values: string[]): string {
+    return [...values].sort().join(",");
+}
+
+function normalizedMembersForAudit(members: FormData["members"]): string {
+    return members
+        .map(member => `${member.age}:${member.sex}`)
+        .sort()
+        .join(",");
 }
 
 function nameValidationMessage(
@@ -450,9 +463,16 @@ export const updateHousehold = protectedAdminHouseholdAction(
             // Check if phone number changed and validate no duplicates
             const newPhoneE164 = normalizePhoneToE164(data.household.phone_number);
 
-            // Fetch current phone number to detect changes (HouseholdData doesn't include it)
+            // Fetch current household data to detect changes (HouseholdData doesn't include all fields)
             const [currentHousehold] = await db
-                .select({ phone_number: households.phone_number })
+                .select({
+                    first_name: households.first_name,
+                    last_name: households.last_name,
+                    phone_number: households.phone_number,
+                    locale: households.locale,
+                    primary_pickup_location_id: households.primary_pickup_location_id,
+                    responsible_user_id: households.responsible_user_id,
+                })
                 .from(households)
                 .where(eq(households.id, household.id))
                 .limit(1);
@@ -500,13 +520,41 @@ export const updateHousehold = protectedAdminHouseholdAction(
                     await ensurePickupLocationExists(tx, primaryLocationId);
                 }
 
-                const [existingResponsibleUser] = await tx
-                    .select({ responsible_user_id: households.responsible_user_id })
+                const [existingHousehold] = await tx
+                    .select({
+                        first_name: households.first_name,
+                        last_name: households.last_name,
+                        phone_number: households.phone_number,
+                        locale: households.locale,
+                        primary_pickup_location_id: households.primary_pickup_location_id,
+                        responsible_user_id: households.responsible_user_id,
+                    })
                     .from(households)
                     .where(eq(households.id, household.id))
                     .limit(1);
 
-                const currentResponsibleUserId = existingResponsibleUser?.responsible_user_id;
+                if (!existingHousehold) {
+                    throw new Error("Household not found");
+                }
+
+                const currentMembers = await tx
+                    .select({ age: householdMembers.age, sex: householdMembers.sex })
+                    .from(householdMembers)
+                    .where(eq(householdMembers.household_id, household.id));
+                const currentDietaryRestrictionIds = await tx
+                    .select({ id: householdDietaryRestrictions.dietary_restriction_id })
+                    .from(householdDietaryRestrictions)
+                    .where(eq(householdDietaryRestrictions.household_id, household.id));
+                const currentAdditionalNeedIds = await tx
+                    .select({ id: householdAdditionalNeeds.additional_need_id })
+                    .from(householdAdditionalNeeds)
+                    .where(eq(householdAdditionalNeeds.household_id, household.id));
+                const currentPetSpeciesIds = await tx
+                    .select({ id: pets.pet_species_id })
+                    .from(pets)
+                    .where(eq(pets.household_id, household.id));
+
+                const currentResponsibleUserId = existingHousehold.responsible_user_id;
                 await ensureResponsibleUserIsAssignable(
                     tx,
                     responsibleUserId,
@@ -631,6 +679,53 @@ export const updateHousehold = protectedAdminHouseholdAction(
                     }
                 }
 
+                const changes = buildChanges(
+                    {
+                        first_name: existingHousehold.first_name,
+                        last_name: existingHousehold.last_name,
+                        phone_number: existingHousehold.phone_number,
+                        locale: existingHousehold.locale,
+                        primary_pickup_location_id:
+                            existingHousehold.primary_pickup_location_id ?? null,
+                        responsible_user_id: existingHousehold.responsible_user_id ?? null,
+                        members: normalizedMembersForAudit(currentMembers),
+                        dietary_restriction_ids: normalizedList(
+                            currentDietaryRestrictionIds.map(row => row.id),
+                        ),
+                        additional_need_ids: normalizedList(
+                            currentAdditionalNeedIds.map(row => row.id),
+                        ),
+                        pet_species_ids: normalizedList(currentPetSpeciesIds.map(row => row.id)),
+                    },
+                    {
+                        first_name: firstName.value,
+                        last_name: lastName.value,
+                        phone_number: newPhoneE164,
+                        locale: data.household.locale,
+                        primary_pickup_location_id: primaryLocationId,
+                        responsible_user_id: responsibleUserId,
+                        members: normalizedMembersForAudit(data.members),
+                        dietary_restriction_ids: normalizedList(
+                            dedupeIds(data.dietaryRestrictions.map(restriction => restriction.id)),
+                        ),
+                        additional_need_ids: normalizedList(
+                            dedupeIds(data.additionalNeeds.map(need => need.id)),
+                        ),
+                        pet_species_ids: normalizedList(data.pets.map(pet => pet.species)),
+                    },
+                );
+
+                if (Object.keys(changes).length > 0) {
+                    await recordAuditEvent(tx, {
+                        session,
+                        entityType: "household",
+                        entityId: household.id,
+                        action: "updated",
+                        summary: "Updated household",
+                        details: auditDetailsForChanges(changes),
+                    });
+                }
+
                 // Audit log with IDs only (no PII)
                 logger.info(
                     {
@@ -709,6 +804,26 @@ export const updateResponsibleStaff = protectedAdminHouseholdAction(
                         responsible_user_id: data.responsibleUserId,
                     })
                     .where(eq(households.id, household.id));
+
+                const changes = buildChanges(
+                    {
+                        responsible_user_id: existingResponsibleUser?.responsible_user_id ?? null,
+                    },
+                    {
+                        responsible_user_id: data.responsibleUserId,
+                    },
+                );
+
+                if (Object.keys(changes).length > 0) {
+                    await recordAuditEvent(tx, {
+                        session,
+                        entityType: "household",
+                        entityId: household.id,
+                        action: "updated",
+                        summary: "Updated household responsible staff",
+                        details: auditDetailsForChanges(changes),
+                    });
+                }
             });
 
             logger.info(

--- a/app/[locale]/schedule/actions.ts
+++ b/app/[locale]/schedule/actions.ts
@@ -46,6 +46,8 @@ import { success, failure, type ActionResult } from "@/app/utils/auth/action-res
 import { logError } from "@/app/utils/logger";
 import { formatUserDisplayName } from "@/app/utils/format-user-display-name";
 import { fetchPickupLocationSchedules } from "@/app/utils/schedule/pickup-location-schedules";
+import { recordAuditEvent } from "@/app/utils/audit/log";
+import { auditDetailsForChanges, buildChanges } from "@/app/utils/audit/changes";
 
 import { type DbOrTransaction } from "@/app/db/types";
 // Import types for use within this server action file
@@ -683,6 +685,8 @@ export const updateFoodParcelSchedule = protectedAdminAction(
                 const [parcel] = await tx
                     .select({
                         locationId: foodParcels.pickup_location_id,
+                        pickupEarliest: foodParcels.pickup_date_time_earliest,
+                        pickupLatest: foodParcels.pickup_date_time_latest,
                     })
                     .from(foodParcels)
                     .where(and(eq(foodParcels.id, parcelId), notDeleted()))
@@ -741,6 +745,26 @@ export const updateFoodParcelSchedule = protectedAdminAction(
                         pickup_date_time_latest: endTime, // Use our calculated end time
                     })
                     .where(eq(foodParcels.id, parcelId));
+
+                const changes = buildChanges(
+                    {
+                        pickup_date_time_earliest: parcel.pickupEarliest.toISOString(),
+                        pickup_date_time_latest: parcel.pickupLatest.toISOString(),
+                    },
+                    {
+                        pickup_date_time_earliest: newTimeslot.startTime.toISOString(),
+                        pickup_date_time_latest: endTime.toISOString(),
+                    },
+                );
+
+                await recordAuditEvent(tx, {
+                    session,
+                    entityType: "parcel",
+                    entityId: parcelId,
+                    action: "rescheduled",
+                    summary: "Rescheduled parcel pickup time",
+                    details: auditDetailsForChanges(changes),
+                });
             });
 
             /**
@@ -1608,7 +1632,7 @@ export async function getTotalOutsideHoursCount(): Promise<number> {
  */
 export const bulkRescheduleParcels = protectedAdminAction(
     async (
-        _session,
+        session,
         parcelIds: string[],
         newTimeslot: { startTime: Date },
     ): Promise<ActionResult<{ count: number }>> => {
@@ -1623,6 +1647,8 @@ export const bulkRescheduleParcels = protectedAdminAction(
                     id: foodParcels.id,
                     locationId: foodParcels.pickup_location_id,
                     isPickedUp: foodParcels.is_picked_up,
+                    pickupEarliest: foodParcels.pickup_date_time_earliest,
+                    pickupLatest: foodParcels.pickup_date_time_latest,
                 })
                 .from(foodParcels)
                 .where(and(inArray(foodParcels.id, parcelIds), notDeleted()));
@@ -1755,6 +1781,28 @@ export const bulkRescheduleParcels = protectedAdminAction(
                         pickup_date_time_latest: endTime,
                     })
                     .where(inArray(foodParcels.id, parcelIds));
+
+                for (const parcel of parcels) {
+                    const changes = buildChanges(
+                        {
+                            pickup_date_time_earliest: parcel.pickupEarliest.toISOString(),
+                            pickup_date_time_latest: parcel.pickupLatest.toISOString(),
+                        },
+                        {
+                            pickup_date_time_earliest: newTimeslot.startTime.toISOString(),
+                            pickup_date_time_latest: endTime.toISOString(),
+                        },
+                    );
+
+                    await recordAuditEvent(tx, {
+                        session,
+                        entityType: "parcel",
+                        entityId: parcel.id,
+                        action: "rescheduled",
+                        summary: "Rescheduled parcel pickup time",
+                        details: auditDetailsForChanges(changes),
+                    });
+                }
             });
 
             // Recompute outside_hours_count after commit

--- a/app/[locale]/settings/general/actions.ts
+++ b/app/[locale]/settings/general/actions.ts
@@ -17,6 +17,8 @@ import { revalidatePath } from "next/cache";
 import { routing } from "@/app/i18n/routing";
 import { logError } from "@/app/utils/logger";
 import { formatUserDisplayName } from "@/app/utils/format-user-display-name";
+import { recordAuditEvent } from "@/app/utils/audit/log";
+import { auditDetailsForChanges, buildChanges } from "@/app/utils/audit/changes";
 import {
     NOSHOW_FOLLOWUP_ENABLED_KEY,
     NOSHOW_CONSECUTIVE_THRESHOLD_KEY,
@@ -485,6 +487,19 @@ export const updateNoShowFollowupSettings = protectedAction(
             ];
 
             await db.transaction(async tx => {
+                const existingSettings = await tx
+                    .select({ key: globalSettings.key, value: globalSettings.value })
+                    .from(globalSettings)
+                    .where(
+                        inArray(
+                            globalSettings.key,
+                            settingsToUpdate.map(setting => setting.key),
+                        ),
+                    );
+                const existingByKey = new Map(
+                    existingSettings.map(setting => [setting.key, setting.value]),
+                );
+
                 // Use ON CONFLICT DO UPDATE for atomic upserts
                 await Promise.all(
                     settingsToUpdate.map(setting =>
@@ -507,6 +522,29 @@ export const updateNoShowFollowupSettings = protectedAction(
                             }),
                     ),
                 );
+
+                const changes = buildChanges(
+                    Object.fromEntries(
+                        settingsToUpdate.map(setting => [
+                            setting.key,
+                            existingByKey.get(setting.key) ?? null,
+                        ]),
+                    ),
+                    Object.fromEntries(
+                        settingsToUpdate.map(setting => [setting.key, setting.value]),
+                    ),
+                );
+
+                if (Object.keys(changes).length > 0) {
+                    await recordAuditEvent(tx, {
+                        session,
+                        entityType: "global_setting",
+                        entityId: "no_show_followup",
+                        action: "updated",
+                        summary: "Updated no-show follow-up settings",
+                        details: auditDetailsForChanges(changes),
+                    });
+                }
             });
 
             revalidateSettingsPage();

--- a/app/[locale]/settings/parcels/actions.ts
+++ b/app/[locale]/settings/parcels/actions.ts
@@ -8,6 +8,8 @@ import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { routing } from "@/app/i18n/routing";
 import { logError } from "@/app/utils/logger";
+import { recordAuditEvent } from "@/app/utils/audit/log";
+import { auditDetailsForChanges, buildChanges } from "@/app/utils/audit/changes";
 
 const PARCEL_WARNING_THRESHOLD_KEY = "parcel_warning_threshold";
 
@@ -69,29 +71,43 @@ export const updateParcelWarningThreshold = protectedAction(
 
             const value = threshold !== null ? threshold.toString() : null;
 
-            // Upsert the setting
-            const [existingSetting] = await db
-                .select()
-                .from(globalSettings)
-                .where(eq(globalSettings.key, PARCEL_WARNING_THRESHOLD_KEY));
-
-            if (existingSetting) {
-                await db
-                    .update(globalSettings)
-                    .set({
-                        value,
-                        updated_at: new Date(),
-                        updated_by: session.user?.githubUsername,
-                    })
+            await db.transaction(async tx => {
+                const [existingSetting] = await tx
+                    .select()
+                    .from(globalSettings)
                     .where(eq(globalSettings.key, PARCEL_WARNING_THRESHOLD_KEY));
-            } else {
-                await db.insert(globalSettings).values({
-                    id: nanoid(8),
-                    key: PARCEL_WARNING_THRESHOLD_KEY,
-                    value,
-                    updated_by: session.user?.githubUsername,
-                });
-            }
+
+                if (existingSetting) {
+                    await tx
+                        .update(globalSettings)
+                        .set({
+                            value,
+                            updated_at: new Date(),
+                            updated_by: session.user?.githubUsername,
+                        })
+                        .where(eq(globalSettings.key, PARCEL_WARNING_THRESHOLD_KEY));
+                } else {
+                    await tx.insert(globalSettings).values({
+                        id: nanoid(8),
+                        key: PARCEL_WARNING_THRESHOLD_KEY,
+                        value,
+                        updated_by: session.user?.githubUsername,
+                    });
+                }
+
+                const changes = buildChanges({ value: existingSetting?.value ?? null }, { value });
+
+                if (Object.keys(changes).length > 0) {
+                    await recordAuditEvent(tx, {
+                        session,
+                        entityType: "global_setting",
+                        entityId: PARCEL_WARNING_THRESHOLD_KEY,
+                        action: "updated",
+                        summary: "Updated parcel warning threshold",
+                        details: auditDetailsForChanges(changes),
+                    });
+                }
+            });
 
             revalidateSettingsPage();
             return success({ threshold });

--- a/app/[locale]/settings/users/actions.ts
+++ b/app/[locale]/settings/users/actions.ts
@@ -97,6 +97,19 @@ export const updateUserRole = protectedAdminAction(
             // Wrapped in a transaction with a FOR UPDATE lock on all admin rows to prevent
             // two concurrent demotions from both passing the count check.
             await db.transaction(async tx => {
+                if (role !== "admin") {
+                    // Lock all active admin rows before counting to serialise concurrent demotions.
+                    // Deactivated admins (deactivated_at IS NOT NULL) are excluded — they can't
+                    // act as admins, so they must not count toward the last-admin guard.
+                    await tx.execute(
+                        sql`SELECT id FROM ${users} WHERE role = 'admin' AND deactivated_at IS NULL FOR UPDATE`,
+                    );
+                }
+
+                // Lock the target row before reading the before-state used by
+                // both anti-lockout checks and audit details.
+                await tx.execute(sql`SELECT id FROM ${users} WHERE id = ${userId} FOR UPDATE`);
+
                 const targetRows = await tx
                     .select({ role: users.role, deactivated_at: users.deactivated_at })
                     .from(users)
@@ -111,13 +124,6 @@ export const updateUserRole = protectedAdminAction(
                 }
 
                 if (role !== "admin") {
-                    // Lock all active admin rows before counting to serialise concurrent demotions.
-                    // Deactivated admins (deactivated_at IS NOT NULL) are excluded — they can't
-                    // act as admins, so they must not count toward the last-admin guard.
-                    await tx.execute(
-                        sql`SELECT id FROM ${users} WHERE role = 'admin' AND deactivated_at IS NULL FOR UPDATE`,
-                    );
-
                     const [{ count }] = await tx
                         .select({ count: sql<number>`count(*)::int` })
                         .from(users)

--- a/app/[locale]/settings/users/actions.ts
+++ b/app/[locale]/settings/users/actions.ts
@@ -8,6 +8,8 @@ import { and, eq, isNull, sql } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { routing } from "@/app/i18n/routing";
 import { logError } from "@/app/utils/logger";
+import { recordAuditEvent } from "@/app/utils/audit/log";
+import { auditDetailsForChanges, buildChanges } from "@/app/utils/audit/changes";
 
 export interface UserRow {
     id: string;
@@ -95,6 +97,19 @@ export const updateUserRole = protectedAdminAction(
             // Wrapped in a transaction with a FOR UPDATE lock on all admin rows to prevent
             // two concurrent demotions from both passing the count check.
             await db.transaction(async tx => {
+                const targetRows = await tx
+                    .select({ role: users.role, deactivated_at: users.deactivated_at })
+                    .from(users)
+                    .where(eq(users.id, userId))
+                    .limit(1);
+                const targetUser = targetRows[0];
+
+                if (!targetUser) {
+                    throw Object.assign(new Error("User not found"), {
+                        code: "USER_NOT_FOUND",
+                    });
+                }
+
                 if (role !== "admin") {
                     // Lock all active admin rows before counting to serialise concurrent demotions.
                     // Deactivated admins (deactivated_at IS NOT NULL) are excluded — they can't
@@ -108,17 +123,11 @@ export const updateUserRole = protectedAdminAction(
                         .from(users)
                         .where(and(eq(users.role, "admin"), isNull(users.deactivated_at)));
 
-                    const targetRows = await tx
-                        .select({ role: users.role, deactivated_at: users.deactivated_at })
-                        .from(users)
-                        .where(eq(users.id, userId))
-                        .limit(1);
-
                     // Only guard active admins: a deactivated admin is not in `count`,
                     // so changing their role cannot remove the last active admin.
                     if (
-                        targetRows[0]?.role === "admin" &&
-                        targetRows[0]?.deactivated_at === null &&
+                        targetUser.role === "admin" &&
+                        targetUser.deactivated_at === null &&
                         count <= 1
                     ) {
                         throw Object.assign(new Error("Cannot demote the last admin"), {
@@ -135,6 +144,18 @@ export const updateUserRole = protectedAdminAction(
                 if (updated.length === 0) {
                     throw Object.assign(new Error("User not found"), {
                         code: "USER_NOT_FOUND",
+                    });
+                }
+
+                const changes = buildChanges({ role: targetUser.role }, { role });
+                if (Object.keys(changes).length > 0) {
+                    await recordAuditEvent(tx, {
+                        session,
+                        entityType: "user_role",
+                        entityId: userId,
+                        action: "role_changed",
+                        summary: "Changed user role",
+                        details: auditDetailsForChanges(changes),
                     });
                 }
             });

--- a/app/api/admin/sms/[smsId]/dismiss/route.ts
+++ b/app/api/admin/sms/[smsId]/dismiss/route.ts
@@ -4,6 +4,7 @@ import { outgoingSms } from "@/app/db/schema";
 import { eq } from "drizzle-orm";
 import { authenticateAdminRequest } from "@/app/utils/auth/api-auth";
 import { logger, logError } from "@/app/utils/logger";
+import { recordAuditEvent } from "@/app/utils/audit/log";
 
 // nanoid default alphabet: A-Za-z0-9_-
 // Standard length is 21 chars, but we allow some flexibility
@@ -80,24 +81,39 @@ export async function PATCH(
                 { status: 400 },
             );
         }
+        const validatedSmsId = smsId;
 
         // Single atomic update with RETURNING to avoid TOCTOU race condition
         const now = new Date();
-        const [updated] = await db
-            .update(outgoingSms)
-            .set(
-                dismissed
-                    ? {
-                          dismissed_at: now,
-                          dismissed_by_user_id: username,
-                      }
-                    : {
-                          dismissed_at: null,
-                          dismissed_by_user_id: null,
-                      },
-            )
-            .where(eq(outgoingSms.id, smsId))
-            .returning({ id: outgoingSms.id });
+        const updated = await db.transaction(async tx => {
+            const [row] = await tx
+                .update(outgoingSms)
+                .set(
+                    dismissed
+                        ? {
+                              dismissed_at: now,
+                              dismissed_by_user_id: username,
+                          }
+                        : {
+                              dismissed_at: null,
+                              dismissed_by_user_id: null,
+                          },
+                )
+                .where(eq(outgoingSms.id, validatedSmsId))
+                .returning({ id: outgoingSms.id });
+
+            if (row && dismissed) {
+                await recordAuditEvent(tx, {
+                    session: authResult.session,
+                    entityType: "sms",
+                    entityId: validatedSmsId,
+                    action: "failure_dismissed",
+                    summary: "Dismissed SMS failure",
+                });
+            }
+
+            return row;
+        });
 
         if (!updated) {
             return NextResponse.json(

--- a/app/api/admin/sms/[smsId]/dismiss/route.ts
+++ b/app/api/admin/sms/[smsId]/dismiss/route.ts
@@ -14,6 +14,14 @@ function isValidSmsId(id: string): boolean {
     return NANOID_PATTERN.test(id);
 }
 
+function smsAuditTarget(sms: { parcelId: string | null; householdId: string }) {
+    if (sms.parcelId) {
+        return { entityType: "parcel", entityId: sms.parcelId };
+    }
+
+    return { entityType: "household", entityId: sms.householdId };
+}
+
 /**
  * PATCH /api/admin/sms/[smsId]/dismiss - Dismiss or restore an SMS failure
  *
@@ -100,15 +108,21 @@ export async function PATCH(
                           },
                 )
                 .where(eq(outgoingSms.id, validatedSmsId))
-                .returning({ id: outgoingSms.id });
+                .returning({
+                    id: outgoingSms.id,
+                    parcelId: outgoingSms.parcel_id,
+                    householdId: outgoingSms.household_id,
+                });
 
             if (row && dismissed) {
                 await recordAuditEvent(tx, {
                     session: authResult.session,
-                    entityType: "sms",
-                    entityId: validatedSmsId,
+                    ...smsAuditTarget(row),
                     action: "failure_dismissed",
                     summary: "Dismissed SMS failure",
+                    details: {
+                        sms_id: validatedSmsId,
+                    },
                 });
             }
 

--- a/app/api/admin/sms/[smsId]/retry/route.ts
+++ b/app/api/admin/sms/[smsId]/retry/route.ts
@@ -27,6 +27,14 @@ const RETRYABLE_INTENTS = new Set([
 
 const PARCEL_INTENTS = new Set(["pickup_reminder", "pickup_updated", "pickup_cancelled"]);
 
+function smsAuditTarget(sms: { parcelId: string | null; householdId: string }) {
+    if (sms.parcelId) {
+        return { entityType: "parcel", entityId: sms.parcelId };
+    }
+
+    return { entityType: "household", entityId: sms.householdId };
+}
+
 /**
  * POST /api/admin/sms/[smsId]/retry - Retry a failed SMS
  *
@@ -244,15 +252,13 @@ export async function POST(
 
             await recordAuditEvent(tx, {
                 session: authResult.session,
-                entityType: "sms",
-                entityId: smsId!,
+                ...smsAuditTarget(originalSms),
                 action: "retried",
                 summary: "Retried SMS failure",
                 details: {
+                    sms_id: smsId!,
                     new_sms_id: newSmsId,
                     intent: originalSms.intent,
-                    household_id: originalSms.householdId,
-                    parcel_id: originalSms.parcelId ?? null,
                 },
             });
 

--- a/app/api/admin/sms/[smsId]/retry/route.ts
+++ b/app/api/admin/sms/[smsId]/retry/route.ts
@@ -9,6 +9,7 @@ import { SMS_RATE_LIMITS } from "@/app/utils/rate-limit";
 import { logger, logError } from "@/app/utils/logger";
 import { Time } from "@/app/utils/time-provider";
 import { nanoid } from "nanoid";
+import { recordAuditEvent } from "@/app/utils/audit/log";
 
 const NANOID_PATTERN = /^[A-Za-z0-9_-]{10,30}$/;
 
@@ -231,7 +232,7 @@ export async function POST(
                 return null; // Another request already handled this SMS
             }
 
-            return createSmsRecord({
+            const newSmsId = await createSmsRecord({
                 intent: originalSms.intent,
                 parcelId: isParcelIntent ? originalSms.parcelId! : undefined,
                 householdId: originalSms.householdId,
@@ -240,6 +241,22 @@ export async function POST(
                 idempotencyKey: `${originalSms.intent}|${originalSms.householdId}|retry|${nanoid(8)}`,
                 tx,
             });
+
+            await recordAuditEvent(tx, {
+                session: authResult.session,
+                entityType: "sms",
+                entityId: smsId!,
+                action: "retried",
+                summary: "Retried SMS failure",
+                details: {
+                    new_sms_id: newSmsId,
+                    intent: originalSms.intent,
+                    household_id: originalSms.householdId,
+                    parcel_id: originalSms.parcelId ?? null,
+                },
+            });
+
+            return newSmsId;
         });
 
         if (!newSmsId) {

--- a/app/api/admin/sms/retry-balance-failures/route.ts
+++ b/app/api/admin/sms/retry-balance-failures/route.ts
@@ -21,7 +21,7 @@ export async function POST() {
             return authResult.response;
         }
 
-        const requeuedCount = await requeueBalanceFailures();
+        const requeuedCount = await requeueBalanceFailures(authResult.session);
 
         logger.info(
             { requeuedCount, triggeredBy: authResult.session.user.githubUsername },

--- a/app/utils/anonymization/anonymize-household.ts
+++ b/app/utils/anonymization/anonymize-household.ts
@@ -17,9 +17,13 @@ import {
     householdAdditionalNeeds,
     householdVerificationStatus,
     pets,
+    auditLog,
 } from "@/app/db/schema";
-import { eq, and, gte, isNull, sql, desc } from "drizzle-orm";
+import { eq, and, gte, isNull, sql, desc, inArray, or } from "drizzle-orm";
 import { logger, logError } from "@/app/utils/logger";
+import { recordAuditEvent, type AuditActorSession } from "@/app/utils/audit/log";
+
+type AnonymizationTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 /**
  * Result of removal operation
@@ -88,6 +92,35 @@ async function getNextAnonymizationSequence(): Promise<number> {
     return isNaN(lastSequence) ? 1 : lastSequence + 1;
 }
 
+function auditSessionFromPerformedBy(performedBy: string): AuditActorSession | null {
+    return performedBy === "system" ? null : { user: { githubUsername: performedBy } };
+}
+
+async function pruneHouseholdAuditRows(
+    tx: AnonymizationTransaction,
+    householdId: string,
+): Promise<void> {
+    const parcelRows = await tx
+        .select({ id: foodParcels.id })
+        .from(foodParcels)
+        .where(eq(foodParcels.household_id, householdId));
+    const parcelIds = parcelRows.map(row => row.id);
+
+    await tx
+        .delete(auditLog)
+        .where(
+            or(
+                and(eq(auditLog.entity_type, "household"), eq(auditLog.entity_id, householdId)),
+                parcelIds.length > 0
+                    ? and(
+                          eq(auditLog.entity_type, "parcel"),
+                          inArray(auditLog.entity_id, parcelIds),
+                      )
+                    : sql`false`,
+            ),
+        );
+}
+
 /**
  * Anonymize household data (replace PII with placeholders, delete comments/SMS)
  */
@@ -99,6 +132,8 @@ async function anonymizeHousehold(
     const phoneNumber = `000000${sequence.toString().padStart(4, "0")}`; // e.g., "0000000001"
 
     await db.transaction(async tx => {
+        await pruneHouseholdAuditRows(tx, householdId);
+
         // Anonymize the household record itself — name and phone become
         // placeholders, anonymized_at marks the row as inactive.
         await tx
@@ -147,6 +182,14 @@ async function anonymizeHousehold(
         await tx
             .delete(householdVerificationStatus)
             .where(eq(householdVerificationStatus.household_id, householdId));
+
+        await recordAuditEvent(tx, {
+            session: auditSessionFromPerformedBy(performedBy),
+            entityType: "household",
+            entityId: householdId,
+            action: "anonymized",
+            summary: "Anonymized household",
+        });
     });
 
     logger.info(
@@ -164,8 +207,23 @@ async function anonymizeHousehold(
 /**
  * Hard delete household (cascade deletes all related records)
  */
-async function hardDeleteHousehold(householdId: string): Promise<RemovalResult> {
-    await db.delete(households).where(eq(households.id, householdId));
+async function hardDeleteHousehold(
+    householdId: string,
+    performedBy: string,
+): Promise<RemovalResult> {
+    await db.transaction(async tx => {
+        await pruneHouseholdAuditRows(tx, householdId);
+
+        await recordAuditEvent(tx, {
+            session: auditSessionFromPerformedBy(performedBy),
+            entityType: "household",
+            entityId: householdId,
+            action: "removed",
+            summary: "Removed household",
+        });
+
+        await tx.delete(households).where(eq(households.id, householdId));
+    });
 
     logger.info(
         {
@@ -208,7 +266,7 @@ export async function removeHousehold(
 
     if (parcelCount.length === 0) {
         // No parcels at all → Hard delete
-        return await hardDeleteHousehold(householdId);
+        return await hardDeleteHousehold(householdId, performedBy);
     }
 
     // Has parcels → Anonymize to preserve statistics

--- a/app/utils/anonymization/anonymize-household.ts
+++ b/app/utils/anonymization/anonymize-household.ts
@@ -21,7 +21,6 @@ import {
 } from "@/app/db/schema";
 import { eq, and, gte, isNull, sql, desc, inArray, or } from "drizzle-orm";
 import { logger, logError } from "@/app/utils/logger";
-import { recordAuditEvent, type AuditActorSession } from "@/app/utils/audit/log";
 
 type AnonymizationTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
@@ -90,10 +89,6 @@ async function getNextAnonymizationSequence(): Promise<number> {
     // Extract sequence from phone number (e.g., "0000000042" -> 42)
     const lastSequence = parseInt(result[0].phone.replace("000000", ""), 10);
     return isNaN(lastSequence) ? 1 : lastSequence + 1;
-}
-
-function auditSessionFromPerformedBy(performedBy: string): AuditActorSession | null {
-    return performedBy === "system" ? null : { user: { githubUsername: performedBy } };
 }
 
 async function pruneHouseholdAuditRows(
@@ -182,14 +177,6 @@ async function anonymizeHousehold(
         await tx
             .delete(householdVerificationStatus)
             .where(eq(householdVerificationStatus.household_id, householdId));
-
-        await recordAuditEvent(tx, {
-            session: auditSessionFromPerformedBy(performedBy),
-            entityType: "household",
-            entityId: householdId,
-            action: "anonymized",
-            summary: "Anonymized household",
-        });
     });
 
     logger.info(
@@ -207,20 +194,9 @@ async function anonymizeHousehold(
 /**
  * Hard delete household (cascade deletes all related records)
  */
-async function hardDeleteHousehold(
-    householdId: string,
-    performedBy: string,
-): Promise<RemovalResult> {
+async function hardDeleteHousehold(householdId: string): Promise<RemovalResult> {
     await db.transaction(async tx => {
         await pruneHouseholdAuditRows(tx, householdId);
-
-        await recordAuditEvent(tx, {
-            session: auditSessionFromPerformedBy(performedBy),
-            entityType: "household",
-            entityId: householdId,
-            action: "removed",
-            summary: "Removed household",
-        });
 
         await tx.delete(households).where(eq(households.id, householdId));
     });
@@ -266,7 +242,7 @@ export async function removeHousehold(
 
     if (parcelCount.length === 0) {
         // No parcels at all → Hard delete
-        return await hardDeleteHousehold(householdId, performedBy);
+        return await hardDeleteHousehold(householdId);
     }
 
     // Has parcels → Anonymize to preserve statistics

--- a/app/utils/audit/changes.ts
+++ b/app/utils/audit/changes.ts
@@ -1,0 +1,41 @@
+import type { JsonObject, JsonValue } from "@/app/utils/audit/log";
+
+export interface FieldChange {
+    [key: string]: JsonValue;
+    before: JsonValue;
+    after: JsonValue;
+}
+
+export interface FieldChanges {
+    [key: string]: FieldChange;
+}
+
+export function buildChanges(
+    before: Record<string, JsonValue>,
+    after: Record<string, JsonValue>,
+): FieldChanges {
+    const changes: FieldChanges = {};
+
+    for (const key of Object.keys(after)) {
+        const beforeValue = before[key] ?? null;
+        const afterValue = after[key] ?? null;
+
+        if (beforeValue !== afterValue) {
+            changes[key] = {
+                before: beforeValue,
+                after: afterValue,
+            };
+        }
+    }
+
+    return changes;
+}
+
+export function auditDetailsForChanges(changes: FieldChanges): JsonObject | undefined {
+    return Object.keys(changes).length > 0 ? { changes } : undefined;
+}
+
+export function isoDate(value: Date | string | null | undefined): string | null {
+    if (!value) return null;
+    return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}

--- a/app/utils/parcels/apply-parcel-schedule-changes.ts
+++ b/app/utils/parcels/apply-parcel-schedule-changes.ts
@@ -14,6 +14,8 @@ import {
     type LocationScheduleInfo,
 } from "@/app/utils/schedule/outside-hours-filter";
 import { Time } from "@/app/utils/time-provider";
+import { recordAuditEvent } from "@/app/utils/audit/log";
+import { auditDetailsForChanges, buildChanges } from "@/app/utils/audit/changes";
 import {
     type ValidationError,
     ValidationErrorCodes,
@@ -584,6 +586,28 @@ export async function applyHouseholdParcelScheduleChanges(
                 pickup_date_time_latest: parcel.pickupLatestTime,
             })
             .where(eq(foodParcels.id, parcel.id!));
+
+        const changes = buildChanges(
+            {
+                pickup_location_id: existing.locationId,
+                pickup_date_time_earliest: existing.earliest.toISOString(),
+                pickup_date_time_latest: existing.latest.toISOString(),
+            },
+            {
+                pickup_location_id: parcelTargetLocationId,
+                pickup_date_time_earliest: parcel.pickupEarliestTime.toISOString(),
+                pickup_date_time_latest: parcel.pickupLatestTime.toISOString(),
+            },
+        );
+
+        await recordAuditEvent(tx, {
+            session: args.session,
+            entityType: "parcel",
+            entityId: parcel.id!,
+            action: "rescheduled",
+            summary: "Rescheduled parcel pickup time",
+            details: auditDetailsForChanges(changes),
+        });
 
         updatedParcelIds.push(parcel.id!);
     }

--- a/app/utils/parcels/state-transitions.ts
+++ b/app/utils/parcels/state-transitions.ts
@@ -64,6 +64,7 @@ import { insertParcels } from "@/app/db/insert-parcels";
 import { notDeleted } from "@/app/db/query-helpers";
 import { Time } from "@/app/utils/time-provider";
 import { formatCancellationSms } from "@/app/utils/sms/templates";
+import { recordAuditEvent } from "@/app/utils/audit/log";
 import type { SupportedLocale } from "@/app/utils/locale-detection";
 
 /**
@@ -155,11 +156,40 @@ export async function createParcels(
     tx: ParcelTransaction,
     args: {
         parcels: NewParcelInput[];
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         session: ParcelActorSession | null;
     },
 ): Promise<string[]> {
-    return insertParcels(tx, args.parcels);
+    const insertedIds = await insertParcels(tx, args.parcels);
+    if (insertedIds.length === 0) return insertedIds;
+
+    const insertedParcels = await tx
+        .select({
+            id: foodParcels.id,
+            householdId: foodParcels.household_id,
+            pickupLocationId: foodParcels.pickup_location_id,
+            pickupEarliest: foodParcels.pickup_date_time_earliest,
+            pickupLatest: foodParcels.pickup_date_time_latest,
+        })
+        .from(foodParcels)
+        .where(inArray(foodParcels.id, insertedIds));
+
+    for (const parcel of insertedParcels) {
+        await recordAuditEvent(tx, {
+            session: args.session,
+            entityType: "parcel",
+            entityId: parcel.id,
+            action: "created",
+            summary: "Created parcel",
+            details: {
+                household_id: parcel.householdId,
+                pickup_location_id: parcel.pickupLocationId,
+                pickup_date_time_earliest: parcel.pickupEarliest.toISOString(),
+                pickup_date_time_latest: parcel.pickupLatest.toISOString(),
+            },
+        });
+    }
+
+    return insertedIds;
 }
 
 // ============================================================================
@@ -197,6 +227,13 @@ export async function markPickedUp(
             error: { code: "NOT_FOUND", message: "Parcel not found or deleted" },
         };
     }
+    await recordAuditEvent(tx, {
+        session: args.session,
+        entityType: "parcel",
+        entityId: args.parcelId,
+        action: "marked_picked_up",
+        summary: "Marked parcel as picked up",
+    });
     return { ok: true };
 }
 
@@ -207,7 +244,6 @@ export async function markPickedUp(
 /** Clear pickup status. No state validation beyond not-deleted. */
 export async function undoPickup(
     tx: ParcelTransaction,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     args: { parcelId: string; session: ParcelActorSession },
 ): Promise<ParcelTransitionResult> {
     const result = await tx
@@ -226,6 +262,13 @@ export async function undoPickup(
             error: { code: "NOT_FOUND", message: "Parcel not found or deleted" },
         };
     }
+    await recordAuditEvent(tx, {
+        session: args.session,
+        entityType: "parcel",
+        entityId: args.parcelId,
+        action: "pickup_undone",
+        summary: "Undid parcel pickup",
+    });
     return { ok: true };
 }
 
@@ -314,6 +357,14 @@ export async function markNoShow(
         })
         .where(eq(foodParcels.id, args.parcelId));
 
+    await recordAuditEvent(tx, {
+        session: args.session,
+        entityType: "parcel",
+        entityId: args.parcelId,
+        action: "marked_no_show",
+        summary: "Marked parcel as no-show",
+    });
+
     return { ok: true };
 }
 
@@ -329,7 +380,6 @@ export async function markNoShow(
  */
 export async function undoNoShow(
     tx: ParcelTransaction,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     args: { parcelId: string; session: ParcelActorSession },
 ): Promise<ParcelTransitionResult> {
     const result = await tx
@@ -356,6 +406,13 @@ export async function undoNoShow(
             },
         };
     }
+    await recordAuditEvent(tx, {
+        session: args.session,
+        entityType: "parcel",
+        entityId: args.parcelId,
+        action: "no_show_undone",
+        summary: "Undid parcel no-show",
+    });
     return { ok: true };
 }
 
@@ -582,6 +639,14 @@ async function performSoftDelete(
             deleted_by_user_id: extractUsername(session),
         })
         .where(eq(foodParcels.id, parcelId));
+
+    await recordAuditEvent(tx, {
+        session,
+        entityType: "parcel",
+        entityId: parcelId,
+        action: "cancelled",
+        summary: "Cancelled parcel",
+    });
 
     return { skipped: false, smsCancelled, smsSent };
 }

--- a/app/utils/sms/sms-service.ts
+++ b/app/utils/sms/sms-service.ts
@@ -23,6 +23,7 @@ import { fetchPickupLocationSchedules } from "@/app/utils/schedule/pickup-locati
 import { generateUrl } from "@/app/config/branding";
 import { nanoid } from "nanoid";
 import { logger, logError } from "@/app/utils/logger";
+import { recordAuditEvent, type AuditActorSession } from "@/app/utils/audit/log";
 
 export type SmsIntent =
     | "pickup_reminder"
@@ -2031,27 +2032,43 @@ export async function getInsufficientBalanceStatus(): Promise<{
  *
  * @returns The number of SMS records that were re-queued
  */
-export async function requeueBalanceFailures(): Promise<number> {
+export async function requeueBalanceFailures(session?: AuditActorSession): Promise<number> {
     const now = Time.now().toUTC();
-    const result = await db
-        .update(outgoingSms)
-        .set({
-            status: "queued",
-            attempt_count: 0,
-            next_attempt_at: now,
-            last_error_message: null,
-            balance_failure: false,
-        })
-        .where(
-            and(
-                eq(outgoingSms.status, "failed"),
-                sql`${outgoingSms.dismissed_at} IS NULL`,
-                eq(outgoingSms.balance_failure, true),
-            ),
-        )
-        .returning({ id: outgoingSms.id });
+    const count = await db.transaction(async tx => {
+        const result = await tx
+            .update(outgoingSms)
+            .set({
+                status: "queued",
+                attempt_count: 0,
+                next_attempt_at: now,
+                last_error_message: null,
+                balance_failure: false,
+            })
+            .where(
+                and(
+                    eq(outgoingSms.status, "failed"),
+                    sql`${outgoingSms.dismissed_at} IS NULL`,
+                    eq(outgoingSms.balance_failure, true),
+                ),
+            )
+            .returning({ id: outgoingSms.id });
 
-    const count = result.length;
+        if (session && result.length > 0) {
+            await recordAuditEvent(tx, {
+                session,
+                entityType: "sms",
+                entityId: null,
+                action: "balance_failures_requeued",
+                summary: "Requeued balance-failed SMS",
+                details: {
+                    count: result.length,
+                },
+            });
+        }
+
+        return result.length;
+    });
+
     if (count > 0) {
         logger.info({ count }, "Re-queued balance-failed SMS for retry");
     }


### PR DESCRIPTION
Household and parcel operations currently leave some important state changes hard to reconstruct after the fact. Existing columns tell us the current state, and some dedicated tables already preserve their own history, but they do not consistently answer the operational questions admins need when something changes: who changed it, when, and why did this state move?

This adds a deliberately narrow audit trail for the business mutations where that history matters: household edit/removal/anonymization, parcel lifecycle transitions, user-role changes, critical settings, and manual SMS interventions. It intentionally avoids general activity tracking. Reads, searches, comments, agreement acceptances, policy/agreement version rows, and automatic SMS provider status updates are left out because those are either not business mutations or already have a better source of truth.

The implementation uses the existing `audit_log` table and `recordAuditEvent()` helper, with audit writes placed inside the same transaction as the mutation they describe. That makes the audit row part of the business action: if the mutation rolls back, no audit row remains; if the audit insert fails, the mutation rolls back too.

| Business area | Entity recorded | Why it is handled this way |
| --- | --- | --- |
| Household changes | `household` | Captures administrative changes, removal, and anonymization without storing full household snapshots |
| Parcel lifecycle | `parcel` | Centralized in the parcel transition helpers so each business action gets one audit row instead of one row per SQL statement |
| User roles | `user_role` | Records privileged access changes while locking the target user row before comparing before/after role values |
| Critical settings | `global_setting`, `pickup_location`, `schedule` | Keeps operational configuration history without tying it to household retention |
| Manual SMS interventions | `parcel`, `household`, or system-level `sms` | Ties retry/dismiss actions to household data when they concern a household or parcel, while keeping balance requeue as a system intervention |

Household-related audit rows are treated as household data. Before a household is anonymized or hard-deleted, the transaction fetches that household's parcel IDs and prunes audit rows for both the household and its parcels. Configuration, user-role, pickup-location, schedule, and system-level SMS audit rows are preserved because they do not contain household data and remain useful for operational follow-up.

Audit details are intentionally compact. They include changed fields or minimal operational identifiers only, and avoid request metadata, session IDs, URLs, SMS text, comment bodies, and full household snapshots. This keeps the audit trail useful for follow-up without turning it into broad staff surveillance or duplicating sensitive household records.

Coverage was added around real mutation flows rather than isolated helper behavior: parcel lifecycle transitions, rollback semantics, household edit changed-field details, household audit pruning on anonymization and hard delete, user-role changes, critical settings, and manual SMS retry/dismiss/requeue behavior. The pre-push hook completed locally with `pnpm test` passing 1,657 tests and `pnpm run validate` passing lint, typecheck, formatting, and security checks.