### PR TITLE
Prevent sensitive data in SMS logs

### DIFF
--- a/__tests__/app/api/webhooks/sms-status/handler.test.ts
+++ b/__tests__/app/api/webhooks/sms-status/handler.test.ts
@@ -4,9 +4,11 @@ import type { NextRequest } from "next/server";
 const mocks = vi.hoisted(() => ({
     updateSmsProviderStatus: vi.fn(),
     debug: vi.fn(),
+    error: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
     logError: vi.fn(),
+    sendSmsHealthAlert: vi.fn(),
 }));
 
 vi.mock("@/app/utils/sms/sms-service", () => ({
@@ -16,10 +18,15 @@ vi.mock("@/app/utils/sms/sms-service", () => ({
 vi.mock("@/app/utils/logger", () => ({
     logger: {
         debug: mocks.debug,
+        error: mocks.error,
         info: mocks.info,
         warn: mocks.warn,
     },
     logError: mocks.logError,
+}));
+
+vi.mock("@/app/utils/notifications/slack", () => ({
+    sendSmsHealthAlert: mocks.sendSmsHealthAlert,
 }));
 
 import { handleSmsStatusCallback } from "@/app/api/webhooks/sms-status/handler";
@@ -110,5 +117,52 @@ describe("SMS status callback logging", () => {
             "SMS status callback for unknown or already processed message",
         );
         expect(JSON.stringify(mocks.debug.mock.calls)).not.toContain(messageId);
+    });
+
+    it("omits database query parameters from logs and Slack alerts", async () => {
+        const messageId =
+            "SENTINEL_CALLBACK_DB_MESSAGE_ID phone=+46709990012 body=SENTINEL_CALLBACK_DB_BODY";
+        const databaseError = new Error(
+            `Failed query: update outgoing_sms\nparams: delivered,${messageId}`,
+        );
+        mocks.updateSmsProviderStatus.mockRejectedValue(databaseError);
+        const request = {
+            json: vi.fn().mockResolvedValue({
+                apiMessageId: messageId,
+                status: "delivered",
+            }),
+        } as unknown as NextRequest;
+
+        const response = await handleSmsStatusCallback(
+            request,
+            "/api/webhooks/sms-status/[secret]",
+        );
+
+        expect(response.status).toBe(200);
+        expect(mocks.error).toHaveBeenCalledWith(
+            {
+                method: "POST",
+                path: "/api/webhooks/sms-status/[secret]",
+            },
+            "Error processing SMS status callback",
+        );
+        await vi.waitFor(() => {
+            expect(mocks.sendSmsHealthAlert).toHaveBeenCalledWith(false, {
+                error: "SMS status callback processing failed",
+                component: "sms-webhook",
+            });
+        });
+
+        const emitted = JSON.stringify([
+            ...mocks.debug.mock.calls,
+            ...mocks.error.mock.calls,
+            ...mocks.info.mock.calls,
+            ...mocks.warn.mock.calls,
+            ...mocks.logError.mock.calls,
+            ...mocks.sendSmsHealthAlert.mock.calls,
+        ]);
+        expect(emitted).not.toContain(messageId);
+        expect(emitted).not.toContain("+46709990012");
+        expect(emitted).not.toContain("SENTINEL_CALLBACK_DB_BODY");
     });
 });

--- a/__tests__/app/api/webhooks/sms-status/handler.test.ts
+++ b/__tests__/app/api/webhooks/sms-status/handler.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+    updateSmsProviderStatus: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    logError: vi.fn(),
+}));
+
+vi.mock("@/app/utils/sms/sms-service", () => ({
+    updateSmsProviderStatus: mocks.updateSmsProviderStatus,
+}));
+
+vi.mock("@/app/utils/logger", () => ({
+    logger: {
+        debug: mocks.debug,
+        info: mocks.info,
+        warn: mocks.warn,
+    },
+    logError: mocks.logError,
+}));
+
+import { handleSmsStatusCallback } from "@/app/api/webhooks/sms-status/handler";
+
+describe("SMS status callback logging", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("omits the uncontrolled callback reference from logs", async () => {
+        const callbackRef =
+            "SENTINEL_CALLBACK_REFERENCE phone=+46709990004 body=SENTINEL_CALLBACK_BODY";
+        const messageId = "SENTINEL_CALLBACK_MESSAGE_ID phone=+46709990004";
+        mocks.updateSmsProviderStatus.mockResolvedValue(true);
+        const request = {
+            json: vi.fn().mockResolvedValue({
+                apiMessageId: messageId,
+                status: "delivered",
+                callbackRef,
+            }),
+        } as unknown as NextRequest;
+
+        const response = await handleSmsStatusCallback(
+            request,
+            "/api/webhooks/sms-status/[secret]",
+        );
+
+        expect(response.status).toBe(200);
+        expect(mocks.info).toHaveBeenCalledWith(
+            {
+                status: "delivered",
+            },
+            "SMS provider status updated via callback",
+        );
+
+        const logged = JSON.stringify([
+            ...mocks.debug.mock.calls,
+            ...mocks.info.mock.calls,
+            ...mocks.warn.mock.calls,
+            ...mocks.logError.mock.calls,
+        ]);
+        expect(logged).not.toContain(callbackRef);
+        expect(logged).not.toContain(messageId);
+        expect(logged).not.toContain("+46709990004");
+        expect(logged).not.toContain("SENTINEL_CALLBACK_BODY");
+    });
+
+    it("omits the provider message ID when the status is invalid", async () => {
+        const messageId = "SENTINEL_INVALID_STATUS_MESSAGE_ID phone=+46709990008";
+        const request = {
+            json: vi.fn().mockResolvedValue({
+                apiMessageId: messageId,
+                status: "SENTINEL_INVALID_PROVIDER_STATUS",
+            }),
+        } as unknown as NextRequest;
+
+        const response = await handleSmsStatusCallback(
+            request,
+            "/api/webhooks/sms-status/[secret]",
+        );
+
+        expect(response.status).toBe(400);
+        expect(mocks.warn).toHaveBeenCalledWith(
+            { statusType: "string" },
+            "SMS status callback has invalid status",
+        );
+        expect(JSON.stringify(mocks.warn.mock.calls)).not.toContain(messageId);
+    });
+
+    it("omits the provider message ID for an unknown SMS record", async () => {
+        const messageId = "SENTINEL_UNKNOWN_MESSAGE_ID phone=+46709990009";
+        mocks.updateSmsProviderStatus.mockResolvedValue(false);
+        const request = {
+            json: vi.fn().mockResolvedValue({
+                apiMessageId: messageId,
+                status: "delivered",
+            }),
+        } as unknown as NextRequest;
+
+        const response = await handleSmsStatusCallback(
+            request,
+            "/api/webhooks/sms-status/[secret]",
+        );
+
+        expect(response.status).toBe(200);
+        expect(mocks.debug).toHaveBeenCalledWith(
+            { status: "delivered" },
+            "SMS status callback for unknown or already processed message",
+        );
+        expect(JSON.stringify(mocks.debug.mock.calls)).not.toContain(messageId);
+    });
+});

