### PR TITLE
Clarify weekly closed day UX

### DIFF
--- a/app/[locale]/schedule/[locationSlug]/weekly/components/WeeklySchedulePage.tsx
+++ b/app/[locale]/schedule/[locationSlug]/weekly/components/WeeklySchedulePage.tsx
@@ -68,6 +68,7 @@ export function WeeklySchedulePage({ locationSlug }: WeeklySchedulePageProps) {
     const lastParcelsRequestRef = useRef<string | null>(null);
     const [summaryStats, setSummaryStats] = useState<TodaySummaryStats | null>(null);
     const [isLoadingSummary, setIsLoadingSummary] = useState(false);
+    const [selectedDateIsAvailable, setSelectedDateIsAvailable] = useState<boolean | null>(null);
 
     // Loading states
     const [isLoadingLocation, setIsLoadingLocation] = useState(true);
@@ -138,6 +139,7 @@ export function WeeklySchedulePage({ locationSlug }: WeeklySchedulePageProps) {
         async function initialize() {
             setIsLoadingLocation(true);
             setLocationError(null);
+            setSelectedDateIsAvailable(null);
 
             try {
                 // Load locations first to validate the slug
@@ -209,6 +211,7 @@ export function WeeklySchedulePage({ locationSlug }: WeeklySchedulePageProps) {
             weekDates[0];
 
         if (formatDateToYMD(nextSelectedDate) !== formatDateToYMD(selectedDate)) {
+            setSelectedDateIsAvailable(null);
             setSelectedDate(nextSelectedDate);
         }
     }, [weekDates, currentDate, selectedDate]);
@@ -217,7 +220,11 @@ export function WeeklySchedulePage({ locationSlug }: WeeklySchedulePageProps) {
         let cancelled = false;
 
         async function loadSummary() {
-            if (!currentLocation) return;
+            if (!currentLocation || selectedDateIsAvailable !== true) {
+                setSummaryStats(null);
+                setIsLoadingSummary(false);
+                return;
+            }
 
             setIsLoadingSummary(true);
 
@@ -242,7 +249,12 @@ export function WeeklySchedulePage({ locationSlug }: WeeklySchedulePageProps) {
         return () => {
             cancelled = true;
         };
-    }, [currentLocation, selectedDate]);
+    }, [currentLocation, selectedDate, selectedDateIsAvailable]);
+
+    const handleSelectDate = useCallback((date: Date) => {
+        setSelectedDateIsAvailable(null);
+        setSelectedDate(date);
+    }, []);
 
     // Navigation functions
     const goToToday = useCallback(() => {
@@ -433,14 +445,21 @@ export function WeeklySchedulePage({ locationSlug }: WeeklySchedulePageProps) {
                 <Paper p="md" withBorder>
                     <Stack gap="sm">
                         <div>
-                            <Text fw={600}>{t("schedule.summary.selectedDayTitle")}</Text>
+                            <Text fw={600}>
+                                {selectedDateIsAvailable === false
+                                    ? t("schedule.summary.noOpenDaySelectedTitle")
+                                    : t("schedule.summary.selectedDayTitle")}
+                            </Text>
                             <Text size="sm" c="dimmed">
-                                {t("schedule.summary.selectedDayDescription", {
-                                    date: selectedDateLabel,
-                                })}
+                                {selectedDateIsAvailable === false
+                                    ? t("schedule.summary.noOpenDaySelectedDescription")
+                                    : t("schedule.summary.selectedDayDescription", {
+                                          date: selectedDateLabel,
+                                      })}
                             </Text>
                         </div>
-                        {isLoadingSummary ? (
+                        {selectedDateIsAvailable === false ? null : isLoadingSummary ||
+                          selectedDateIsAvailable === null ? (
                             <Center py="md">
                                 <Loader size="sm" />
                             </Center>
@@ -473,7 +492,8 @@ export function WeeklySchedulePage({ locationSlug }: WeeklySchedulePageProps) {
                             onParcelRescheduled={handleParcelRescheduled}
                             locationId={currentLocation.id}
                             selectedDate={selectedDate}
-                            onSelectDate={setSelectedDate}
+                            onSelectDate={handleSelectDate}
+                            onSelectedDateAvailabilityChange={setSelectedDateIsAvailable}
                         />
                     )}
                 </Paper>

--- a/app/[locale]/schedule/components/WeeklyScheduleGrid.tsx
+++ b/app/[locale]/schedule/components/WeeklyScheduleGrid.tsx
@@ -21,13 +21,12 @@ import {
     ScrollArea,
     Text,
     Button,
-    Tooltip,
     Alert,
     UnstyledButton,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { showNotification } from "@mantine/notifications";
-import { IconArrowBackUp, IconCheck, IconInfoCircle, IconAlertTriangle } from "@tabler/icons-react";
+import { IconArrowBackUp, IconCheck, IconAlertTriangle } from "@tabler/icons-react";
 import TimeSlotCell from "./TimeSlotCell";
 import PickupCard from "./PickupCard";
 import ReschedulePickupModal from "./ReschedulePickupModal";
@@ -111,6 +110,7 @@ interface WeeklyScheduleGridProps {
     onOpenAdminDialog?: (parcelId: string) => void;
     selectedDate?: Date | null;
     onSelectDate?: (date: Date) => void;
+    onSelectedDateAvailabilityChange?: (isAvailable: boolean | null) => void;
 }
 
 export default function WeeklyScheduleGrid({
@@ -124,6 +124,7 @@ export default function WeeklyScheduleGrid({
     onOpenAdminDialog,
     selectedDate,
     onSelectDate,
+    onSelectedDateAvailabilityChange,
 }: WeeklyScheduleGridProps) {
     // null = no limit (from database), undefined = use default of 3
     const effectiveMaxParcelsPerSlot = maxParcelsPerSlot === null ? null : (maxParcelsPerSlot ?? 3);
@@ -238,6 +239,19 @@ export default function WeeklyScheduleGrid({
         }
         return false;
     }, [locationSchedules, slotDuration]);
+
+    useEffect(() => {
+        if (!onSelectedDateAvailabilityChange) return;
+
+        if (!selectedDate || !locationSchedules) {
+            onSelectedDateAvailabilityChange(null);
+            return;
+        }
+
+        onSelectedDateAvailabilityChange(
+            isDateAvailable(selectedDate, locationSchedules).isAvailable,
+        );
+    }, [locationSchedules, onSelectedDateAvailabilityChange, selectedDate]);
 
     // Fetch the slot duration when locationId changes
     useEffect(() => {
@@ -1139,10 +1153,6 @@ export default function WeeklyScheduleGrid({
 
                                 {weekDates.map(date => {
                                     const isPast = isPastDate(date);
-                                    const isSelected =
-                                        !!selectedDate &&
-                                        formatDateToYMD(selectedDate) === formatDateToYMD(date);
-                                    const isInteractive = !!onSelectDate;
                                     const weekdayLabel = t(`days.${getWeekdayName(date)}`);
                                     const formattedDate = formatDate(date);
 
@@ -1150,20 +1160,32 @@ export default function WeeklyScheduleGrid({
                                     const isDateUnavailable = locationSchedules
                                         ? !isDateAvailable(date, locationSchedules).isAvailable
                                         : true; // Default to unavailable if no schedule data
+                                    const isSelected =
+                                        !isDateUnavailable &&
+                                        !!selectedDate &&
+                                        formatDateToYMD(selectedDate) === formatDateToYMD(date);
+                                    const isInteractive = !!onSelectDate && !isDateUnavailable;
 
                                     // Determine background color for day header
-                                    // In today-only mode, don't grey out today even if it's "past"
                                     const getBgColor = () => {
-                                        const shouldGreyOut = isPast || isDateUnavailable;
-                                        if (shouldGreyOut) return "gray.7"; // Grey out past or unavailable dates
+                                        if (isDateUnavailable) return "gray.1";
+                                        if (isPast) return "gray.7";
                                         return "blue.7";
                                     };
+                                    const dayHeaderTextColor = isDateUnavailable
+                                        ? "dimmed"
+                                        : "white";
 
                                     return (
                                         <Grid.Col span={30 / 7} key={date.toISOString()}>
                                             <UnstyledButton
                                                 type="button"
-                                                onClick={() => onSelectDate?.(new Date(date))}
+                                                disabled={!isInteractive}
+                                                onClick={() => {
+                                                    if (isInteractive) {
+                                                        onSelectDate?.(new Date(date));
+                                                    }
+                                                }}
                                                 aria-pressed={isSelected}
                                                 title={
                                                     isInteractive
@@ -1184,18 +1206,20 @@ export default function WeeklyScheduleGrid({
                                                     radius="sm"
                                                     withBorder
                                                     bg={getBgColor()}
-                                                    c="white"
+                                                    c={dayHeaderTextColor}
                                                     styles={{
                                                         root: {
-                                                            height: "100%",
+                                                            minHeight: 86,
                                                             position: "relative",
                                                             opacity:
-                                                                isPast || isDateUnavailable
+                                                                isPast && !isDateUnavailable
                                                                     ? 0.8
                                                                     : 1,
                                                             borderColor: isSelected
                                                                 ? "var(--mantine-color-yellow-4)"
-                                                                : undefined,
+                                                                : isDateUnavailable
+                                                                  ? "var(--mantine-color-gray-4)"
+                                                                  : undefined,
                                                             boxShadow: isSelected
                                                                 ? "inset 0 0 0 2px var(--mantine-color-yellow-4), var(--mantine-shadow-sm)"
                                                                 : undefined,
@@ -1224,21 +1248,23 @@ export default function WeeklyScheduleGrid({
                                                         },
                                                     }}
                                                 >
-                                                    {/* Capacity indicator in top-right corner */}
-                                                    <Text
-                                                        size="xs"
-                                                        c="gray.2"
-                                                        style={{
-                                                            position: "absolute",
-                                                            top: 4,
-                                                            right: 4,
-                                                        }}
-                                                        data-testid="capacity-indicator"
-                                                    >
-                                                        {parcelCountByDate[formatDateToYMD(date)] ||
-                                                            0}
-                                                        /{maxParcelsPerDay || "∞"}
-                                                    </Text>
+                                                    {!isDateUnavailable && (
+                                                        <Text
+                                                            size="xs"
+                                                            c="gray.2"
+                                                            style={{
+                                                                position: "absolute",
+                                                                top: 4,
+                                                                right: 4,
+                                                            }}
+                                                            data-testid="capacity-indicator"
+                                                        >
+                                                            {parcelCountByDate[
+                                                                formatDateToYMD(date)
+                                                            ] || 0}
+                                                            /{maxParcelsPerDay || "∞"}
+                                                        </Text>
+                                                    )}
 
                                                     <Text fw={500} ta="center" size="sm">
                                                         {weekdayLabel}
@@ -1246,38 +1272,17 @@ export default function WeeklyScheduleGrid({
                                                     <Text size="xs" ta="center">
                                                         {formattedDate}
                                                     </Text>
-                                                    <Text
-                                                        size="10px"
-                                                        fw={700}
-                                                        ta="center"
-                                                        c={isSelected ? "yellow.1" : "gray.2"}
-                                                        mt={6}
-                                                        style={{
-                                                            letterSpacing: "0.04em",
-                                                            textTransform: "uppercase",
-                                                        }}
-                                                    >
-                                                        {isSelected
-                                                            ? t("summary.dayHeaderSelected")
-                                                            : t("summary.dayHeaderAction")}
-                                                    </Text>
-
                                                     {isDateUnavailable && (
-                                                        <Tooltip
-                                                            label={t("unavailableDay", {})}
-                                                            position="bottom"
-                                                            withArrow
+                                                        <Text
+                                                            size="xs"
+                                                            fw={700}
+                                                            ta="center"
+                                                            c="gray.7"
+                                                            mt={6}
+                                                            style={{ textTransform: "uppercase" }}
                                                         >
-                                                            <IconInfoCircle
-                                                                size="0.9rem"
-                                                                style={{
-                                                                    position: "absolute",
-                                                                    bottom: 4,
-                                                                    right: 4,
-                                                                    opacity: 0.8,
-                                                                }}
-                                                            />
-                                                        </Tooltip>
+                                                            {t("closedDay")}
+                                                        </Text>
                                                     )}
                                                 </Paper>
                                             </UnstyledButton>

--- a/messages/en.json
+++ b/messages/en.json
@@ -554,6 +554,8 @@
             "selectedDayTitle": "Selected day summary",
             "selectedDayDescription": "Showing packing summary for {date}.",
             "gridHint": "Tap or click a day header in the weekly schedule to view a different packing summary.",
+            "noOpenDaySelectedTitle": "No open day selected",
+            "noOpenDaySelectedDescription": "Select an open day in the weekly schedule to view its packing summary.",
             "dayHeaderAction": "View summary",
             "dayHeaderSelected": "Selected",
             "dayHeaderAriaLabel": "View packing summary for {date}"
@@ -563,6 +565,7 @@
         "refresh": "Refresh",
         "selectWeek": "Select Week",
         "pastDateError": "This date has already passed",
+        "closedDay": "Closed",
         "unavailableDay": "This location is not open on this day",
         "unavailableSlot": "This time is outside opening hours",
         "timeGap": "Time gap",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -554,6 +554,8 @@
             "selectedDayTitle": "Sammanfattning för vald dag",
             "selectedDayDescription": "Visar packningssammanfattning för {date}.",
             "gridHint": "Tryck eller klicka på en dagsrubrik i veckoschemat för att visa en annan packningssammanfattning.",
+            "noOpenDaySelectedTitle": "Ingen öppen dag vald",
+            "noOpenDaySelectedDescription": "Välj en öppen dag i veckoschemat för att visa dess packningssammanfattning.",
             "dayHeaderAction": "Visa sammanfattning",
             "dayHeaderSelected": "Vald",
             "dayHeaderAriaLabel": "Visa packningssammanfattning för {date}"
@@ -563,6 +565,7 @@
         "refresh": "Uppdatera",
         "selectWeek": "Välj vecka",
         "pastDateError": "Detta datum har redan passerat",
+        "closedDay": "Stängt",
         "unavailableDay": "Denna plats är inte öppen denna dag",
         "unavailableSlot": "Denna tid är utanför öppettiderna",
         "timeGap": "Tidshopp",


### PR DESCRIPTION
## Motivation

The weekly schedule day headers mixed several meanings into the same visual treatment. Closed days, past days, and open days with no parcels could all look like valid schedule days, and closed days still showed capacity like `0/15`. That made the week view harder to scan: `0/15` reads like an empty but bookable/open day, while a closed day should communicate that no operational summary exists for that date.

## Design

The week header now separates day states by operational meaning:

| Day state | Visual treatment | Interaction | Header detail |
| --- | --- | --- | --- |
| Open with parcels | Active day styling | Selectable | Parcel count / daily capacity |
| Open with zero parcels | Active day styling | Selectable | `0 / daily capacity` |
| Closed | Muted disabled styling | Not selectable | `Closed` / `Stängt` |

The per-card `View summary` / `Selected` labels were removed because the grid already has helper text explaining that day headers can be clicked, and the selected day is already communicated through the selected border treatment. Keeping those labels on every day made the cards noisy without adding useful information.

## Intentional behavior

Closed days are not auto-replaced with the next open day. If the current selected date resolves to a closed day, the summary panel shows a neutral "no open day selected" state instead. That keeps the UI honest: the system does not silently change the date context, and closed days remain visibly non-selectable.

Open days with zero parcels remain selectable because "open but empty" is useful operational information for packing and capacity review.

## Validation

Ran `pnpm run validate` after rebasing onto the latest `origin/main`. The pre-push hook also ran the full test suite: 157 test files passed, 1664 tests passed, 1 skipped.