### PR TITLE
Canonicalize HTTPS host aliases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,15 +140,22 @@ jobs:
                   grep -F 'listen 80 default_server;' /tmp/nginx-production.conf
                   grep -F 'server_name _;' /tmp/nginx-production.conf
                   grep -F 'return 444;' /tmp/nginx-production.conf
-                  grep -F 'return 301 https://example.com$request_uri;' /tmp/nginx-production.conf
+                  test "$(grep -Fc 'server_name example.com www.example.com;' /tmp/nginx-production.conf)" -eq 2
+                  test "$(grep -Fc "return 301 https://example.com\$request_uri;" /tmp/nginx-production.conf)" -eq 2
+                  grep -F "if (\$host != example.com) {" /tmp/nginx-production.conf
+                  # shellcheck disable=SC2016 # The nginx variables must remain literal.
                   if grep -F 'return 301 https://$host$request_uri;' /tmp/nginx-production.conf; then
                     echo "Production redirect trusts the request Host header"
                     exit 1
                   fi
+                  # shellcheck disable=SC2016 # Detect incorrectly escaped nginx variables.
                   if grep -F 'https://\$host\$request_uri' /tmp/nginx-production.conf; then
                     echo "Production redirect contains escaped nginx variables"
                     exit 1
                   fi
+                  ./generate-nginx-config.sh production "staging.example.com" "staging.example.com" > /tmp/nginx-staging.conf
+                  test "$(grep -Fc 'server_name staging.example.com;' /tmp/nginx-staging.conf)" -eq 2
+                  grep -F "if (\$host != staging.example.com) {" /tmp/nginx-staging.conf
                   docker run --rm -v "$(pwd):/etc/nginx/conf.d" nginx:alpine nginx -t -c /etc/nginx/conf.d/local.conf 2>/dev/null || echo "Local config syntax check failed (this may be expected due to missing includes)"
                   echo "Nginx template generates configs successfully"
 

--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -186,7 +186,6 @@ jobs:
 
                   verify_domain() {
                       local domain="$1"
-                      local redirect_domain="${2:-$domain}"
                       local base_url="https://${domain}"
                       local root_code
                       local redirect_code
@@ -204,7 +203,7 @@ jobs:
 
                       redirect_code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://${domain}/api/health")
                       redirect_location=$(curl -sS -D - -o /dev/null --max-time 10 "http://${domain}/api/health" | awk 'BEGIN { IGNORECASE=1 } /^Location:/ { print $2; exit }' | tr -d '\r')
-                      if [ "$redirect_code" != "301" ] || [ "$redirect_location" != "https://${redirect_domain}/api/health" ]; then
+                      if [ "$redirect_code" != "301" ] || [ "$redirect_location" != "https://${domain}/api/health" ]; then
                           echo "❌ HTTP redirect for ${domain} returned ${redirect_code} -> ${redirect_location}"
                           return 1
                       fi
@@ -376,7 +375,6 @@ jobs:
 
                   verify_domain() {
                       local domain="$1"
-                      local redirect_domain="${2:-$domain}"
                       local base_url="https://${domain}"
                       local root_code
                       local redirect_code
@@ -394,7 +392,7 @@ jobs:
 
                       redirect_code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://${domain}/api/health")
                       redirect_location=$(curl -sS -D - -o /dev/null --max-time 10 "http://${domain}/api/health" | awk 'BEGIN { IGNORECASE=1 } /^Location:/ { print $2; exit }' | tr -d '\r')
-                      if [ "$redirect_code" != "301" ] || [ "$redirect_location" != "https://${redirect_domain}/api/health" ]; then
+                      if [ "$redirect_code" != "301" ] || [ "$redirect_location" != "https://${domain}/api/health" ]; then
                           echo "❌ HTTP redirect for ${domain} returned ${redirect_code} -> ${redirect_location}"
                           return 1
                       fi
@@ -408,5 +406,33 @@ jobs:
                       echo "✅ HSTS header present for ${domain}"
                   }
 
+                  verify_redirect_host() {
+                      local domain="$1"
+                      local primary_domain="$2"
+                      local path="/api/health"
+                      local expected_location="https://${primary_domain}${path}"
+                      local scheme
+                      local redirect_code
+                      local redirect_location
+                      local headers
+
+                      for scheme in http https; do
+                          redirect_code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "${scheme}://${domain}${path}")
+                          redirect_location=$(curl -sS -D - -o /dev/null --max-time 10 "${scheme}://${domain}${path}" | awk 'BEGIN { IGNORECASE=1 } /^Location:/ { print $2; exit }' | tr -d '\r')
+                          if [ "$redirect_code" != "301" ] || [ "$redirect_location" != "$expected_location" ]; then
+                              echo "❌ ${scheme} redirect for ${domain} returned ${redirect_code} -> ${redirect_location}"
+                              return 1
+                          fi
+                          echo "✅ ${scheme} redirect for ${domain} is correct"
+                      done
+
+                      headers=$(curl -sS -D - -o /dev/null --max-time 10 "https://${domain}${path}")
+                      if ! printf '%s\n' "$headers" | grep -qi '^Strict-Transport-Security: '; then
+                          echo "❌ Missing HSTS header for ${domain}"
+                          return 1
+                      fi
+                      echo "✅ HSTS header present for ${domain}"
+                  }
+
                   verify_domain "matcentralen.com"
