### PR TITLE
Harden public HTTP route handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,14 @@ jobs:
                   cd nginx
                   ./generate-nginx-config.sh local
                   ./generate-nginx-config.sh production "example.com www.example.com" "example.com" > /tmp/nginx-production.conf
-                  grep -F 'return 301 https://$host$request_uri;' /tmp/nginx-production.conf
+                  grep -F 'listen 80 default_server;' /tmp/nginx-production.conf
+                  grep -F 'server_name _;' /tmp/nginx-production.conf
+                  grep -F 'return 444;' /tmp/nginx-production.conf
+                  grep -F 'return 301 https://example.com$request_uri;' /tmp/nginx-production.conf
+                  if grep -F 'return 301 https://$host$request_uri;' /tmp/nginx-production.conf; then
+                    echo "Production redirect trusts the request Host header"
+                    exit 1
+                  fi
                   if grep -F 'https://\$host\$request_uri' /tmp/nginx-production.conf; then
                     echo "Production redirect contains escaped nginx variables"
                     exit 1

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -75,9 +75,13 @@ describe("Middleware API Authentication", () => {
     it("should allow unauthenticated requests to public API routes", async () => {
         const publicRoutes = [
             "/api/health",
+            "/api/health/",
             "/api/auth/providers",
             "/api/auth/signin",
             "/api/csp-report",
+            "/api/csp-report/",
+            "/api/webhooks/sms-status/callback-secret",
+            "/api/webhooks/sms-status/callback-secret/",
         ];
 
         for (const route of publicRoutes) {
@@ -90,6 +94,29 @@ describe("Middleware API Authentication", () => {
             // Should pass through to the actual route handler (status 200, not 401)
             expect(response.status).not.toBe(401);
             expect(response.status).toBe(200); // NextResponse.next() returns 200
+        }
+    });
+
+    it("should fail closed for routes that only resemble public API routes", async () => {
+        const protectedNearMatches = [
+            "/api/healthcheck",
+            "/api/health/extra",
+            "/api/csp-reporting",
+            "/api/csp-report/extra",
+            "/api/webhooks/sms-status",
+            "/api/webhooks/sms-status/callback-secret/extra",
+            "/api/webhooks/future-callback/callback-secret",
+        ];
+
+        for (const route of protectedNearMatches) {
+            const request = new NextRequest(`http://localhost:3000${route}`, {
+                method: "GET",
+            });
+
+            const response = await middleware(request);
+
+            expect(response.status).toBe(401);
+            expect(await response.json()).toEqual({ error: "Unauthorized" });
         }
     });
 

--- a/docs/auth-guide.md
+++ b/docs/auth-guide.md
@@ -145,12 +145,15 @@ This script ensures:
 
 ### Public API Routes (Exceptions)
 
-Kept in `middleware.ts` as the `publicApiPatterns` allow-list:
+Kept in `middleware.ts` as the `isPublicApiRoute()` allow-list:
 
 - `/api/auth/*` — NextAuth routes (public by design)
 - `/api/health` — Health check endpoint
 - `/api/csp-report` — CSP violation reporting (browser-initiated)
-- `/api/webhooks/*` — Webhook endpoints (authenticated via URL secret, not session)
+- `/api/webhooks/sms-status/[secret]` — HelloSMS callback (authenticated via URL secret, not session)
+
+All other `/api/*` paths require a session by default. New public callbacks must be added to the
+allow-list explicitly.
 
 ## GitHub OAuth Configuration
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -42,6 +42,28 @@ function createCSP(nonce: string): string {
 // Create the internationalization middleware
 const intlMiddleware = createIntlMiddleware(routing);
 
+const exactPublicApiRoutes = new Set([
+    "/api/health",
+    "/api/health/",
+    "/api/csp-report",
+    "/api/csp-report/",
+]);
+
+function isPublicApiRoute(pathname: string): boolean {
+    if (exactPublicApiRoutes.has(pathname)) {
+        return true;
+    }
+
+    // Auth.js owns this namespace and must remain reachable before sign-in.
+    if (pathname === "/api/auth" || pathname.startsWith("/api/auth/")) {
+        return true;
+    }
+
+    // HelloSMS authenticates this one callback route with the secret path segment.
+    // Keep the match exact so a future webhook is private until explicitly allowed.
+    return /^\/api\/webhooks\/sms-status\/[^/]+\/?$/.test(pathname);
+}
+
 export default async function middleware(request: NextRequest) {
     const { pathname } = request.nextUrl;
 
@@ -64,17 +86,7 @@ export default async function middleware(request: NextRequest) {
 
     // 1. Handle API routes first (new logic)
     if (pathname.startsWith("/api/")) {
-        // Public API routes - no auth required
-        const publicApiPatterns = [
-            /^\/api\/health/, // Health check endpoint
-            /^\/api\/auth\//, // NextAuth endpoints
-            /^\/api\/csp-report/, // CSP violation reports
-            /^\/api\/webhooks\//, // Webhook endpoints (authenticated via URL secret or other means)
-        ];
-
-        const isPublicApiRoute = publicApiPatterns.some(pattern => pattern.test(pathname));
-
-        if (isPublicApiRoute) {
+        if (isPublicApiRoute(pathname)) {
             const response = NextResponse.next();
             return addCSPHeaders(response);
         }

--- a/nginx/generate-nginx-config.sh
+++ b/nginx/generate-nginx-config.sh
@@ -49,12 +49,19 @@ generate_production_config() {
     export SERVER_NAMES="$domain_names"
     export NEXTJS_UPSTREAM="localhost"  # In production, nginx runs on host, not in container
 
-    # HTTP redirect block for production
-    export HTTP_REDIRECT_BLOCK="# Redirect HTTP to HTTPS
+    # Reject unknown hosts, then redirect configured hosts to the canonical HTTPS domain.
+    export HTTP_REDIRECT_BLOCK="# Reject unknown HTTP hosts
+server {
+    listen 80 default_server;
+    server_name _;
+    return 444;
+}
+
+# Redirect configured HTTP hosts to the canonical HTTPS domain
 server {
     listen 80;
     server_name $domain_names;
-    return 301 https://\$host\$request_uri;
+    return 301 https://$primary_domain\$request_uri;
 }"
 
     # SSL configuration block


### PR DESCRIPTION
## Why

The middleware's prefix-based public API exceptions treated lookalike health and CSP paths, plus every route below `/api/webhooks/`, as public. That meant a future route could unintentionally bypass the middleware's session gate. Separately, the HTTP-to-HTTPS redirect reflected the request Host header into the Location response.

## Approach

Make the public API boundary explicit and make HTTP host handling fail closed.

| Request | Behavior |
| --- | --- |
| Auth.js, health, CSP reports, exact HelloSMS callback | Public by design |
| Any other `/api/*` route | Requires a session cookie before reaching its handler |
| Configured HTTP host | Redirects to the primary domain supplied by deployment configuration |
| Unknown HTTP host | Closed by nginx with status 444 |

Regression coverage includes valid public routes, near-match paths that must remain private, and the generated nginx configuration.

## Intentional Boundaries

This does not replace route-handler authentication; protected handlers still perform full session and organization validation. The HelloSMS callback still authenticates with its existing URL secret. No deployment domain is hardcoded, TLS virtual-host handling is unchanged, and the PR does not alter secrets or deployment automation.