### PR TITLE
Harden deployment identity and release pinning

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -6,11 +6,13 @@ on:
 
 permissions:
     contents: read
-    packages: write # Required for pushing to GHCR
 
 jobs:
     publish-images:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write # Required for pushing to GHCR
         strategy:
             matrix:
                 include:
@@ -79,6 +81,7 @@ jobs:
                   host: ${{ secrets.SERVER_HOST_STAGING }}
                   username: ${{ secrets.SERVER_USER }}
                   key: ${{ secrets.SERVER_SSH_KEY }}
+                  fingerprint: ${{ vars.SERVER_SSH_FINGERPRINT }}
                   script: |
                       # Fail fast on errors — this block used to swallow git failures and
                       # leave the VPS on an outdated commit while reporting success.
@@ -243,6 +246,7 @@ jobs:
                   host: ${{ secrets.SERVER_HOST_PRODUCTION }}
                   username: ${{ secrets.SERVER_USER }}
                   key: ${{ secrets.SERVER_SSH_KEY }}
+                  fingerprint: ${{ vars.SERVER_SSH_FINGERPRINT }}
                   script: |
                       # Fail fast on errors — see deploy-to-staging above for context.
                       # Assumes the remote login shell is bash (`pipefail` is a bashism).

--- a/.github/workflows/init_deploy.yml
+++ b/.github/workflows/init_deploy.yml
@@ -33,15 +33,15 @@ jobs:
 
             - name: Add to workflow summary
               run: |
-                  echo "## 🚀 Deploying to ${{ github.event.inputs.environment }} environment" >> $GITHUB_STEP_SUMMARY
+                  echo "## 🚀 Deploying to ${{ github.event.inputs.environment }} environment" >> "$GITHUB_STEP_SUMMARY"
 
             - name: Set server host based on environment
               id: set-host
               run: |
                   if [ "${{ github.event.inputs.environment }}" == "production" ]; then
-                    echo "server_host=${{ secrets.SERVER_HOST_PRODUCTION }}" >> $GITHUB_OUTPUT
+                    echo "server_host=${{ secrets.SERVER_HOST_PRODUCTION }}" >> "$GITHUB_OUTPUT"
                   else
-                    echo "server_host=${{ secrets.SERVER_HOST_STAGING }}" >> $GITHUB_OUTPUT
+                    echo "server_host=${{ secrets.SERVER_HOST_STAGING }}" >> "$GITHUB_OUTPUT"
                   fi
 
             - name: Deploy via SSH
@@ -50,6 +50,7 @@ jobs:
                   host: ${{ steps.set-host.outputs.server_host }}
                   username: ${{ secrets.SERVER_USER }}
                   key: ${{ secrets.SERVER_SSH_KEY }}
+                  fingerprint: ${{ vars.SERVER_SSH_FINGERPRINT }}
                   script: |
                       # Fail fast on errors (defense in depth — init_deploy re-clones so
                       # the stale-branch bug doesn't apply, but strict mode is the right
@@ -69,6 +70,9 @@ jobs:
                       export AUTH_GITHUB_APP_INSTALLATION_ID="${{ secrets.AUTH_GITHUB_APP_INSTALLATION_ID }}"
                       export GITHUB_ORG="vasteras-stadsmission"
                       export ENV_NAME="${{ github.event.inputs.environment }}"
+                      export DEPLOY_SHA="${{ github.sha }}"
+                      export APP_IMAGE_TAG="sha-${DEPLOY_SHA}"
+                      export DB_BACKUP_IMAGE_TAG="sha-${DEPLOY_SHA}"
                       # Optional: set the DATABASE_SSL repo/environment secret to
                       # "require" or "verify-full" when the DB is managed/external.
                       # Leave unset for the current trusted-network Docker DB.
@@ -140,11 +144,23 @@ jobs:
                       # git clone into an existing empty directory is supported.
                       sudo install -d -m 700 -o ubuntu -g ubuntu "$APP_DIR"
 
-                      echo "Cloning the repository (shallow clone for faster deployment)"
-                      git clone --depth 1 https://github.com/Vasteras-Stadsmission/matkassen.git "$APP_DIR"
+                      echo "Cloning the repository at workflow commit ${DEPLOY_SHA}"
+                      git clone --depth 1 --no-checkout https://github.com/Vasteras-Stadsmission/matkassen.git "$APP_DIR"
 
                       echo "Change directory to the app folder"
                       cd "$APP_DIR"
