### PR TITLE
Update Node and PostgreSQL security releases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,7 @@ coverage
 # IDE files
 .vscode
 .idea
+.claude
 
 # OS files
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM node:22.19.0-alpine3.22 AS base
+FROM node:22.23.1-alpine3.23 AS base
 
 LABEL org.opencontainers.image.source=https://github.com/Vasteras-Stadsmission/matkassen
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,6 @@
 # This Dockerfile is used for development purposes, i.e. in combination with `docker-compose.dev.yml`
 
-FROM node:22.19.0-alpine3.22
+FROM node:22.23.1-alpine3.23
 
 # Install pnpm globally
 RUN corepack enable && corepack prepare pnpm@latest --activate

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,7 +30,7 @@ services:
             - HELLO_SMS_TEST_MODE=true # Development mode - test SMS only
 
     db:
-        image: postgres:17.5
+        image: postgres:17.10
         restart: always
         environment:
             POSTGRES_USER: ${POSTGRES_USER}

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -72,7 +72,7 @@ services:
             start_period: 40s
 
     db:
-        image: postgres:17.5
+        image: postgres:17.10
         restart: always
         environment:
             POSTGRES_USER: ${POSTGRES_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,8 @@ services:
 
     db:
         # Using specific PostgreSQL version for reproducible builds
-        # postgres:17.5 is the latest stable release with security updates
-        image: postgres:17.5
+        # Keep on the latest PostgreSQL 17 minor release for security and bug fixes
+        image: postgres:17.10
         restart: always
         environment:
             POSTGRES_USER: ${POSTGRES_USER}


### PR DESCRIPTION
## Why

Production is running Node 22.19.0 and PostgreSQL 17.5, both of which predate security fixes available on their supported release lines. Keeping these versions pinned makes deployments reproducible but also leaves those fixes unapplied.

## Design

- Keep Node on the 22 LTS line and update it to 22.23.1. The official patch image is based on Alpine 3.23 because no `22.23.1-alpine3.22` image exists.
- Keep PostgreSQL on major version 17 and update all production, local, and development Compose definitions to 17.10. This is an in-place minor release update and does not require a schema migration.
- Exclude local `.claude` worktrees from Docker build contexts. The production-image review exposed that they could otherwise send gigabytes of unrelated local material to the builder.

The production application image builds successfully with Node 22.23.1, and the PostgreSQL image reports version 17.10.