### PR TITLE
Upgrade application runtime to Node.js 24 LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: "pnpm"
 
             - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: "pnpm"
 
             - name: Install dependencies
@@ -93,7 +93,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: "pnpm"
 
             - name: Install dependencies
@@ -126,7 +126,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
               with:
-                  node-version: 22
+                  node-version: 24
                   cache: "pnpm"
 
             - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,7 @@ FROM node:24.18.0-alpine3.23 AS base
 
 LABEL org.opencontainers.image.source=https://github.com/Vasteras-Stadsmission/matkassen
 
-# Keep in sync with "packageManager" in package.json
-ARG PNPM_VERSION=10.29.3
-RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+RUN corepack enable
 
 # Stage 1: Install dependencies
 FROM base AS deps
@@ -59,6 +57,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 # The below are needed for drizzle to work (db migrations inside the container)
+COPY --chown=nextjs:nodejs package.json ./
 COPY --chown=nextjs:nodejs drizzle.config.ts ./
 COPY --from=builder --chown=nextjs:nodejs /app/migrations ./migrations
 COPY --from=deps-prod --chown=nextjs:nodejs /app/node_modules ./node_modules
@@ -76,10 +75,9 @@ RUN chmod +x docker-entrypoint.sh
 # Switch to non-root user
 USER nextjs
 
-# Prepare pnpm cache as nextjs user (must be after USER nextjs)
-# Running as root would cache in root's home, inaccessible at runtime
-ARG PNPM_VERSION
-RUN corepack prepare pnpm@${PNPM_VERSION} --activate
+# Cache the package.json-declared pnpm version as nextjs (must be after USER nextjs).
+# Running as root would cache it in root's home, inaccessible at runtime.
+RUN corepack install
 
 EXPOSE 3000
 CMD ["./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM node:22.23.1-alpine3.23 AS base
+FROM node:24.18.0-alpine3.23 AS base
 
 LABEL org.opencontainers.image.source=https://github.com/Vasteras-Stadsmission/matkassen
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,9 +2,7 @@
 
 FROM node:24.18.0-alpine3.23
 
-# Keep in sync with "packageManager" in package.json
-ARG PNPM_VERSION=10.29.3
-RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+RUN corepack enable
 
 WORKDIR /app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,10 @@
 # This Dockerfile is used for development purposes, i.e. in combination with `docker-compose.dev.yml`
 
-FROM node:22.23.1-alpine3.23
+FROM node:24.18.0-alpine3.23
 
-# Install pnpm globally
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Keep in sync with "packageManager" in package.json
+ARG PNPM_VERSION=10.29.3
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 WORKDIR /app
 
@@ -11,7 +12,7 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 
 # Install dependencies
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 
 # Auth.js requirements
 ENV PORT=3000

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
     "name": "matkassen",
     "version": "0.1.0",
     "private": true,
+    "engines": {
+        "node": "^24.0.0"
+    },
     "scripts": {
         "build": "next build",
         "dev": "docker compose -f docker-compose.dev.yml up db -d && ./scripts/wait-for-db.sh && pnpm run db:migrate && next dev --turbopack",
@@ -79,7 +82,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@types/ms": "^2.1.0",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.13.3",
         "@types/node-cron": "^3.0.11",
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19.2.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,8 +153,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       '@types/node':
-        specifier: ^25.9.1
-        version: 25.9.1
+        specifier: ^24.13.3
+        version: 24.13.3
       '@types/node-cron':
         specifier: ^3.0.11
         version: 3.0.11
@@ -175,7 +175,7 @@ importers:
         version: 8.60.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^5.1.2
-        version: 5.1.2(vite@7.3.5(@types/node@25.9.1)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))
+        version: 5.1.2(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))
       '@vitest/ui':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -211,10 +211,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.5
-        version: 7.3.5(@types/node@25.9.1)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)
+        version: 7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.1)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))
 
 packages:
 
