### PR TITLE
Disable unused image optimizer

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,22 +18,11 @@ const nextConfig: NextConfig = {
     // Optional: bring your own cache handler
     // cacheHandler: path.resolve('./cache-handler.mjs'),
     // cacheMaxMemorySize: 0, // Disable default in-memory caching
+    // The app only serves local SVG assets, which Next.js already passes
+    // through unchanged. Disable the unused optimizer so /_next/image is not
+    // exposed and the Sharp/libvips processing path cannot accept input.
     images: {
-        // Optional: use a different optimization service
-        // loader: 'custom',
-        // loaderFile: './image-loader.ts',
-        //
-        // We're defaulting to optimizing images with
-        // Sharp, which is built-into `next start`
-        remotePatterns: [
-            {
-                protocol: "https",
-                hostname: "images.unsplash.com",
-                port: "",
-                pathname: "/**",
-                search: "",
-            },
-        ],
+        unoptimized: true,
     },
     // Nginx will do gzip compression. We disable
     // compression here so we can prevent buffering


### PR DESCRIPTION
## Why

The application only renders local SVG assets: the logo and two language flags. Next.js already serves SVG files directly, so the built-in image optimizer provides no benefit. Keeping the optimizer enabled still exposes `/_next/image` and retains an unused remote-image allow-list, unnecessarily leaving the Sharp/libvips processing path available.

## Approach

Set `images.unoptimized` globally and remove the unused Unsplash configuration. Existing `next/image` components continue to provide explicit dimensions and loading behavior, while their SVG sources are served directly. Next.js returns 404 for direct requests to the optimizer endpoint when this setting is enabled.

## Risk considerations

Future raster images will be served without automatic resizing or compression, and future remote images will require an intentional configuration change. That fail-closed behavior is appropriate for the current application and keeps image processing from being enabled accidentally.

Sharp remains present as an optional Next.js lockfile dependency, but no application or public endpoint can invoke it after this change. Once this PR is merged, the Sharp advisory can be dismissed as vulnerable code not used instead of forcing an unsupported dependency override.