--- a/__tests__/app/utils/sms/hello-sms-logging.test.ts
+++ b/__tests__/app/utils/sms/hello-sms-logging.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const logMocks = vi.hoisted(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    logError: vi.fn(),
+}));
+
+vi.mock("@/app/utils/logger", () => ({
+    logger: {
+        debug: logMocks.debug,
+        info: logMocks.info,
+        warn: logMocks.warn,
+        error: logMocks.error,
+        fatal: logMocks.fatal,
+    },
+    logError: logMocks.logError,
+}));
+
+vi.mock("@/app/config/branding", () => ({
+    SMS_SENDER_NAME: "SENTINEL_SMS_SENDER",
+}));
+
+describe("HelloSMS privacy-safe logging", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+        vi.stubEnv("NODE_ENV", "test");
+        vi.stubEnv("HELLO_SMS_TEST_MODE", "false");
+        vi.stubEnv("HELLO_SMS_USERNAME", "SENTINEL_SMS_USERNAME");
+        vi.stubEnv("HELLO_SMS_PASSWORD", "SENTINEL_SMS_PASSWORD");
+        vi.stubEnv(
+            "HELLO_SMS_API_URL",
+            "https://sms.example.test/send?authorization=SENTINEL_URL_AUTHORIZATION",
+        );
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
+    });
+
+    it("does not log request data, credentials, authorization, or provider rejection text", async () => {
+        const phone = "+46709990003";
+        const smsBody = "SENTINEL_SMS_BODY_PROVIDER";
+        const providerMessageId = `SENTINEL_PROVIDER_MESSAGE_ID phone=${phone}`;
+        const providerError =
+            "SENTINEL_PROVIDER_REJECTION authorization=SENTINEL_PROVIDER_AUTHORIZATION";
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: vi.fn().mockResolvedValue({
+                status: "success",
+                messageIds: [
+                    {
+                        apiMessageId: providerMessageId,
+                        to: phone,
+                        status: -5,
+                        message: providerError,
+                    },
+                ],
+            }),
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const { sendSms } = await import("@/app/utils/sms/hello-sms");
+        const result = await sendSms({ to: phone, text: smsBody });
+
+        expect(result).toMatchObject({
+            success: false,
+            error: providerError,
+            messageId: providerMessageId,
+            httpStatus: 400,
+        });
+
+        const [, fetchOptions] = fetchMock.mock.calls[0];
+        const requestBody = JSON.parse(fetchOptions.body as string);
+        expect(requestBody).toMatchObject({ to: phone, message: smsBody });
+        const authorization = fetchOptions.headers.Authorization as string;
+        expect(authorization).toContain("Basic ");
+
+        const logged = JSON.stringify(Object.values(logMocks).flatMap(mock => mock.mock.calls));
+        for (const sensitiveValue of [
+            phone,
+            smsBody,
+            providerMessageId,
+            providerError,
+            "SENTINEL_SMS_USERNAME",
+            "SENTINEL_SMS_PASSWORD",
+            "SENTINEL_SMS_SENDER",
+            "SENTINEL_URL_AUTHORIZATION",
+            "SENTINEL_PROVIDER_AUTHORIZATION",
+            authorization,
+        ]) {
+            expect(logged).not.toContain(sensitiveValue);
+        }
+
+        expect(logMocks.warn).toHaveBeenCalledWith(
+            {
+                recipientStatus: -5,
+            },
+            "SMS recipient rejected by provider",
+        );
+    });
+
+    it("does not log an uncontrolled recipient status value", async () => {
+        const rawStatus = "SENTINEL_UNCONTROLLED_RECIPIENT_STATUS phone=+46709990011";
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue({
+                ok: true,
+                status: 200,
+                json: vi.fn().mockResolvedValue({
+                    status: "success",
+                    messageIds: [
+                        {
+                            apiMessageId: "provider-message-invalid-status",
+                            to: "+46709990011",
+                            status: rawStatus,
+                            message: "Rejected",
+                        },
+                    ],
+                }),
+            }),
+        );
+
+        const { sendSms } = await import("@/app/utils/sms/hello-sms");
+        await sendSms({ to: "+46709990011", text: "Status validation test" });
+
+        expect(JSON.stringify(logMocks.warn.mock.calls)).not.toContain(rawStatus);
+        expect(logMocks.warn).toHaveBeenCalledWith(
+            { recipientStatus: "invalid" },
+            "SMS recipient rejected by provider",
+        );
+    });
+});