-                  verify_domain "www.matcentralen.com" "matcentralen.com"
+                  verify_redirect_host "www.matcentralen.com" "matcentralen.com"

--- a/nginx/generate-nginx-config.sh
+++ b/nginx/generate-nginx-config.sh
@@ -16,13 +16,15 @@ generate_local_config() {
     export SSL_PARAMS=""
     export SERVER_NAMES="localhost"
     export HTTP_REDIRECT_BLOCK="# No HTTP redirect needed for local development"
+    export HTTPS_CANONICAL_REDIRECT="# No HTTPS canonical redirect needed for local development"
     export SSL_CONFIG_BLOCK="# SSL configuration omitted for local development"
     export HSTS_HEADER="# HSTS omitted for local development"
     export NEXTJS_UPSTREAM="nextjs"  # Use container name for local Docker networking
 
     # Generate the config with specific variable substitution
     export DOLLAR='$'
-    envsubst '${NGINX_PORT},${SSL_PARAMS},${SERVER_NAMES},${HTTP_REDIRECT_BLOCK},${SSL_CONFIG_BLOCK},${HSTS_HEADER},${NEXTJS_UPSTREAM}' < "$TEMPLATE_FILE" > "$SCRIPT_DIR/local.conf"
+    # shellcheck disable=SC2016 # envsubst needs literal variable names here.
+    envsubst '${NGINX_PORT},${SSL_PARAMS},${SERVER_NAMES},${HTTP_REDIRECT_BLOCK},${HTTPS_CANONICAL_REDIRECT},${SSL_CONFIG_BLOCK},${HSTS_HEADER},${NEXTJS_UPSTREAM}' < "$TEMPLATE_FILE" > "$SCRIPT_DIR/local.conf"
 
     # Add header comment
     {
@@ -70,6 +72,11 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;"
 
+    export HTTPS_CANONICAL_REDIRECT="# Redirect HTTPS aliases to the canonical domain
+    if (\$host != $primary_domain) {
+        return 301 https://$primary_domain\$request_uri;
+    }"
+
     # HSTS header for production
     export HSTS_HEADER='add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;'
 
@@ -79,7 +86,8 @@ server {
         echo "# Generated from nginx.conf.template - DO NOT EDIT MANUALLY"
         echo "# NOTE: Keep template in sync with nginx/local.conf generation"
         echo ""
-        envsubst '${NGINX_PORT},${SSL_PARAMS},${SERVER_NAMES},${HTTP_REDIRECT_BLOCK},${SSL_CONFIG_BLOCK},${HSTS_HEADER},${NEXTJS_UPSTREAM}' < "$TEMPLATE_FILE"
+        # shellcheck disable=SC2016 # envsubst needs literal variable names here.
+        envsubst '${NGINX_PORT},${SSL_PARAMS},${SERVER_NAMES},${HTTP_REDIRECT_BLOCK},${HTTPS_CANONICAL_REDIRECT},${SSL_CONFIG_BLOCK},${HSTS_HEADER},${NEXTJS_UPSTREAM}' < "$TEMPLATE_FILE"
     }
 }
 

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -26,6 +26,8 @@ server {
 
     ${SSL_CONFIG_BLOCK}
 
+    ${HTTPS_CANONICAL_REDIRECT}
+
     # Include shared configuration (rate limiting, gzip, security headers, proxy settings)
     include /etc/nginx/shared.conf;
 


### PR DESCRIPTION
## Why

Authentication cookies are intentionally host-only, so a browser that reaches www.matcentralen.com over HTTPS does not send its matcentralen.com session and is shown the sign-in page. HSTS and HTTPS-first browsing can upgrade the request before the existing HTTP redirect runs, leaving the two hostnames with different login behavior.

## Approach

Generate a server-level nginx redirect for every HTTPS hostname that does not match the deployment-provided primary domain. The destination remains the configured primary domain and preserves the original path and query string. Deployment verification now treats www as a redirect host and checks both HTTP and HTTPS redirects plus HSTS.

## Intentional Boundaries

Authentication cookies remain host-only and no domain is hardcoded into the nginx template. This does not change application, OAuth, database, or session behavior on the primary hostname.