### PR TITLE
Cancel obsolete PR CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
     pull_request:
         branches: [main]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
 permissions:
     contents: read
 


### PR DESCRIPTION
## Why

When a new commit is pushed to a pull request, any older CI run for that same pull request can no longer determine whether the current commit is mergeable. Letting it finish adds noise and can delay useful feedback even though standard GitHub-hosted minutes are free for this public repository.

## Approach

Give this workflow a concurrency group made from the workflow name and pull-request number, then enable cancellation of an in-progress run when a newer run enters that exact group. Including both values prevents one pull request or workflow from cancelling another.

## Intentional Boundaries

This does not add path classification or skip any validation, test, build, infrastructure, or Docker job. Every current check still runs for every pull request. It also does not change repository rules, permissions, triggers, deployment behavior, or production behavior.