### PR TITLE
Remove repository secrets from PR checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,20 +105,8 @@ jobs:
 
             - name: Build
               env:
-                  POSTGRES_PASSWORD: ci-build-only
-                  POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-                  POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
-                  EMAIL: ${{ secrets.EMAIL }}
-                  AUTH_GITHUB_ID: ${{ secrets.AUTH_GITHUB_ID }}
-                  AUTH_GITHUB_SECRET: ${{ secrets.AUTH_GITHUB_SECRET }}
-                  AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
-                  AUTH_GITHUB_APP_ID: ${{ secrets.AUTH_GITHUB_APP_ID }}
-                  AUTH_GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTH_GITHUB_APP_PRIVATE_KEY }}
-                  AUTH_GITHUB_APP_INSTALLATION_ID: ${{ secrets.AUTH_GITHUB_APP_INSTALLATION_ID }}
                   GITHUB_ORG: "vasteras-stadsmission"
                   LOG_LEVEL: "error"
-                  DATABASE_URL: postgres://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@db:5432/${{ env.POSTGRES_DB }}
-                  DATABASE_URL_EXTERNAL: postgres://${{ env.POSTGRES_USER }}:${{ env.POSTGRES_PASSWORD }}@localhost:5432/${{ env.POSTGRES_DB }}
               run: pnpm run build
 
     # Job 4: Infrastructure checks (nginx, migrations)
@@ -155,10 +143,7 @@ jobs:
 
             - name: Verify migration files
               env:
-                  POSTGRES_PASSWORD: ci-build-only
-                  POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-                  POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
-                  DATABASE_URL: postgres://${{ secrets.POSTGRES_USER }}:ci-build-only@localhost:5432/${{ secrets.POSTGRES_DB }}
+                  DATABASE_URL: postgres://ci:ci-build-only@localhost:5432/ci
               run: |
                   SCHEMA_CHANGES=$(pnpm drizzle-kit check)
                   if [[ $SCHEMA_CHANGES == *"Schema drift detected"* ]]; then


### PR DESCRIPTION
## Why

The pull-request workflow supplied authentication credentials and shared database metadata to code checked out from the pull request. Neither the application build nor the migration consistency check needs real values, so this unnecessarily expanded the set of processes that could access repository secrets.

## Design

The build retains its public organization and logging configuration but receives no credentials. The migration check uses a syntactically valid CI-only database URL; `drizzle-kit check` reads the configuration without connecting to a database. Deployment workflows are unchanged and continue to receive the existing repository secrets.