### PR TITLE
Fix brace-expansion denial-of-service vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
             "flatted": ">=3.4.2",
             "minimatch": ">=10.2.1",
             "yaml": ">=2.8.3",
-            "brace-expansion": ">=5.0.6",
+            "brace-expansion": ">=5.0.7",
             "picomatch": ">=4.0.4",
             "dompurify": ">=3.4.8",
             "postcss": ">=8.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   flatted: '>=3.4.2'
   minimatch: '>=10.2.1'
   yaml: '>=2.8.3'
-  brace-expansion: '>=5.0.6'
+  brace-expansion: '>=5.0.7'
   picomatch: '>=4.0.4'
   dompurify: '>=3.4.8'
   postcss: '>=8.5.10'
@@ -1957,8 +1957,8 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5857,7 +5857,7 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.3
 
@@ -7157,11 +7157,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Dependabot alert 124 reports a denial-of-service vulnerability in brace-expansion 5.0.6 (CVE-2026-13149). The dependency is pulled in transitively by ESLint tooling, so production exposure is limited, but retaining the vulnerable version adds avoidable build and CI risk.

Raise the existing pnpm override floor to the patched 5.0.7 release and refresh the lockfile. This keeps the current minimatch consumers unchanged while ensuring both transitive ESLint paths resolve the patched package.

Resolves [Dependabot alert 124](https://github.com/Vasteras-Stadsmission/matkassen/security/dependabot/124).