### PR TITLE
Document production deployment queue behavior

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -225,6 +225,14 @@ jobs:
             name: production
             url: https://matcentralen.com
         runs-on: ubuntu-latest
+        # Promote the exact image that this run built and verified in staging;
+        # never substitute a newer `main`/`latest` image after approval. Production
+        # deploys are serialized, and `cancel-in-progress` stays false so a new push
+        # cannot interrupt an active deploy. Consequently, an older run waiting for
+        # approval can hold this group while the newest run is pending. In that case,
+        # reject or cancel the older run as superseded, then approve the newest run.
+        # Do not approve the old run just to clear the queue: the freshness check
+        # below will intentionally reject its stale SHA.
         concurrency:
             group: deploy-production
             cancel-in-progress: false


### PR DESCRIPTION
## Why

Production deployments intentionally promote the immutable `sha-*` image built and verified by the same workflow run. When an older run is waiting for approval, it owns the production concurrency group and leaves the newest run pending. That behavior is safe but non-obvious: changing the workflow to follow moving `main`/`latest`, or enabling automatic cancellation, would weaken artifact traceability or risk interrupting an active deployment.

Without the rationale beside the configuration, a future maintainer could reasonably "fix" the queue by removing those safeguards.

## Design

Document the operational contract directly beside the production concurrency block:

- deploy the exact image verified in staging;
- serialize production deployments without cancelling an active deployment;
- reject or cancel an older waiting run as superseded;
- approve only the newest run, rather than approving a stale run merely to clear the queue.

This changes documentation only; workflow behavior remains unchanged. The repository pre-push hook completed successfully: validation passed and all 1,664 executed tests passed (one skipped).