### PR TITLE
Clarify parcel status audit rules

### DIFF
--- a/__tests__/app/schedule/components/PickupCard.test.tsx
+++ b/__tests__/app/schedule/components/PickupCard.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+import { TestWrapper } from "../../../test-utils";
+import { FoodParcel } from "../../../../app/[locale]/schedule/types";
+
+vi.mock("@dnd-kit/sortable", () => ({
+    useSortable: () => ({
+        attributes: {},
+        listeners: {},
+        setNodeRef: vi.fn(),
+        transform: null,
+        transition: undefined,
+        isDragging: false,
+    }),
+}));
+
+vi.mock("next-intl", () => ({
+    useLocale: () => "sv",
+    useTranslations: () => (key: string) => {
+        const translations: Record<string, string> = {
+            noShowStatus: "No-show",
+            notPickedUpStatus: "Not handed out",
+            pickedUpStatus: "Handed out",
+            pickupTimeLabel: "Pickup time",
+            statusLabel: "Status",
+            viewParcelDetails: "View parcel details",
+            primaryLocationLabel: "Primary pickup location",
+            createdByLabel: "Created by",
+        };
+
+        return translations[key] ?? key;
+    },
+}));
+
+import PickupCard from "../../../../app/[locale]/schedule/components/PickupCard";
+
+function parcel(overrides: Partial<FoodParcel> = {}): FoodParcel {
+    return {
+        id: "parcel-1",
+        householdId: "household-1",
+        householdName: "Test Household",
+        pickupDate: new Date("2026-06-18T00:00:00.000Z"),
+        pickupEarliestTime: new Date("2026-06-18T10:00:00.000Z"),
+        pickupLatestTime: new Date("2026-06-18T10:30:00.000Z"),
+        isPickedUp: false,
+        noShowAt: null,
+        ...overrides,
+    };
+}
+
+describe("PickupCard", () => {
+    it("shows no-show status in compact schedule cards", () => {
+        const { container } = render(
+            <TestWrapper>
+                <PickupCard
+                    foodParcel={parcel({
+                        noShowAt: new Date("2026-06-18T11:00:00.000Z"),
+                    })}
+                />
+            </TestWrapper>,
+        );
+
+        expect(container.textContent).toContain("Test Household");
+
+        const noShowMarker = container.querySelector('[aria-label="No-show"]');
+        expect(noShowMarker).toBeTruthy();
+        expect(noShowMarker?.getAttribute("title")).toBe("No-show");
+    });
+
+    it("does not show the no-show marker for ordinary unpicked parcels", () => {
+        const { container } = render(
+            <TestWrapper>
+                <PickupCard foodParcel={parcel()} />
+            </TestWrapper>,
+        );
+
+        expect(container.textContent).toContain("Test Household");
+        expect(container.querySelector('[aria-label="No-show"]')).toBeNull();
+    });
+});