@@ -1617,8 +1617,8 @@ packages:
   '@types/node-cron@3.0.11':
     resolution: {integrity: sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==}
 
-  '@types/node@25.9.1':
-    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
   '@types/pg@8.15.4':
     resolution: {integrity: sha512-I6UNVBAoYbvuWkkU3oosC8yxqH21f4/Jc4DK71JLG3dT2mdlGe1z+ep/LQGXaKaOgcvUrsQoPRqfgtMcvZiJhg==}
@@ -4017,8 +4017,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
@@ -5484,20 +5484,20 @@ snapshots:
 
   '@types/node-cron@3.0.11': {}
 
-  '@types/node@25.9.1':
+  '@types/node@24.13.3':
     dependencies:
-      undici-types: 7.24.6
+      undici-types: 7.18.2
 
   '@types/pg@8.15.4':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.13.3
       pg-protocol: 1.14.0
       pg-types: 2.2.0
     optional: true
 
   '@types/qrcode@1.5.6':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.13.3
 
   '@types/react-dom@19.2.3(@types/react@19.2.16)':
     dependencies:
@@ -5516,7 +5516,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.13.3
 
   '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
@@ -5673,7 +5673,7 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@5.1.2(vite@7.3.5(@types/node@25.9.1)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))':
+  '@vitejs/plugin-react@5.1.2(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
@@ -5681,7 +5681,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.5(@types/node@25.9.1)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)
+      vite: 7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5694,13 +5694,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@25.9.1)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))':
+  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@25.9.1)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)
+      vite: 7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -5729,7 +5729,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.1)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))
 
   '@vitest/utils@4.1.8':
     dependencies:
@@ -5876,7 +5876,7 @@ snapshots:
 
   bun-types@1.2.15:
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.13.3
     optional: true
 
   call-bind-apply-helpers@1.0.2:
@@ -6776,7 +6776,7 @@ snapshots:
 
   happy-dom@20.9.0:
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.13.3
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
@@ -8116,7 +8116,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@7.24.6: {}
+  undici-types@7.18.2: {}
 
   undici@7.28.0: {}
 
@@ -8225,7 +8225,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@7.3.5(@types/node@25.9.1)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0):
+  vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8234,16 +8234,16 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.13.3
       fsevents: 2.3.3
       jiti: 1.21.7
       sugarss: 5.0.1(postcss@8.5.15)
       tsx: 4.21.0
 
-  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.9.1)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@25.9.1)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))
+      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -8260,11 +8260,11 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@25.9.1)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)
+      vite: 7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 25.9.1
+      '@types/node': 24.13.3
       '@vitest/ui': 4.1.8(vitest@4.1.8)
       happy-dom: 20.9.0
       jsdom: 29.1.1


### PR DESCRIPTION
## Why

Node 22 remains supported, but moving while the change is small avoids accumulating a larger runtime migration later. Node 24 is the current LTS line and extends the application runtime support window through April 2028.

## Approach

Production, development, CI, and local package metadata now agree on Node 24. The production and development containers pin Node 24.18.0 while retaining Alpine 3.23, deliberately separating the runtime upgrade from an operating-system upgrade. GitHub Actions follows the latest Node 24 patch, while the local engine constraint accepts compatible Node 24 patch and minor releases.

The TypeScript environment now uses Node 24 definitions instead of Node 25 definitions, preventing compile-time access to APIs unavailable in production. Corepack resolves pnpm from the single integrity-checked `packageManager` declaration in `package.json`; neither Dockerfile duplicates that version. The development image requires the frozen lockfile, while the production image pre-caches the same declared pnpm version for non-root startup migrations.

| Surface | Version policy |
| --- | --- |
| Production and development containers | Node 24.18.0 on Alpine 3.23 |
| GitHub Actions | Latest Node 24 patch |
| Local development | Compatible Node 24 release |
| TypeScript | Node 24 API definitions |
| pnpm | Single integrity-pinned `package.json` declaration |