### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Why
+
+Explain the problem, motivation, or maintenance reason for this change.
+
+## Approach
+
+Explain the chosen approach and any relevant tradeoffs.
+
+## Intentional Boundaries
+
+Call out what this PR deliberately does not do, especially if a broader change was possible.


### PR DESCRIPTION
## Why

PR descriptions should consistently explain purpose, tradeoffs, and intentional boundaries. That style currently lives in personal/global agent guidance, which makes it easy for an AI agent or tool to miss when creating a GitHub PR.

Adding a repo-local template gives GitHub and coding agents a visible default shape for every new PR.

## Approach

Add a lightweight `.github/PULL_REQUEST_TEMPLATE.md` with three sections:

| Section | Purpose |
| --- | --- |
| `Why` | Explain the motivation or maintenance reason. |
| `Approach` | Explain the chosen implementation and tradeoffs. |
| `Intentional Boundaries` | Make clear what the PR deliberately leaves out. |

The template intentionally avoids a test-plan checklist because validation results belong in CI or chat, not repeated in every PR description.

## Intentional Boundaries

This does not try to encode all agent rules from `AGENTS.md`. Security, i18n, validation, and workflow rules already live there; this template only shapes PR descriptions.