--- a/__tests__/app/schedule/components/TimeSlotCell.test.tsx
+++ b/__tests__/app/schedule/components/TimeSlotCell.test.tsx
@@ -74,7 +74,7 @@ const TimeSlotCell = ({
             {/* Parcels stack */}
             <MockStack>
                 {parcels.map((parcel: FoodParcel) => (
-                    <MockPickupCard key={parcel.id} foodParcel={parcel} isCompact={true} />
+                    <MockPickupCard key={parcel.id} foodParcel={parcel} />
                 ))}
             </MockStack>
         </MockPaper>

--- a/__tests__/app/schedule/mock-components.tsx
+++ b/__tests__/app/schedule/mock-components.tsx
@@ -121,13 +121,10 @@ export const MockButton = ({
  */
 export interface MockPickupCardProps {
     foodParcel: FoodParcel;
-    isCompact?: boolean;
 }
 
-export const MockPickupCard = ({ foodParcel, isCompact }: MockPickupCardProps) => (
-    <div data-testid={`pickup-card-${foodParcel.id}`} data-compact={isCompact}>
-        {foodParcel.householdName}
-    </div>
+export const MockPickupCard = ({ foodParcel }: MockPickupCardProps) => (
+    <div data-testid={`pickup-card-${foodParcel.id}`}>{foodParcel.householdName}</div>
 );
 
 /**

--- a/__tests__/app/utils/public-parcel-data.test.ts
+++ b/__tests__/app/utils/public-parcel-data.test.ts
@@ -1,5 +1,30 @@
-import { describe, it, expect } from "vitest";
-import { generateAdminUrl } from "../../../app/utils/public-parcel-data";
+import { afterEach, describe, it, expect } from "vitest";
+import {
+    generateAdminUrl,
+    getParcelStatus,
+    type PublicParcelData,
+} from "../../../app/utils/public-parcel-data";
+import { MockTimeProvider, TimeProvider, setTimeProvider } from "../../../app/utils/time-provider";
+
+function parcel(overrides: Partial<PublicParcelData>): PublicParcelData {
+    return {
+        id: "parcel-1",
+        householdName: "Test Household",
+        householdLocale: "sv",
+        pickupDateTimeEarliest: new Date("2026-06-17T10:00:00.000Z"),
+        pickupDateTimeLatest: new Date("2026-06-17T11:00:00.000Z"),
+        isPickedUp: false,
+        locationName: "Test Location",
+        locationAddress: "Test Street 1",
+        locationPostalCode: "12345",
+        deletedAt: null,
+        ...overrides,
+    };
+}
+
+afterEach(() => {
+    setTimeProvider(new TimeProvider());
+});
 
 describe("generateAdminUrl", () => {
     it("should generate locale-agnostic admin URL without hardcoded locale", () => {
@@ -35,5 +60,37 @@ describe("generateAdminUrl", () => {
         expect(shortId).toContain("?parcel=123");
         expect(longId).toContain("?parcel=abcdefghijklmnop");
         expect(mixedId).toContain("?parcel=A1b2C3d4E5");
+    });
+});
+
+describe("getParcelStatus", () => {
+    it("returns cancelled before collected when a parcel is soft-deleted", () => {
+        setTimeProvider(new MockTimeProvider("2026-06-17T10:30:00.000Z"));
+
+        expect(
+            getParcelStatus(
+                parcel({
+                    isPickedUp: true,
+                    deletedAt: new Date("2026-06-17T09:00:00.000Z"),
+                }),
+            ),
+        ).toBe("cancelled");
+    });
+
+    it("uses pickup-window status for the public recipient page", () => {
+        setTimeProvider(new MockTimeProvider("2026-06-17T10:30:00.000Z"));
+        expect(getParcelStatus(parcel({}))).toBe("ready");
+
+        setTimeProvider(new MockTimeProvider("2026-06-17T12:00:00.000Z"));
+        expect(getParcelStatus(parcel({}))).toBe("scheduled");
+
+        setTimeProvider(new MockTimeProvider("2026-06-25T12:00:00.000Z"));
+        expect(getParcelStatus(parcel({}))).toBe("expired");
+    });
+
+    it("returns collected for picked-up parcels regardless of pickup window", () => {
+        setTimeProvider(new MockTimeProvider("2026-06-25T12:00:00.000Z"));
+
+        expect(getParcelStatus(parcel({ isPickedUp: true }))).toBe("collected");
     });
 });

--- a/app/[locale]/schedule/components/PickupCard.module.css
+++ b/app/[locale]/schedule/components/PickupCard.module.css
@@ -1,13 +1,14 @@
+.pickup-card-compact:hover {
+    background-color: var(--mantine-color-blue-0);
+}
+
 .pickup-card-compact:hover .reschedule-button,
-.pickup-card:hover .reschedule-button,
-.pickup-card-compact:hover .admin-button,
-.pickup-card:hover .admin-button {
+.pickup-card-compact:hover .admin-button {
     opacity: 1 !important;
 }
 
 /* Ensure dragged elements are visible */
-.pickup-card-compact[data-dragging="true"],
-.pickup-card[data-dragging="true"] {
+.pickup-card-compact[data-dragging="true"] {
     z-index: 1000 !important;
     position: relative;
 }

--- a/app/[locale]/schedule/components/PickupCard.tsx
+++ b/app/[locale]/schedule/components/PickupCard.tsx
@@ -5,23 +5,17 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { FoodParcel } from "@/app/[locale]/schedule/types";
 import { IconCalendarTime, IconInfoCircle } from "@tabler/icons-react";
-import styles from "./PickupCard.module.css"; // Import the CSS module
+import styles from "./PickupCard.module.css";
 import { useTranslations, useLocale } from "next-intl";
 import { memo, useMemo } from "react";
 
 interface PickupCardProps {
     foodParcel: FoodParcel;
-    isCompact?: boolean;
     onReschedule?: (foodParcel: FoodParcel) => void;
     onOpenAdminDialog?: (parcelId: string) => void;
 }
 
-function PickupCard({
-    foodParcel,
-    isCompact = false,
-    onReschedule,
-    onOpenAdminDialog,
-}: PickupCardProps) {
+function PickupCard({ foodParcel, onReschedule, onOpenAdminDialog }: PickupCardProps) {
     const t = useTranslations("schedule");
     const locale = useLocale();
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -42,14 +36,11 @@ function PickupCard({
         [transform, transition, isDragging],
     );
 
-    // Memoize color calculation
-    const statusColor = useMemo(() => {
-        if (foodParcel.isPickedUp) return "green.6";
-
-        const now = new Date();
-        const isInPast = foodParcel.pickupLatestTime < now;
-        return isInPast ? "red.6" : "primary";
-    }, [foodParcel.isPickedUp, foodParcel.pickupLatestTime]);
+    const statusLabel = useMemo(() => {
+        if (foodParcel.isPickedUp) return t("pickedUpStatus");
+        if (foodParcel.noShowAt) return t("noShowStatus");
+        return t("notPickedUpStatus");
+    }, [foodParcel.isPickedUp, foodParcel.noShowAt, t]);
 
     // Memoize time formatting
     const timeDisplay = useMemo(() => {
@@ -111,8 +102,7 @@ function PickupCard({
                 {t("pickupTimeLabel")}: {timeDisplay.earliest} - {timeDisplay.latest}
             </Text>
             <Text size="sm">
-                {t("statusLabel")}:{" "}
-                {foodParcel.isPickedUp ? t("pickedUpStatus") : t("notPickedUpStatus")}
+                {t("statusLabel")}: {statusLabel}
             </Text>
             {foodParcel.primaryPickupLocationName && (
                 <Text size="sm">
@@ -126,87 +116,6 @@ function PickupCard({
             )}
         </div>
     );
-
-    if (isCompact) {
-        return (
-            <Tooltip
-                label={tooltipContent}
-                withArrow
-                multiline
-                withinPortal
-                position="top"
-                disabled={isDragging}
-            >
-                <Paper
-                    ref={setNodeRef}
-                    style={{
-                        ...style,
-                        "cursor": "grab",
-                        "&:hover": { backgroundColor: "var(--mantine-color-blue-0)" },
-                        "position": "relative",
-                    }}
-                    {...attributes}
-                    {...listeners}
-                    px="xs"
-                    py={2}
-                    radius="sm"
-                    withBorder
-                    bg="gray.0"
-                    shadow="xs"
-                    className={styles["pickup-card-compact"]}
-                    data-dragging={isDragging}
-                >
-                    <Text size="xs" truncate fw={500}>
-                        {foodParcel.householdName}
-                    </Text>
-
-                    {/* Add admin info button */}
-                    {onOpenAdminDialog && (
-                        <ActionIcon
-                            size="xs"
-                            variant="subtle"
-                            color="blue"
-                            onClick={handleAdminDialogClick}
-                            style={{
-                                position: "absolute",
-                                top: "50%",
-                                right: onReschedule ? "20px" : "4px", // Adjust position if reschedule button is present
-                                transform: "translateY(-50%)",
-                                opacity: 0, // Hidden by default
-                                transition: "opacity 0.2s",
-                            }}
-                            className={styles["admin-button"]}
-                            title="View household details"
-                        >
-                            <IconInfoCircle size="0.8rem" />
-                        </ActionIcon>
-                    )}
-
-                    {/* Add reschedule button */}
-                    {onReschedule && (
-                        <ActionIcon
-                            size="xs"
-                            variant="subtle"
-                            color="blue"
-                            onClick={handleRescheduleClick}
-                            style={{
-                                position: "absolute",
-                                top: "50%",
-                                right: "4px",
-                                transform: "translateY(-50%)",
-                                opacity: 0, // Hidden by default
-                                transition: "opacity 0.2s",
-                            }}
-                            className={styles["reschedule-button"]}
-                            title={t("reschedule.outsideWeek")}
-                        >
-                            <IconCalendarTime size="0.8rem" />
-                        </ActionIcon>
-                    )}
-                </Paper>
-            </Tooltip>
-        );
-    }
 
     return (
         <Tooltip
@@ -222,45 +131,50 @@ function PickupCard({
                 style={{
                     ...style,
                     cursor: "grab",
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: "4px",
                     position: "relative",
                 }}
                 {...attributes}
                 {...listeners}
-                p="xs"
+                px="xs"
+                py={2}
                 radius="sm"
                 withBorder
-                bg="white"
+                bg="gray.0"
                 shadow="xs"
-                className={styles["pickup-card"]}
+                className={styles["pickup-card-compact"]}
                 data-dragging={isDragging}
             >
                 <div
                     style={{
                         display: "flex",
-                        justifyContent: "space-between",
                         alignItems: "center",
+                        gap: 4,
+                        paddingRight: onOpenAdminDialog
+                            ? onReschedule
+                                ? 36
+                                : 18
+                            : onReschedule
+                              ? 18
+                              : 0,
                     }}
                 >
-                    <Text size="sm" fw={500} truncate style={{ flex: 1 }}>
+                    {foodParcel.noShowAt && (
+                        <span
+                            aria-label={statusLabel}
+                            title={statusLabel}
+                            style={{
+                                width: 7,
+                                height: 7,
+                                borderRadius: "50%",
+                                backgroundColor: "var(--mantine-color-orange-6)",
+                                flexShrink: 0,
+                            }}
+                        />
+                    )}
+                    <Text size="xs" truncate fw={500} style={{ minWidth: 0 }}>
                         {foodParcel.householdName}
                     </Text>
-
-                    <div
-                        style={{
-                            width: 8,
-                            height: 8,
-                            borderRadius: "50%",
-                            backgroundColor: `var(--mantine-color-${statusColor})`,
-                        }}
-                    />
                 </div>
-
-                <Text size="xs" c="dimmed">
-                    {timeDisplay.earliest}
-                </Text>
 
                 {/* Add admin info button */}
                 {onOpenAdminDialog && (
@@ -271,13 +185,14 @@ function PickupCard({
                         onClick={handleAdminDialogClick}
                         style={{
                             position: "absolute",
-                            top: "4px",
+                            top: "50%",
                             right: onReschedule ? "20px" : "4px", // Adjust position if reschedule button is present
+                            transform: "translateY(-50%)",
                             opacity: 0, // Hidden by default
                             transition: "opacity 0.2s",
                         }}
                         className={styles["admin-button"]}
-                        title="View household details"
+                        title={t("viewParcelDetails")}
                     >
                         <IconInfoCircle size="0.8rem" />
                     </ActionIcon>
@@ -292,8 +207,9 @@ function PickupCard({
                         onClick={handleRescheduleClick}
                         style={{
                             position: "absolute",
-                            top: "4px",
+                            top: "50%",
                             right: "4px",
+                            transform: "translateY(-50%)",
                             opacity: 0, // Hidden by default
                             transition: "opacity 0.2s",
                         }}

--- a/app/[locale]/schedule/components/TimeSlotCell.tsx
+++ b/app/[locale]/schedule/components/TimeSlotCell.tsx
@@ -110,7 +110,6 @@ function TimeSlotCell({
                         <PickupCard
                             key={parcel.id}
                             foodParcel={parcel}
-                            isCompact={true}
                             onOpenAdminDialog={onOpenAdminDialog}
                         />
                     ),

--- a/app/[locale]/schedule/components/WeeklyScheduleGrid.tsx
+++ b/app/[locale]/schedule/components/WeeklyScheduleGrid.tsx
@@ -1101,7 +1101,6 @@ export default function WeeklyScheduleGrid({
                                                     <Box pl={hasValidSlots ? 20 : 0}>
                                                         <PickupCard
                                                             foodParcel={parcel}
-                                                            isCompact={true}
                                                             onReschedule={
                                                                 hasValidSlots
                                                                     ? handleRescheduleClick
@@ -1399,7 +1398,6 @@ export default function WeeklyScheduleGrid({
                                                                                     foodParcel={
                                                                                         parcel
                                                                                     }
-                                                                                    isCompact={true}
                                                                                     onReschedule={
                                                                                         handleRescheduleClick
                                                                                     }
@@ -1476,9 +1474,7 @@ export default function WeeklyScheduleGrid({
 
                     {/* DragOverlay for visual feedback during dragging */}
                     <DragOverlay>
-                        {activeDragParcel && (
-                            <PickupCard foodParcel={activeDragParcel} isCompact={true} />
-                        )}
+                        {activeDragParcel && <PickupCard foodParcel={activeDragParcel} />}
                     </DragOverlay>
                 </DndContext>
             )}

--- a/app/utils/public-parcel-data.ts
+++ b/app/utils/public-parcel-data.ts
@@ -79,7 +79,12 @@ export async function getPublicParcelData(parcelId: string): Promise<PublicParce
 }
 
 /**
- * Determine parcel status based on current time and pickup window
+ * Public recipient-facing status for `/p/[parcelId]`.
+ *
+ * This intentionally differs from admin parcel badges: admin views use
+ * date-only operational status so same-day parcels do not become "missed"
+ * after the nominal pickup window, while the public page should tell the
+ * recipient whether the pickup window is active right now.
  */
 export function getParcelStatus(parcel: PublicParcelData): ParcelStatus {
     // Check if cancelled (soft deleted)

--- a/docs/business-logic-audit.md
+++ b/docs/business-logic-audit.md
@@ -1,0 +1,112 @@
+# Business Logic Audit
+
+This is a living maintenance plan for reviewing Matkassen's business logic. The goal is to keep the codebase simple, readable, and easy to change for a one-person project.
+
+## Goals
+
+- Find and remove dead or obsolete business logic.
+- Reduce duplicated domain rules when a shared helper would make behavior clearer.
+- Simplify code that is more abstract than the problem requires.
+- Keep behavior aligned with code, tests, and production expectations.
+- Make small, validated changes instead of broad refactors.
+
+## Non-Goals
+
+- Large architecture redesigns.
+- Cosmetic-only rewrites.
+- Changing product behavior without an explicit decision.
+- Moving logic into shared helpers when local duplication is clearer.
+- Expanding public/user documentation as part of the audit.
+
+## Working Principles
+
+- Audit one domain at a time.
+- Start each audit pass by looking for code that can be deleted or made less configurable.
+- Prefer deleting code over reshaping it when code is truly unused.
+- Treat optional props, mode flags, status branches, feature toggles, and generic helpers with suspicion until their real call sites prove they are needed.
+- Prefer boring named helpers for repeated business rules.
+- Keep one-off logic close to the feature that owns it.
+- Preserve existing security patterns: server actions use `protectedAction()`, and admin API routes use `authenticateAdminRequest()`.
+- Preserve i18n for all user-facing text.
+- Run focused tests or `pnpm run validate` after meaningful changes.
+
+## Deletion-First Search Checklist
+
+Before adding abstractions or centralizing rules, actively search for simplifications in the current audit area:
+
+1. Find optional props, mode flags, and booleans that are always passed the same way.
+2. Find status branches that no real production path can reach.
+3. Find components that support multiple layouts when only one layout is used.
+4. Find helpers with one meaningful caller, especially when the helper hides simple local logic.
+5. Find stale i18n keys, labels, or comments tied to removed states.
+6. Find tests or mocks that preserve an old API after production code stopped needing it.
+7. Find duplicated UI states where one state is just an older spelling of another.
+
+Useful searches:
+
+```bash
+rg -n "is[A-Z]|mode|variant|compact|status|type|TODO|deprecated|legacy" app components __tests__ messages
+rg -n "noShow|pickedUp|cancelled|deletedAt|archived|outsideHours" app __tests__
+rg -n "export function|export const|interface .*Props|type .*Props" app components
+```
+
+For each suspicious branch, verify all call sites with `rg` before editing. If all production call sites use the same path, prefer removing the option over preserving a dormant API.
+
+## Audit Areas
+
+| Area                                          | Focus                                                                                             | Status      | Notes                                                                                                                                                                                         |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parcel status and pickup rules                | Date-only status logic, picked-up/not-picked-up transitions, public and admin display consistency | In progress | Admin household status follows date-only display; pickup/no-show mutations are centralized. Public parcel status intentionally uses pickup-window/expiry semantics and now has focused tests. |
+| Household management                          | Household actions, eligibility, member/contact fields, deletion/archive behavior                  | Not started |                                                                                                                                                                                               |
+| Scheduling                                    | Parcel scheduling, calendar/date handling, pickup windows, recurring assumptions                  | Not started |                                                                                                                                                                                               |
+| Handout locations                             | Location availability, assignment rules, related parcel constraints                               | Not started |                                                                                                                                                                                               |
+| SMS queue and notifications                   | Queue state transitions, retry behavior, scheduler assumptions, message generation                | Not started |                                                                                                                                                                                               |
+| Verification questions and public parcel flow | Public page rules, verification state, QR/parcel access behavior                                  | Not started |                                                                                                                                                                                               |
+| Statistics and reporting                      | Query duplication, derived metrics, filters, date ranges                                          | Not started |                                                                                                                                                                                               |
+| Auth, roles, and user agreement               | Admin/staff role checks, agreement gates, protected UI assumptions                                | Not started | Keep security-sensitive cleanup conservative.                                                                                                                                                 |
+| i18n-related domain text                      | Message key duplication, dead messages tied to removed flows                                      | Not started | Do this after domain cleanup to avoid churn.                                                                                                                                                  |
+
+## Finding Categories
+
+| Category           | Meaning                                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------------------- |
+| Dead code          | Unused functions, unreachable branches, obsolete feature remnants, unused message keys tied to removed logic. |
+| Duplicated rule    | The same business rule exists in multiple places and could drift.                                             |
+| Over-abstraction   | A helper/component/module makes a simple rule harder to read or change.                                       |
+| Under-abstraction  | Repeated logic would be safer and clearer as a shared domain helper.                                          |
+| Behavior ambiguity | Code, docs, tests, or UI imply different business behavior.                                                   |
+| Test gap           | Important business behavior lacks a focused test.                                                             |
+
+## Findings
+
+| Date       | Area                           | Category           | Finding                                                                                                                                                                                                                                                                                                                        | Recommendation                                                                                                                                           | Status    |
+| ---------- | ------------------------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| 2026-06-17 | Parcel status and pickup rules | Behavior ambiguity | Admin parcel badges are date-only (`upcoming`, `not picked up`, `picked up`), while public `/p/[parcelId]` uses recipient-facing pickup-window states (`scheduled`, `ready`, `expired`, `collected`, `cancelled`). The difference is intentional, but it had little direct test coverage and was easy to miss from code alone. | Keep the split behavior, explain it near the public status calculation, and pin public status semantics with focused tests.                              | Addressed |
+| 2026-06-17 | Parcel status and pickup rules | Duplicated rule    | Admin status display is calculated locally in multiple UI surfaces: household parcel list, today handouts, weekly schedule cards, and parcel admin dialog. The core order is similar, but each surface uses its own labels and emphasis.                                                                                       | Do not centralize yet; the contexts differ enough that local rules are still readable. Revisit only if another status state is added or drift continues. | Accepted  |
+| 2026-06-17 | Parcel status and pickup rules | Behavior ambiguity | Weekly schedule `PickupCard` accepted `noShowAt` but displayed any non-picked-up parcel as “not handed out” in the tooltip and colored it as past/upcoming rather than explicit no-show. Other admin surfaces show no-show as its own status.                                                                                  | Show explicit no-show label/color in `PickupCard` using existing schedule i18n.                                                                          | Addressed |
+| 2026-06-18 | Parcel status and pickup rules | Dead code          | `PickupCard` exposed an `isCompact` option, but all production call sites used compact mode: time-slot cells, weekly grid cells, outside-hours parcels, and drag overlays. The non-compact branch was effectively unused.                                                                                                      | Remove the option and make the compact card the only implementation.                                                                                     | Addressed |
+| 2026-06-17 | Parcel status and pickup rules | Test gap           | Public parcel status logic had tests for admin URL generation but not for cancelled/collected/window/expired state precedence.                                                                                                                                                                                                 | Add focused unit coverage for `getParcelStatus()`.                                                                                                       | Addressed |
+
+## Decisions
+
+| Date       | Decision                                                      | Reason                                                                                                                           |
+| ---------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-17 | Track the business-logic cleanup in this repo.                | The audit is tied to this codebase and should survive Codex restarts, branches, and future maintenance work.                     |
+| 2026-06-17 | Install general Next.js guidance globally, not project-local. | `next-best-practices` is framework guidance, while Matkassen-specific audit state belongs in the repo.                           |
+| 2026-06-17 | Deprecate broad business-logic prose as source of truth.      | Durable rules should live in clear code, focused tests, and short comments near surprising behavior; broad prose docs can drift. |
+
+## Completed Changes
+
+| Date       | Area                           | Summary                                                                                                                                                                                                                                       | Validation                                                                                                                                                                                                                                                 |
+| ---------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-17 | Parcel status and pickup rules | Updated weekly schedule pickup cards to show explicit no-show status, removed the unused non-compact `PickupCard` branch, documented the public/admin status split near public status code, and added direct card/public parcel status tests. | `pnpm vitest run __tests__/app/schedule/components/PickupCard.test.tsx __tests__/app/schedule/components/TimeSlotCell.test.tsx __tests__/app/utils/public-parcel-data.test.ts __tests__/app/households/parcel-status-display.test.ts`; `pnpm run validate` |
+
+## Resume Instructions
+
+When continuing this work in a new Codex session:
+
+1. Read `AGENTS.md`.
+2. Read `docs/business-logic-audit.md`.
+3. Treat code and tests as the source of truth; use prose docs only as historical context until `docs/business-logic.md` is deprecated or removed.
+4. Pick one audit area and inspect existing code/tests before making changes.
+5. Update this document with findings, decisions, and completed changes.

--- a/messages/en.json
+++ b/messages/en.json
@@ -600,6 +600,8 @@
         "statusLabel": "Status",
         "pickedUpStatus": "Handed out",
         "notPickedUpStatus": "Not handed out",
+        "noShowStatus": "No-show",
+        "viewParcelDetails": "View parcel details",
         "primaryLocationLabel": "Home location",
         "createdByLabel": "Created by",
         "reschedule": {

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -600,6 +600,8 @@
         "statusLabel": "Status",
         "pickedUpStatus": "Utlämnad",
         "notPickedUpStatus": "Ej utlämnad",
+        "noShowStatus": "Utebliven",
+        "viewParcelDetails": "Visa matkassedetaljer",
         "primaryLocationLabel": "Hemmaplats",
         "createdByLabel": "Skapad av",
         "reschedule": {


### PR DESCRIPTION
Parcel status is one of the few pieces of Matkassen logic where the same underlying parcel can correctly look different depending on who is viewing it. Staff views need operational, date-only status so a same-day household is not prematurely shown as missed. The public parcel page needs recipient-facing status based on the pickup window, so households can tell whether the pickup is currently active.

This change records that distinction in the business logic audit, pins it with focused tests, and leaves the durable explanation next to the public status calculation. That is intentional: broad prose docs like `docs/business-logic.md` are not a great long-term source of truth for rules like this because they can drift from the code.

| Context | Status model | Reason |
| --- | --- | --- |
| Admin household and schedule views | Date-only operational states such as upcoming, picked up, no-show, cancelled, and previous-day not picked up | Staff may still process same-day handouts after the nominal pickup window, so same-day parcels should not turn red automatically. |
| Public parcel page | Pickup-window states such as scheduled, ready, collected, expired, and cancelled | Recipients need to know whether the current time is inside the active pickup window. |

The audit found one concrete drift point: the weekly schedule card already received no-show data, but still presented no-show parcels as generic “not handed out” parcels. The card now shows no-show explicitly, using localized schedule messages like the rest of the UI.

I also removed the unused non-compact `PickupCard` branch. Every production call site already rendered compact cards: time-slot cells, weekly grid cells, outside-hours parcels, and drag overlays. Keeping an `isCompact` option made the component look more flexible than it actually was.

I kept the display rules local instead of introducing a shared status abstraction. The admin surfaces use similar inputs, but each context has slightly different emphasis and labels. Centralizing this now would make the code look tidier while hiding the product distinction that the audit is trying to preserve.

The audit now also records the follow-up direction: deprecate broad business-logic prose as a source of truth and migrate valuable rule documentation into clear code, focused tests, and short comments near surprising behavior.