### PR TITLE
Stop installing conflicting Certbot nginx hooks

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -299,23 +299,8 @@ fi
 # Set up automatic SSL certificate renewal
 echo "Setting up automatic SSL certificate renewal..."
 
-# Create pre and post renewal hooks to handle Nginx restart
-sudo mkdir -p /etc/letsencrypt/renewal-hooks/pre
-sudo mkdir -p /etc/letsencrypt/renewal-hooks/post
-
-# Create pre-renewal hook to stop Nginx
-sudo tee /etc/letsencrypt/renewal-hooks/pre/stop-nginx.sh > /dev/null <<'EOHOOK'
-#!/bin/bash
-systemctl stop nginx
-EOHOOK
-sudo chmod +x /etc/letsencrypt/renewal-hooks/pre/stop-nginx.sh
-
-# Create post-renewal hook to start Nginx
-sudo tee /etc/letsencrypt/renewal-hooks/post/start-nginx.sh > /dev/null <<'EOHOOK'
-#!/bin/bash
-systemctl start nginx
-EOHOOK
-sudo chmod +x /etc/letsencrypt/renewal-hooks/post/start-nginx.sh
+# Certbot uses the nginx plugin above, which handles nginx configuration and
+# reloads itself. Extra stop/start hooks conflict with that plugin.
 
 # Setup automated renewal cron job that runs twice daily
 echo "0 3,15 * * * root certbot renew --quiet" | sudo tee /etc/cron.d/certbot-renew > /dev/null

--- a/update.sh
+++ b/update.sh
@@ -272,7 +272,13 @@ if sudo systemctl is-active --quiet nginx; then
     fi
     echo "✅ Nginx reloaded with new configuration"
 else
-    sudo systemctl start nginx
+    if ! sudo systemctl start nginx; then
+        echo "❌ Nginx start failed — processes listening on ports 80/443:"
+        sudo ss -ltnp "( sport = :80 or sport = :443 )" || true
+        echo "Recent nginx logs:"
+        sudo journalctl -u nginx -n 20 --no-pager || true
+        exit 1
+    fi
     sudo systemctl enable nginx
     echo "✅ Nginx started"
 fi


### PR DESCRIPTION
A staging deploy failed because nginx was still serving traffic, but no longer belonged to `systemd`. Certbot renewal had left an nginx master process bound to ports `80/443`, so the deploy script saw `nginx.service` as inactive, tried to start it, and failed on address-in-use errors. Production had the same latent state before we repaired it manually.

The root cause was the setup script installing Certbot renewal hooks that stopped and started nginx even though certificates are managed with Certbot’s nginx plugin. The plugin already owns the nginx reload/configuration flow during renewal. Adding separate stop/start hooks made renewal ordering fragile and allowed nginx to drift outside the service manager.

This changes the desired setup behavior instead of adding recurring cleanup or process recovery. Fresh setup no longer creates those hooks at all. Staging and production were already cleaned manually, so normal deploys do not need to delete hook files or try to recover orphaned nginx processes.

The normal deploy path stays simple: if nginx is active, reload it; if it is inactive, start it through `systemd`. If that start fails, the script now prints the port listeners and recent nginx journal entries before exiting. That gives the next failure enough evidence for a safe manual fix without making deployment mutate unexpected process state.

Verified locally with shell syntax checks, `pnpm run validate`, and the pre-push hook’s full `pnpm test` run. The repaired staging and production deployments both completed successfully after nginx was returned to `systemd`.