+
+                      # The workflow may wait for environment approval while main moves
+                      # forward. Fetch and check out this run's exact commit so the repo,
+                      # deployment scripts, migrations, and sha-* images stay aligned.
+                      git fetch --depth 1 origin "$DEPLOY_SHA"
+                      git checkout --detach "$DEPLOY_SHA"
+                      ACTUAL_SHA="$(git rev-parse HEAD)"
+                      if [ "$ACTUAL_SHA" != "$DEPLOY_SHA" ]; then
+                        echo "❌ VPS checkout mismatch: got $ACTUAL_SHA, expected $DEPLOY_SHA"
+                        exit 1
+                      fi
+                      echo "HEAD: $ACTUAL_SHA  (workflow SHA: $DEPLOY_SHA)"
 
                       echo "Run the deploy script"
                       chmod +x deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -340,16 +340,14 @@ for gz_file in $(find "$APP_DIR" -name "*.gz" -type f 2>/dev/null || true); do
   sudo rm -f "$gz_file"
 done
 
-# Pull pre-built images from GHCR (with fallback to build for first-time setup)
+# Pull the exact pre-built images selected by the workflow. The Compose file
+# intentionally has no local build definitions, so a pull failure must abort
+# rather than silently diverging from the workflow commit.
 echo "Pulling Docker images from GitHub Container Registry..."
 if ! sudo docker compose pull; then
-  echo "⚠️  Failed to pull images from GHCR (this is expected on first deployment)"
-  echo "Falling back to building images locally..."
-  if ! sudo docker compose build --no-cache; then
-    echo "❌ Docker build also failed. Check the logs above."
-    exit 1
-  fi
-  echo "✅ Images built successfully locally"
+  echo "❌ Failed to pull the requested images from GHCR."
+  echo "Confirm the workflow's sha-* images were published, then retry."
+  exit 1
 fi
 
 # Start the containers with health check dependencies
@@ -465,8 +463,10 @@ sudo docker system prune -af
 # Start backup service automatically on production
 if [ "${ENV_NAME:-}" = "production" ]; then
   echo "Starting backup service (profile: backup)..."
-  # Pull the backup image from GHCR
-  sudo docker compose -f docker-compose.yml -f docker-compose.backup.yml --profile backup pull || true
+  # A production init is incomplete without a working backup service. Pull and
+  # wait for health so missing images, credentials, or scheduler startup fail
+  # the workflow instead of reporting a successful deployment without backups.
+  sudo docker compose -f docker-compose.yml -f docker-compose.backup.yml --profile backup pull
   SWIFT_PREFIX="$SWIFT_PREFIX" \
   OS_AUTH_TYPE="$OS_AUTH_TYPE" \
   OS_AUTH_URL="$OS_AUTH_URL" \
@@ -477,7 +477,7 @@ if [ "${ENV_NAME:-}" = "production" ]; then
   OS_APPLICATION_CREDENTIAL_SECRET="$OS_APPLICATION_CREDENTIAL_SECRET" \
   SLACK_BOT_TOKEN="$SLACK_BOT_TOKEN" \
   SLACK_CHANNEL_ID="$SLACK_CHANNEL_ID" \
-  sudo docker compose -f docker-compose.yml -f docker-compose.backup.yml --profile backup up -d db-backup || true
+  sudo docker compose -f docker-compose.yml -f docker-compose.backup.yml --profile backup up -d --wait --wait-timeout 300 db-backup
 fi
 
 # Helper function to check URL accessibility


### PR DESCRIPTION
## Why

GitHub-hosted deploy runners authenticated with an SSH private key but did not verify the VPS host key. Initial deployments could also combine the workflow commit with a newer `main` checkout or a mutable `latest` image, making the deployed release ambiguous. Production bootstrap additionally ignored backup-service startup failures, while every CD job inherited package-write authority.

## Design

The deployment environments now pin each VPS verified ED25519 host fingerprint, so an unexpected server identity fails before any remote commands or secrets are sent. The staging and production fingerprint variables have already been configured in their corresponding GitHub environments.

Initial deployment carries the workflow SHA through repository checkout and both application image tags. The exact commit is fetched and verified even if `main` moves while environment approval is pending. Missing SHA-tagged images now fail closed; the previous local-build fallback could not provide the same release guarantee and the Compose file has no local build definitions.

Production bootstrap now treats the backup service as part of a successful deployment and waits for it to become healthy. Routine CD still promotes through staging before production, while only the image-publishing job retains `packages: write`.