### PR TITLE
Fix production redirect verification

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -186,6 +186,7 @@ jobs:
 
                   verify_domain() {
                       local domain="$1"
+                      local redirect_domain="${2:-$domain}"
                       local base_url="https://${domain}"
                       local root_code
                       local redirect_code
@@ -203,7 +204,7 @@ jobs:
 
                       redirect_code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://${domain}/api/health")
                       redirect_location=$(curl -sS -D - -o /dev/null --max-time 10 "http://${domain}/api/health" | awk 'BEGIN { IGNORECASE=1 } /^Location:/ { print $2; exit }' | tr -d '\r')
-                      if [ "$redirect_code" != "301" ] || [ "$redirect_location" != "https://${domain}/api/health" ]; then
+                      if [ "$redirect_code" != "301" ] || [ "$redirect_location" != "https://${redirect_domain}/api/health" ]; then
                           echo "❌ HTTP redirect for ${domain} returned ${redirect_code} -> ${redirect_location}"
                           return 1
                       fi
@@ -375,6 +376,7 @@ jobs:
 
                   verify_domain() {
                       local domain="$1"
+                      local redirect_domain="${2:-$domain}"
                       local base_url="https://${domain}"
                       local root_code
                       local redirect_code
@@ -392,7 +394,7 @@ jobs:
 
                       redirect_code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://${domain}/api/health")
                       redirect_location=$(curl -sS -D - -o /dev/null --max-time 10 "http://${domain}/api/health" | awk 'BEGIN { IGNORECASE=1 } /^Location:/ { print $2; exit }' | tr -d '\r')
-                      if [ "$redirect_code" != "301" ] || [ "$redirect_location" != "https://${domain}/api/health" ]; then
+                      if [ "$redirect_code" != "301" ] || [ "$redirect_location" != "https://${redirect_domain}/api/health" ]; then
                           echo "❌ HTTP redirect for ${domain} returned ${redirect_code} -> ${redirect_location}"
                           return 1
                       fi
@@ -407,4 +409,4 @@ jobs:
                   }
 
                   verify_domain "matcentralen.com"
-                  verify_domain "www.matcentralen.com"
+                  verify_domain "www.matcentralen.com" "matcentralen.com"


### PR DESCRIPTION
## Why

The production deployment verifier expected every hostname to redirect HTTP requests back to the same hostname. After the public HTTP hardening, the configured www hostname intentionally redirects to the primary matcentralen.com domain, so a successful deployment was reported as failed.

## Approach

Allow the shared verifier to receive an optional expected redirect domain while defaulting to the hostname under test. Production now checks both hostnames for health and security headers, while explicitly expecting www.matcentralen.com HTTP traffic to redirect to the primary domain.

## Intentional Boundaries

This changes only post-deployment verification. It does not alter nginx, application behavior, deployment steps, or production state.