--- a/__tests__/integration/sms/food-parcels-ended.integration.test.ts
+++ b/__tests__/integration/sms/food-parcels-ended.integration.test.ts
@@ -9,7 +9,7 @@
  * IMPORTANT: Uses shared TEST_NOW for deterministic testing.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { getTestDb } from "../../db/test-db";
 import {
     createTestHousehold,
@@ -28,6 +28,7 @@ import { eq } from "drizzle-orm";
 import { getHouseholdsForEndedNotification } from "@/app/utils/sms/sms-service";
 import { MockSmsGateway } from "@/app/utils/sms/mock-sms-gateway";
 import { setSmsGateway, resetSmsGateway } from "@/app/utils/sms/sms-gateway";
+import { logger } from "@/app/utils/logger";
 
 describe("Food Parcels Ended SMS - Integration Tests", () => {
     beforeEach(() => {
@@ -41,6 +42,7 @@ describe("Food Parcels Ended SMS - Integration Tests", () => {
     afterEach(() => {
         // Reset SMS gateway after each test
         resetSmsGateway();
+        vi.restoreAllMocks();
     });
 
     describe("Eligibility Query", () => {
@@ -497,6 +499,66 @@ describe("Food Parcels Ended SMS - Integration Tests", () => {
 
             // Verify mock was called exactly once
             expect(mockGateway.getCallCount()).toBe(1);
+        });
+
+        it("does not log the provider message ID when persisting success fails", async () => {
+            const phone = "+46709990014";
+            const providerMessageId =
+                "SENTINEL_ENDED_PROVIDER_ID_AFTER_SUCCESS_phone_46709990014_body_secret";
+            const db = await getTestDb();
+            const household = await createTestHousehold({
+                phone_number: phone,
+                locale: "sv",
+            });
+            const { location } = await createTestLocationWithSchedule();
+            const threeDaysAgo = daysFromTestNow(-3);
+            const parcel = await createTestPickedUpParcel({
+                household_id: household.id,
+                pickup_location_id: location.id,
+                pickup_date_time_earliest: threeDaysAgo,
+                pickup_date_time_latest: new Date(threeDaysAgo.getTime() + 30 * 60 * 1000),
+                picked_up_at: hoursFromTestNow(-49),
+            });
+            const mockGateway = new MockSmsGateway();
+            vi.spyOn(mockGateway, "send").mockResolvedValue({
+                success: true,
+                messageId: providerMessageId,
+            });
+            setSmsGateway(mockGateway);
+            const errorLogSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
+            const { sendEndedSmsForHousehold } = await import("@/app/utils/sms/sms-service");
+
+            const result = await sendEndedSmsForHousehold({
+                householdId: household.id,
+                phoneNumber: phone,
+                locale: "sv",
+                lastParcelId: parcel.id,
+            });
+
+            expect(result).toMatchObject({
+                success: false,
+                recordId: expect.any(String),
+            });
+            expect(result.error).toContain(providerMessageId);
+
+            const [smsRecord] = await db
+                .select()
+                .from(outgoingSms)
+                .where(eq(outgoingSms.id, result.recordId!));
+            expect(smsRecord.status).toBe("retrying");
+            expect(smsRecord.last_error_message).toContain(providerMessageId);
+
+            const logged = JSON.stringify(errorLogSpy.mock.calls);
+            expect(logged).not.toContain(providerMessageId);
+            expect(logged).not.toContain(phone);
+            expect(logged).not.toContain("body_secret");
+            expect(errorLogSpy).toHaveBeenCalledWith(
+                {
+                    smsId: result.recordId,
+                    householdId: household.id,
+                },
+                "Failed to persist sent food parcels ended SMS status",
+            );
         });
 
         it("respects idempotency - does not create duplicate SMS", async () => {

--- a/__tests__/integration/sms/pickup-reminder-pipeline.integration.test.ts
+++ b/__tests__/integration/sms/pickup-reminder-pipeline.integration.test.ts
@@ -308,6 +308,65 @@ describe("Pickup Reminder SMS Pipeline - Integration Tests", () => {
             );
         });
 
+        it("does not log the provider message ID when persisting success fails", async () => {
+            const phone = "+46709990013";
+            const providerMessageId =
+                "SENTINEL_PROVIDER_MESSAGE_ID_AFTER_SUCCESS_phone_46709990013_body_secret";
+            const db = await getTestDb();
+            const household = await createTestHousehold({
+                phone_number: phone,
+                locale: "sv",
+            });
+            const { location } = await createTestLocationWithSchedule();
+            const tomorrow = daysFromTestNow(1);
+            const parcel = await createTestParcel({
+                household_id: household.id,
+                pickup_location_id: location.id,
+                pickup_date_time_earliest: tomorrow,
+                pickup_date_time_latest: new Date(tomorrow.getTime() + 30 * 60 * 1000),
+            });
+            const mockGateway = new MockSmsGateway();
+            vi.spyOn(mockGateway, "send").mockResolvedValue({
+                success: true,
+                messageId: providerMessageId,
+            });
+            setSmsGateway(mockGateway);
+            const errorLogSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
+
+            const result = await sendReminderForParcel({
+                parcelId: parcel.id,
+                householdId: household.id,
+                phone,
+                locale: "sv",
+                pickupDate: tomorrow,
+            });
+
+            expect(result).toMatchObject({
+                success: false,
+                recordId: expect.any(String),
+            });
+            expect(result.error).toContain(providerMessageId);
+
+            const [smsRecord] = await db
+                .select()
+                .from(outgoingSms)
+                .where(eq(outgoingSms.id, result.recordId!));
+            expect(smsRecord.status).toBe("retrying");
+            expect(smsRecord.last_error_message).toContain(providerMessageId);
+
+            const logged = JSON.stringify(errorLogSpy.mock.calls);
+            expect(logged).not.toContain(providerMessageId);
+            expect(logged).not.toContain(phone);
+            expect(logged).not.toContain("body_secret");
+            expect(errorLogSpy).toHaveBeenCalledWith(
+                {
+                    smsId: result.recordId,
+                    parcelId: parcel.id,
+                },
+                "Failed to persist sent SMS status (JIT)",
+            );
+        });
+
         it("retry via sendSmsRecord succeeds after initial failure", async () => {
             const db = await getTestDb();
             const household = await createTestHousehold({

--- a/__tests__/integration/sms/pickup-reminder-pipeline.integration.test.ts
+++ b/__tests__/integration/sms/pickup-reminder-pipeline.integration.test.ts
@@ -29,6 +29,7 @@ import {
     sendSmsRecord,
     getSmsRecordsReadyForSending,
 } from "@/app/utils/sms/sms-service";
+import { logger } from "@/app/utils/logger";
 
 describe("Pickup Reminder SMS Pipeline - Integration Tests", () => {
     beforeEach(() => {
@@ -40,6 +41,7 @@ describe("Pickup Reminder SMS Pipeline - Integration Tests", () => {
 
     afterEach(() => {
         resetSmsGateway();
+        vi.restoreAllMocks();
     });
 
     describe("Success Scenarios", () => {
@@ -249,6 +251,63 @@ describe("Pickup Reminder SMS Pipeline - Integration Tests", () => {
             expect(smsRecord.attempt_count).toBe(1);
         });
 
+        it("does not log sensitive data when the provider throws", async () => {
+            const phone = "+46709990010";
+            const smsBody = "SENTINEL_THROWN_PROVIDER_SMS_BODY";
+            const providerError =
+                `SENTINEL_THROWN_PROVIDER_ERROR phone=${phone} body=${smsBody} ` +
+                "credential=SENTINEL_THROWN_PROVIDER_CREDENTIAL";
+            const db = await getTestDb();
+            const household = await createTestHousehold({
+                phone_number: phone,
+                locale: "sv",
+            });
+            const { location } = await createTestLocationWithSchedule();
+            const tomorrow = daysFromTestNow(1);
+            const parcel = await createTestParcel({
+                household_id: household.id,
+                pickup_location_id: location.id,
+                pickup_date_time_earliest: tomorrow,
+                pickup_date_time_latest: new Date(tomorrow.getTime() + 30 * 60 * 1000),
+            });
+            const mockGateway = new MockSmsGateway();
+            vi.spyOn(mockGateway, "send").mockRejectedValue(new Error(providerError));
+            setSmsGateway(mockGateway);
+            const errorLogSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
+
+            const result = await sendReminderForParcel({
+                parcelId: parcel.id,
+                householdId: household.id,
+                phone,
+                locale: "sv",
+                pickupDate: tomorrow,
+            });
+
+            expect(result).toMatchObject({
+                success: false,
+                error: providerError,
+            });
+            const [smsRecord] = await db
+                .select()
+                .from(outgoingSms)
+                .where(eq(outgoingSms.id, result.recordId!));
+            expect(smsRecord.status).toBe("retrying");
+            expect(smsRecord.last_error_message).toBe(providerError);
+
+            const logged = JSON.stringify(errorLogSpy.mock.calls);
+            expect(logged).not.toContain(phone);
+            expect(logged).not.toContain(smsBody);
+            expect(logged).not.toContain(providerError);
+            expect(logged).not.toContain("SENTINEL_THROWN_PROVIDER_CREDENTIAL");
+            expect(errorLogSpy).toHaveBeenCalledWith(
+                {
+                    smsId: result.recordId,
+                    parcelId: parcel.id,
+                },
+                "SMS provider request failed unexpectedly (JIT)",
+            );
+        });
+
         it("retry via sendSmsRecord succeeds after initial failure", async () => {
             const db = await getTestDb();
             const household = await createTestHousehold({
@@ -315,9 +374,14 @@ describe("Pickup Reminder SMS Pipeline - Integration Tests", () => {
 
     describe("Permanent Failure", () => {
         it("non-retriable error (400) sets status to failed immediately", async () => {
+            const phone = "+46709990002";
+            const providerError =
+                "SENTINEL_PROVIDER_ERROR_JIT credential=SENTINEL_CREDENTIAL_JIT " +
+                `phone=${phone}`;
+            const errorLogSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
             const db = await getTestDb();
             const household = await createTestHousehold({
-                phone_number: "+46701234567",
+                phone_number: phone,
                 locale: "sv",
             });
             const { location } = await createTestLocationWithSchedule();
@@ -331,13 +395,13 @@ describe("Pickup Reminder SMS Pipeline - Integration Tests", () => {
             });
 
             // Mock gateway that fails with permanent error
-            const mockGateway = new MockSmsGateway().alwaysFail("Invalid phone number", 400);
+            const mockGateway = new MockSmsGateway().alwaysFail(providerError, 400);
             setSmsGateway(mockGateway);
 
             const result = await sendReminderForParcel({
                 parcelId: parcel.id,
                 householdId: household.id,
-                phone: "+46701234567",
+                phone,
                 locale: "sv",
                 pickupDate: tomorrow,
             });
@@ -352,11 +416,24 @@ describe("Pickup Reminder SMS Pipeline - Integration Tests", () => {
                 .where(eq(outgoingSms.id, result.recordId!));
 
             expect(smsRecord.status).toBe("failed");
-            expect(smsRecord.last_error_message).toContain("Invalid phone");
+            expect(smsRecord.last_error_message).toBe(providerError);
             expect(smsRecord.next_attempt_at).toBeNull();
 
             // Mock was called only once (no retry)
             expect(mockGateway.getCallCount()).toBe(1);
+
+            const logged = JSON.stringify(errorLogSpy.mock.calls);
+            expect(logged).not.toContain(phone);
+            expect(logged).not.toContain(providerError);
+            expect(logged).not.toContain("SENTINEL_CREDENTIAL_JIT");
+            expect(errorLogSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    smsId: result.recordId,
+                    parcelId: parcel.id,
+                    providerHttpStatus: 400,
+                }),
+                "SMS failed permanently (JIT)",
+            );
         });
     });
 

--- a/__tests__/integration/sms/queue-processing.integration.test.ts
+++ b/__tests__/integration/sms/queue-processing.integration.test.ts
@@ -27,6 +27,7 @@ import { eq } from "drizzle-orm";
 import { MockSmsGateway } from "@/app/utils/sms/mock-sms-gateway";
 import { setSmsGateway, resetSmsGateway } from "@/app/utils/sms/sms-gateway";
 import { sendSmsRecord, getSmsRecordsReadyForSending } from "@/app/utils/sms/sms-service";
+import { logger } from "@/app/utils/logger";
 
 describe("SMS Queue Processing (sendSmsRecord) - Integration Tests", () => {
     beforeEach(() => {
@@ -38,6 +39,7 @@ describe("SMS Queue Processing (sendSmsRecord) - Integration Tests", () => {
 
     afterEach(() => {
         resetSmsGateway();
+        vi.restoreAllMocks();
     });
 
     describe("Successful Send", () => {
@@ -248,9 +250,17 @@ describe("SMS Queue Processing (sendSmsRecord) - Integration Tests", () => {
 
     describe("Max Attempts", () => {
         it("stops retrying and marks failed after max attempts (3)", async () => {
+            const phone = "+46709990001";
+            const smsBody = "SENTINEL_SMS_BODY_QUEUE";
+            const credential = "SENTINEL_PROVIDER_CREDENTIAL_QUEUE";
+            const authorization = "Basic SENTINEL_AUTHORIZATION_QUEUE";
+            const providerError =
+                `SENTINEL_PROVIDER_ERROR_QUEUE phone=${phone} body=${smsBody} ` +
+                `credential=${credential} authorization=${authorization}`;
+            const errorLogSpy = vi.spyOn(logger, "error").mockImplementation(() => logger);
             const db = await getTestDb();
             const household = await createTestHousehold({
-                phone_number: "+46701234567",
+                phone_number: phone,
             });
             const { location } = await createTestLocationWithSchedule();
 
@@ -269,9 +279,10 @@ describe("SMS Queue Processing (sendSmsRecord) - Integration Tests", () => {
                 status: "retrying",
                 attempt_count: 2,
                 next_attempt_at: new Date(),
+                text: smsBody,
             });
 
-            const mockGateway = new MockSmsGateway().alwaysFail("Still failing", 503);
+            const mockGateway = new MockSmsGateway().alwaysFail(providerError, 503);
             setSmsGateway(mockGateway);
 
             const readyRecords = await getSmsRecordsReadyForSending();
@@ -290,6 +301,22 @@ describe("SMS Queue Processing (sendSmsRecord) - Integration Tests", () => {
             expect(updatedRecord.status).toBe("failed");
             expect(updatedRecord.attempt_count).toBe(3);
             expect(updatedRecord.next_attempt_at).toBeNull(); // No more retries
+            expect(updatedRecord.last_error_message).toBe(providerError);
+
+            const logged = JSON.stringify(errorLogSpy.mock.calls);
+            expect(logged).not.toContain(phone);
+            expect(logged).not.toContain(smsBody);
+            expect(logged).not.toContain(credential);
+            expect(logged).not.toContain(authorization);
+            expect(logged).not.toContain(providerError);
+            expect(errorLogSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    smsId: sms.id,
+                    providerHttpStatus: 503,
+                    attempts: 3,
+                }),
+                "SMS failed permanently",
+            );
         });
     });
 

--- a/__tests__/integration/sms/reconciliation-logging.integration.test.ts
+++ b/__tests__/integration/sms/reconciliation-logging.integration.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestHousehold, resetHouseholdCounter } from "../../factories/household.factory";
+import { createTestSms, resetSmsCounter } from "../../factories/sms.factory";
+import { hoursFromTestNow, TEST_NOW } from "../../test-time";
+import { MockSmsGateway } from "@/app/utils/sms/mock-sms-gateway";
+import {
+    resetSmsGateway,
+    setSmsGateway,
+    type ConversationMessageStatus,
+} from "@/app/utils/sms/sms-gateway";
+import { reconcileStaleMessages } from "@/app/utils/sms/sms-service";
+import { logger } from "@/app/utils/logger";
+
+vi.mock("@/app/utils/sms/hello-sms", async importOriginal => {
+    const actual = await importOriginal<typeof import("@/app/utils/sms/hello-sms")>();
+    return {
+        ...actual,
+        getHelloSmsConfig: () => ({
+            ...actual.getHelloSmsConfig(),
+            testMode: false,
+        }),
+    };
+});
+
+describe("SMS reconciliation privacy-safe logging", () => {
+    beforeEach(() => {
+        vi.useRealTimers();
+        vi.useFakeTimers({ toFake: ["Date"] });
+        vi.setSystemTime(TEST_NOW);
+        resetHouseholdCounter();
+        resetSmsCounter();
+        resetSmsGateway();
+    });
+
+    afterEach(() => {
+        resetSmsGateway();
+        vi.restoreAllMocks();
+    });
+
+    it("does not log a recipient phone number or SMS body when reconciliation succeeds", async () => {
+        const phone = "+46709990005";
+        const smsBody = "SENTINEL_RECONCILIATION_SMS_BODY";
+        const sentAt = hoursFromTestNow(-2);
+        const household = await createTestHousehold({ phone_number: phone });
+        const sms = await createTestSms({
+            household_id: household.id,
+            to_e164: phone,
+            text: smsBody,
+            status: "sent",
+            sent_at: sentAt,
+            provider_message_id: "provider-message-789",
+        });
+        const mockGateway = new MockSmsGateway().mockConversation([
+            {
+                ts: sentAt.getTime() / 1000,
+                subject: "",
+                text: smsBody,
+                direction: "out",
+                status: "delivered",
+            },
+        ]);
+        setSmsGateway(mockGateway);
+        const infoLogSpy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+
+        const result = await reconcileStaleMessages();
+
+        expect(result).toMatchObject({ reconciled: 1, checked: 1, errors: [] });
+        const logged = JSON.stringify(infoLogSpy.mock.calls);
+        expect(logged).not.toContain(phone);
+        expect(logged).not.toContain(smsBody);
+        expect(infoLogSpy).toHaveBeenCalledWith(
+            {
+                smsId: sms.id,
+                providerStatus: "delivered",
+            },
+            "SMS delivery status reconciled via conversation API (callback was missing)",
+        );
+    });
+
+    it("does not log an uncontrolled provider status", async () => {
+        const phone = "+46709990006";
+        const smsBody = "SENTINEL_UNKNOWN_STATUS_SMS_BODY";
+        const rawStatus = "SENTINEL_UNCONTROLLED_PROVIDER_STATUS";
+        const sentAt = hoursFromTestNow(-2);
+        const household = await createTestHousehold({ phone_number: phone });
+        const sms = await createTestSms({
+            household_id: household.id,
+            to_e164: phone,
+            text: smsBody,
+            status: "sent",
+            sent_at: sentAt,
+            provider_message_id: "provider-message-unknown-status",
+        });
+        const mockGateway = new MockSmsGateway().mockConversation([
+            {
+                ts: sentAt.getTime() / 1000,
+                subject: "",
+                text: smsBody,
+                direction: "out",
+                status: rawStatus as ConversationMessageStatus,
+            },
+        ]);
+        setSmsGateway(mockGateway);
+        const warnLogSpy = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+
+        const result = await reconcileStaleMessages();
+
+        expect(result).toMatchObject({ reconciled: 0, checked: 1, errors: [] });
+        const logged = JSON.stringify(warnLogSpy.mock.calls);
+        expect(logged).not.toContain(phone);
+        expect(logged).not.toContain(smsBody);
+        expect(logged).not.toContain(rawStatus);
+        expect(warnLogSpy).toHaveBeenCalledWith(
+            { smsId: sms.id },
+            "SMS reconciliation: unknown provider status from conversation API, skipping",
+        );
+    });
+
+    it("keeps provider conversation failures out of returned alert details", async () => {
+        const phone = "+46709990007";
+        const smsBody = "SENTINEL_FAILED_CONVERSATION_SMS_BODY";
+        const providerError =
+            "SENTINEL_CONVERSATION_PROVIDER_ERROR credential=SENTINEL_CONVERSATION_CREDENTIAL";
+        const household = await createTestHousehold({ phone_number: phone });
+        const sms = await createTestSms({
+            household_id: household.id,
+            to_e164: phone,
+            text: smsBody,
+            status: "sent",
+            sent_at: hoursFromTestNow(-2),
+            provider_message_id: "provider-message-failed-conversation",
+        });
+        setSmsGateway(new MockSmsGateway().mockConversationError(providerError));
+
+        const result = await reconcileStaleMessages();
+
+        expect(result).toMatchObject({
+            reconciled: 0,
+            checked: 1,
+            errors: [`${sms.id}: provider conversation request failed`],
+        });
+        const alertDetails = JSON.stringify(result.errors);
+        expect(alertDetails).not.toContain(phone);
+        expect(alertDetails).not.toContain(smsBody);
+        expect(alertDetails).not.toContain(providerError);
+        expect(alertDetails).not.toContain("SENTINEL_CONVERSATION_CREDENTIAL");
+    });
+});

--- a/app/api/webhooks/sms-status/handler.ts
+++ b/app/api/webhooks/sms-status/handler.ts
@@ -56,10 +56,7 @@ export async function handleSmsStatusCallback(
         // Extract and validate the status
         const status = body.status;
         if (!isValidStatus(status)) {
-            logger.warn(
-                { messageId, statusType: typeof status },
-                "SMS status callback has invalid status",
-            );
+            logger.warn({ statusType: typeof status }, "SMS status callback has invalid status");
             return NextResponse.json({ error: "Invalid status" }, { status: 400 });
         }
 
@@ -67,14 +64,11 @@ export async function handleSmsStatusCallback(
         const updated = await updateSmsProviderStatus(messageId, status);
 
         if (updated) {
-            logger.info(
-                { messageId, status, callbackRef: body.callbackRef },
-                "SMS provider status updated via callback",
-            );
+            logger.info({ status }, "SMS provider status updated via callback");
         } else {
             // This is not necessarily an error - the message might be old or already processed
             logger.debug(
-                { messageId, status },
+                { status },
                 "SMS status callback for unknown or already processed message",
             );
         }

--- a/app/api/webhooks/sms-status/handler.ts
+++ b/app/api/webhooks/sms-status/handler.ts
@@ -75,18 +75,21 @@ export async function handleSmsStatusCallback(
 
         // Always return 200 for valid payloads to prevent HelloSMS retries
         return NextResponse.json({ received: true }, { status: 200 });
-    } catch (error) {
-        logError("Error processing SMS status callback", error, {
-            method: "POST",
-            path: logPath,
-        });
+    } catch {
+        logger.error(
+            {
+                method: "POST",
+                path: logPath,
+            },
+            "Error processing SMS status callback",
+        );
 
         // Alert to Slack so webhook processing failures are visible.
         // Uses state-transition pattern to avoid flooding Slack during a DB outage.
         import("@/app/utils/notifications/slack")
             .then(({ sendSmsHealthAlert }) =>
                 sendSmsHealthAlert(false, {
-                    error: error instanceof Error ? error.message : String(error),
+                    error: "SMS status callback processing failed",
                     component: "sms-webhook",
                 }),
             )

--- a/app/utils/sms/hello-sms.ts
+++ b/app/utils/sms/hello-sms.ts
@@ -155,10 +155,9 @@ export async function sendSms(request: SendSmsRequest): Promise<SendSmsResponse>
     if (!configLogged) {
         logger.info(
             {
-                apiUrl: config.apiUrl,
                 username: config.username ? "configured" : "missing",
                 testMode: config.testMode,
-                from: config.from,
+                from: config.from ? "configured" : "missing",
             },
             "SMS configuration loaded",
         );
@@ -217,9 +216,11 @@ export async function sendSms(request: SendSmsRequest): Promise<SendSmsResponse>
                     `Recipient rejected (status: ${firstRecipient.status})`;
                 logger.warn(
                     {
-                        to: normalizedTo,
-                        recipientStatus: firstRecipient.status,
-                        message: firstRecipient.message,
+                        recipientStatus:
+                            typeof firstRecipient.status === "number" &&
+                            Number.isFinite(firstRecipient.status)
+                                ? firstRecipient.status
+                                : "invalid",
                     },
                     "SMS recipient rejected by provider",
                 );

--- a/app/utils/sms/sms-service.ts
+++ b/app/utils/sms/sms-service.ts
@@ -61,6 +61,28 @@ const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
 // 48 hours in milliseconds - delay before sending "food parcels ended" SMS
 const FORTY_EIGHT_HOURS_MS = 48 * 60 * 60 * 1000;
 
+function logPermanentSmsFailure(
+    message: string,
+    result: SendSmsResponse,
+    context: Record<string, unknown>,
+): void {
+    const providerHttpStatus =
+        typeof result.httpStatus === "number" &&
+        Number.isInteger(result.httpStatus) &&
+        result.httpStatus >= 100 &&
+        result.httpStatus <= 599
+            ? result.httpStatus
+            : undefined;
+
+    logger.error(
+        {
+            ...context,
+            providerHttpStatus,
+        },
+        message,
+    );
+}
+
 /**
  * HTTP status codes that indicate transient errors eligible for retry.
  * Unified across both queued and JIT SMS pipelines.
@@ -746,7 +768,8 @@ async function handleSmsFailure(record: SmsRecord, result: SendSmsResponse): Pro
             incrementAttempt: true,
         });
     } else {
-        logError("SMS failed permanently", new Error(result.error || "Unknown error"), {
+        logPermanentSmsFailure("SMS failed permanently", result, {
+            smsId: record.id,
             intent: record.intent,
             householdId: record.householdId,
             attempts: currentAttempt,
@@ -1073,11 +1096,15 @@ export async function sendReminderForParcel(parcel: {
     }
 
     // Step 2: Send SMS
+    let providerCallCompleted = false;
+    let providerReturnedFailure = false;
     try {
         const result = await sendSmsViaGateway({
             to: phoneToUse,
             text: textToUse,
         });
+        providerCallCompleted = true;
+        providerReturnedFailure = !result.success;
 
         // Step 3: Update record with final status
         if (result.success) {
@@ -1100,7 +1127,22 @@ export async function sendReminderForParcel(parcel: {
         }
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error";
-        logError("Failed to send SMS (JIT)", error, { parcelId: parcel.parcelId });
+        if (!providerCallCompleted) {
+            logger.error(
+                { smsId: id, parcelId: parcel.parcelId },
+                "SMS provider request failed unexpectedly (JIT)",
+            );
+        } else if (providerReturnedFailure) {
+            logger.error(
+                { smsId: id, parcelId: parcel.parcelId },
+                "Failed to process SMS provider failure (JIT)",
+            );
+        } else {
+            logError("Failed to send SMS (JIT)", error, {
+                smsId: id,
+                parcelId: parcel.parcelId,
+            });
+        }
 
         // Handle exception with retry logic (treat as retriable if pickup hasn't passed)
         await handleJitFailure(id, parcel.parcelId, freshData.pickupLatest, {
@@ -1177,7 +1219,7 @@ async function handleJitFailure(
             })
             .where(eq(outgoingSms.id, smsId));
     } else {
-        logError("SMS failed permanently (JIT)", new Error(result.error || "Unknown error"), {
+        logPermanentSmsFailure("SMS failed permanently (JIT)", result, {
             smsId,
             parcelId,
             attempts: currentAttempt,
@@ -1736,11 +1778,15 @@ export async function sendEndedSmsForHousehold(household: {
     }
 
     // Step 2: Send SMS
+    let providerCallCompleted = false;
+    let providerReturnedFailure = false;
     try {
         const result = await sendSmsViaGateway({
             to: phoneToUse,
             text: textToUse,
         });
+        providerCallCompleted = true;
+        providerReturnedFailure = !result.success;
 
         // Step 3: Update record with final status
         if (result.success) {
@@ -1766,9 +1812,22 @@ export async function sendEndedSmsForHousehold(household: {
         }
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error";
-        logError("Failed to send food parcels ended SMS", error, {
-            householdId: household.householdId,
-        });
+        if (!providerCallCompleted) {
+            logger.error(
+                { smsId: id, householdId: household.householdId },
+                "SMS provider request failed unexpectedly for food parcels ended notification",
+            );
+        } else if (providerReturnedFailure) {
+            logger.error(
+                { smsId: id, householdId: household.householdId },
+                "Failed to process SMS provider failure for food parcels ended notification",
+            );
+        } else {
+            logError("Failed to send food parcels ended SMS", error, {
+                smsId: id,
+                householdId: household.householdId,
+            });
+        }
 
         // Handle exception with retry logic
         await handleEndedSmsFailure(id, household.householdId, {
@@ -1827,15 +1886,11 @@ async function handleEndedSmsFailure(
             })
             .where(eq(outgoingSms.id, smsId));
     } else {
-        logError(
-            "Food parcels ended SMS failed permanently",
-            new Error(result.error || "Unknown error"),
-            {
-                smsId,
-                householdId,
-                attempts: currentAttempt,
-            },
-        );
+        logPermanentSmsFailure("Food parcels ended SMS failed permanently", result, {
+            smsId,
+            householdId,
+            attempts: currentAttempt,
+        });
 
         await db
             .update(outgoingSms)
@@ -2081,8 +2136,8 @@ export async function getAvailableCredits(): Promise<number | null> {
         if (result.success && typeof result.credits === "number") {
             return result.credits;
         }
-    } catch (error) {
-        logger.warn({ error }, "Balance check failed, proceeding without credit limit");
+    } catch {
+        logger.warn("Balance check failed, proceeding without credit limit");
     }
     return null; // fail-open
 }
@@ -2181,7 +2236,8 @@ export async function reconcileStaleMessages(): Promise<{
         const conversation = await fetchConversationViaGateway(phone);
 
         if (!conversation.success) {
-            errors.push(`${phone}: ${conversation.error}`);
+            const smsIds = records.map(record => record.id).join(", ");
+            errors.push(`${smsIds}: provider conversation request failed`);
             continue;
         }
 
@@ -2214,7 +2270,7 @@ export async function reconcileStaleMessages(): Promise<{
                 )
             ) {
                 logger.warn(
-                    { smsId: record.id, phone, rawStatus: match.status },
+                    { smsId: record.id },
                     "SMS reconciliation: unknown provider status from conversation API, skipping",
                 );
                 continue;
@@ -2240,7 +2296,7 @@ export async function reconcileStaleMessages(): Promise<{
                 if (updated.length > 0) {
                     reconciled++;
                     logger.info(
-                        { smsId: record.id, phone, providerStatus: normalizedStatus },
+                        { smsId: record.id, providerStatus: normalizedStatus },
                         "SMS delivery status reconciled via conversation API (callback was missing)",
                     );
                 } else {
@@ -2253,9 +2309,7 @@ export async function reconcileStaleMessages(): Promise<{
                 logError("SMS reconciliation: failed to update record", updateError, {
                     smsId: record.id,
                 });
-                errors.push(
-                    `${record.id}: ${updateError instanceof Error ? updateError.message : "DB update failed"}`,
-                );
+                errors.push(`${record.id}: database update failed`);
             }
         }
 

--- a/app/utils/sms/sms-service.ts
+++ b/app/utils/sms/sms-service.ts
@@ -1138,10 +1138,13 @@ export async function sendReminderForParcel(parcel: {
                 "Failed to process SMS provider failure (JIT)",
             );
         } else {
-            logError("Failed to send SMS (JIT)", error, {
-                smsId: id,
-                parcelId: parcel.parcelId,
-            });
+            logger.error(
+                {
+                    smsId: id,
+                    parcelId: parcel.parcelId,
+                },
+                "Failed to persist sent SMS status (JIT)",
+            );
         }
 
         // Handle exception with retry logic (treat as retriable if pickup hasn't passed)
@@ -1823,10 +1826,13 @@ export async function sendEndedSmsForHousehold(household: {
                 "Failed to process SMS provider failure for food parcels ended notification",
             );
         } else {
-            logError("Failed to send food parcels ended SMS", error, {
-                smsId: id,
-                householdId: household.householdId,
-            });
+            logger.error(
+                {
+                    smsId: id,
+                    householdId: household.householdId,
+                },
+                "Failed to persist sent food parcels ended SMS status",
+            );
         }
 
         // Handle exception with retry logic


### PR DESCRIPTION
## Why

Production logs are about to become persistent across deployments. The SMS flow currently allows recipient phone numbers and provider-controlled text to reach logs directly or through later failure handling, which would turn longer retention into a privacy liability.

## Design

This change treats provider responses and callback fields as untrusted. Log records now use an allowlist of operational metadata: internal SMS, parcel, and household IDs plus validated status codes. Provider errors, provider message IDs, callback references, phone numbers, message bodies, endpoint values, and credentials are omitted.

Returned provider errors and `last_error_message` remain unchanged so existing retry decisions and admin diagnostics keep working. Reconciliation alerts still fire, but identify affected internal SMS records rather than copying phone numbers or provider text into Slack.

## Intentional behavior

| Area | Retained | Excluded |
| --- | --- | --- |
| Send failures | Internal IDs, attempt count, valid HTTP status | Provider error text, recipient, SMS body |
| Status callbacks | Valid delivery status | Provider message ID, callback reference |
| Reconciliation | Internal SMS ID, valid provider status, aggregate counts | Phone number, raw provider status, provider error text |
| Configuration | Whether values are configured | Endpoint, sender value, username, password, authorization |

This is the privacy prerequisite for the persistent-log rollout. It should be deployed before the host retention and container logging changes are promoted.