### PR TITLE
Document pinned SSH host fingerprints

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -89,6 +89,36 @@ EOF
 
 Workflow: `.github/workflows/continuous_deployment.yml`
 
+### SSH Host Identity Pinning
+
+Both deployment workflows verify the VPS host key before sending credentials or
+executing remote commands. `SERVER_SSH_FINGERPRINT` is a GitHub environment
+variable, not a secret, and must have the following value in each environment:
+
+| Environment  | Expected ECDSA SHA256 fingerprint                    |
+| ------------ | ---------------------------------------------------- |
+| `staging`    | `SHA256:2P7G9KgU7IIP/Ty/R19MTKeG2oUn75naY+qw5WhO6Cs` |
+| `production` | `SHA256:92R9clTm9OvzjiTfB/6lkOnEquHgWo324JGWvG6tj9I` |
+
+The pinned `appleboy/ssh-action` currently negotiates the servers' ECDSA host
+keys. Do not substitute the ED25519 fingerprint merely because a local OpenSSH
+client prefers ED25519; the fingerprint must match the key negotiated by the
+deployment action.
+
+Verify a fingerprint from the VPS provider console or an existing independently
+trusted SSH session:
+
+```bash
+sudo ssh-keygen -lf /etc/ssh/ssh_host_ecdsa_key.pub -E sha256
+```
+
+Do not establish trust from an unauthenticated `ssh-keyscan` result alone. After
+an intentional VPS rebuild or SSH host-key rotation, verify the new key through
+a trusted channel, update the corresponding GitHub environment variable, and
+run staging before approving production. An unexpected mismatch must be treated
+as a possible wrong-host or man-in-the-middle event until the change is
+explained.
+
 ## Docker Services
 
 ```yaml


### PR DESCRIPTION
## Why

SSH host verification now makes deployments fail closed when a VPS presents an unexpected identity, but the expected values and negotiated key algorithm previously lived only in GitHub environment settings. The first rollout exposed an important ambiguity: local OpenSSH prefers the servers’ ED25519 keys, while the pinned deployment action currently negotiates ECDSA.

## Design

The deployment guide records the environment-specific ECDSA fingerprints that GitHub Actions must use and the trusted server-side command for verifying them. It also documents the rotation procedure for an intentional VPS rebuild or host-key change, and warns against treating an unauthenticated `ssh-keyscan` result as the source of trust.