### PR TITLE
Prepare bounded persistent journal storage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
             - name: Validate shell scripts
               run: |
                   echo "Validating shell scripts..."
-                  SCRIPTS=("deploy.sh" "update.sh" "scripts/backup-db.sh" "scripts/backup-restore.sh" "scripts/backup-manage.sh")
+                  SCRIPTS=("deploy.sh" "update.sh" "scripts/backup-db.sh" "scripts/backup-restore.sh" "scripts/backup-manage.sh" "scripts/configure-journald.sh")
                   for script in "${SCRIPTS[@]}"; do
                       if [ -f "$script" ]; then
                           echo "Checking $script..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -323,6 +323,9 @@ sudo systemctl restart nginx
 # Build and run the Docker containers from the app directory
 cd "$APP_DIR"
 
+echo "Configuring bounded persistent journal storage..."
+sudo "$APP_DIR/scripts/configure-journald.sh"
+
 # Stop and remove existing containers to ensure clean state
 echo "Stopping existing containers (if any)..."
 sudo docker compose down || true

--- a/docs/log-retention-architecture.md
+++ b/docs/log-retention-architecture.md
@@ -1,0 +1,204 @@
+# Log Retention Architecture
+
+## Status
+
+Accepted architecture for production and staging VPS log retention.
+
+## Context
+
+Matkassen application and backup containers originally used Docker's local
+`json-file` logging driver. Those files belong to the container, so replacing
+and pruning a container during deployment also removes its older logs.
+
+Other records already have separate lifecycles:
+
+- Nginx writes access and error logs below `/var/log/nginx`.
+- Deployment output remains in GitHub Actions.
+- PostgreSQL backups are encrypted and uploaded to Swift, but those backups do
+  not contain application or host-security logs.
+- Important SSH, sudo, systemd, and other host-security records exist only in
+  the VPS system journal.
+
+The system needs a useful troubleshooting history under normal traffic,
+bounded disk consumption, and minimal additional infrastructure.
+
+## Decision
+
+Use the VPS's existing `systemd-journald` service as the durable storage layer
+for container output that must survive container replacement.
+
+| Area             | Decision                                                           |
+| ---------------- | ------------------------------------------------------------------ |
+| Application      | Route the `web` container's standard output and error to journald  |
+| Backups          | Route the `db-backup` container's output to journald               |
+| PostgreSQL       | Keep the `db` container on its existing `json-file` driver         |
+| Host services    | Continue using their existing journald integration                 |
+| Nginx            | Continue writing files below `/var/log/nginx`                      |
+| Deployments      | Continue retaining workflow output in GitHub Actions               |
+| Capacity         | Cap the whole system journal at 2 GB and reserve 5 GB of free disk |
+| Time limit       | Do not impose a global age limit                                   |
+| Off-host archive | Do not export logs to Swift in this implementation                 |
+
+## System design
+
+```mermaid
+flowchart LR
+    WEB["Web container<br>Pino JSON on stdout/stderr"]
+    BACKUP["Backup container<br>stdout/stderr"]
+    DB["PostgreSQL container"]
+    HOST["SSH, sudo, systemd<br>and other host services"]
+    JOURNALD["systemd-journald"]
+    STORE["/var/log/journal<br>persistent and compressed"]
+    JSON["Docker json-file"]
+
+    WEB -->|"Docker journald driver"| JOURNALD
+    BACKUP -->|"Docker journald driver"| JOURNALD
+    HOST --> JOURNALD
+    JOURNALD --> STORE
+    DB --> JSON
+```
+
+Pino records remain JSON inside journald's `MESSAGE` field. Docker adds
+metadata such as `CONTAINER_NAME` and `CONTAINER_ID`. A stable container name
+allows queries to include entries from previous container instances, while
+the changing container ID distinguishes deployments.
+
+Logs written before a container starts using the journald driver are not
+migrated and cannot be recovered after Docker removes their old container.
+
+## Host retention policy
+
+The repository manages this journald drop-in:
+
+```ini
+[Journal]
+Storage=persistent
+SystemMaxUse=2G
+SystemKeepFree=5G
+MaxRetentionSec=0
+Compress=yes
+```
+
+The 2 GB value is an initial safety ceiling, not preallocated space or a
+retention promise. It covers the entire host journal, including security and
+application records. It provides incident headroom above the existing host
+journal while remaining small relative to the VPS disk. The 5 GB free-space
+reserve is the final protection against logs exhausting the host.
+
+The operational target is at least 30 days of history under normal volume.
+Actual history can be shorter during a noisy incident because capacity and
+free-space limits take precedence. Quiet systems may retain records much
+longer.
+
+There is no global time-based deletion rule because it would also remove the
+only retained copy of important host-security records. Reassess the 2 GB
+ceiling from measured journal growth after application logging is enabled;
+investigate unexpectedly noisy sources before increasing it.
+
+## Deployment invariants
+
+The repository-managed journald helper runs from both initial and continuous
+deployment before Docker replaces any application container.
+
+It must:
+
+1. Create `/var/log/journal` and let systemd apply its expected ownership,
+   modes, and ACLs.
+2. Install the drop-in atomically with root ownership and normal configuration
+   permissions.
+3. Record that a restart is required before replacing the drop-in.
+4. Restart journald only when the policy changed or an earlier run did not
+   finish applying it.
+5. Keep the boot-scoped restart marker until journald is confirmed active.
+6. Flush volatile records into persistent storage.
+7. Inspect the merged configuration and reject a later conflicting drop-in.
+8. Write and read a unique canary from persistent journal files.
+
+A failed installation, restart, configuration check, or canary check aborts
+the deployment before container replacement. A retry must finish an
+interrupted restart instead of treating matching on-disk content as proof that
+the running service loaded it.
+
+Setup must not vacuum or delete existing journal records.
+
+## Rollout and acceptance
+
+The change is intentionally ordered:
+
+1. Remove known sensitive SMS values from application logs.
+2. Deploy and verify persistent, bounded host journal storage while all Docker
+   services remain on their existing logging drivers.
+3. Route `web` and `db-backup` to journald while leaving `db` unchanged.
+
+The host-policy stage must prove on staging and then production that:
+
+- The intended settings are effective.
+- A second helper run makes no changes and avoids another restart.
+- The persistent canary remains readable.
+- Restarting journald does not interrupt Docker, Nginx, SSH, application
+  health, or subsequent journal writes.
+- Existing history remains available and disk usage remains reasonable.
+
+After changing the Docker drivers, staging must recreate the web container a
+second time and prove that an entry from the preceding journald-enabled
+container remains queryable. Production promotion is blocked if that
+cross-container persistence test fails.
+
+Day-to-day query and troubleshooting commands belong in
+`docs/production-logs.md`.
+
+## Security and privacy
+
+Longer retention increases the impact of accidental over-logging. Complete
+phone numbers, SMS bodies, credentials, authorization values, session data,
+provider callback data, and uncontrolled provider errors must not reach the
+application logger.
+
+The journal retains the VPS's existing privileged access model. This design
+does not make records publicly accessible, add application secrets, or add a
+hosted logging provider.
+
+The retained journal remains local to the VPS. It is not an independent or
+tamper-resistant security archive and can be lost with the host.
+
+## Failure handling and rollback
+
+If the container logging-driver change causes an operational issue:
+
+1. Return `web` and `db-backup` to their previous bounded `json-file`
+   configuration.
+2. Recreate only those services through the normal deployment path.
+3. Leave PostgreSQL untouched.
+
+Previously collected journal entries remain available under the host policy
+after that rollback.
+
+If the host policy itself causes an issue, stop future deployments from
+reinstalling the repository-managed drop-in, remove only that managed file,
+and restart journald. Do not automatically delete `/var/log/journal` or vacuum
+records. Confirm the remaining effective policy and the health of SSH, Docker,
+Nginx, and the application.
+
+## Consequences and trade-offs
+
+- Journald capacity is shared by application and host records.
+- High log volume may reduce the available history below 30 days.
+- Systemd's default rate limiting may suppress extreme bursts.
+- Docker's default blocking delivery behavior can apply backpressure if the
+  logging path becomes unhealthy.
+- Pino fields are not individually indexed journald fields.
+- The design survives container replacement and host reboot, but not VPS loss
+  or compromise.
+- It avoids another service, credential set, monitoring surface, and ongoing
+  operating cost.
+
+An off-host archive should be designed separately if audit, legal, insurance,
+incident-response, or host-loss requirements emerge. Such a design would need
+separate least-privilege Swift credentials, encryption, lifecycle deletion,
+integrity checks, restore testing, privacy review, and upload-failure alerting.
+
+## References
+
+- [Docker journald logging driver](https://docs.docker.com/engine/logging/drivers/journald/)
+- [Configure Docker logging drivers](https://docs.docker.com/engine/logging/configure/)
+- [systemd journald configuration](https://www.freedesktop.org/software/systemd/man/journald.conf.html)

--- a/scripts/configure-journald.sh
+++ b/scripts/configure-journald.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 
+# Configure persistent, bounded systemd journal storage on a Matkassen VPS.
+#
+# deploy.sh and update.sh call this as root before replacing Docker containers.
+# It is safe to rerun: unchanged policy avoids a restart, while an interrupted
+# policy update forces the next run to finish loading it.
+#
+# Usage: sudo ./scripts/configure-journald.sh
+#
+# The script verifies the effective policy and a persistent canary. It does not
+# change Docker logging drivers, delete journal records, or export logs off-host.
+
 set -euo pipefail
 
 export LC_ALL=C
@@ -7,6 +18,7 @@ export LC_ALL=C
 readonly CONFIG_DIR="/etc/systemd/journald.conf.d"
 readonly CONFIG_FILE="$CONFIG_DIR/90-matkassen-retention.conf"
 readonly JOURNAL_DIR="/var/log/journal"
+readonly RESTART_REQUIRED_FILE="/run/matkassen-journald-restart-required"
 
 if [[ "$(id -u)" -ne 0 ]]; then
     echo "This script must be run as root (for example with sudo)." >&2
@@ -36,20 +48,8 @@ printf '%s\n' \
     "Storage=persistent" \
     "SystemMaxUse=2G" \
     "SystemKeepFree=5G" \
+    "MaxRetentionSec=0" \
     "Compress=yes" >"$desired_config"
-
-install -d -o root -g root -m 0755 "$CONFIG_DIR"
-
-config_changed=false
-if [[ ! -f "$CONFIG_FILE" ]] ||
-    ! cmp -s "$desired_config" "$CONFIG_FILE" ||
-    [[ "$(stat -c '%u:%g:%a' "$CONFIG_FILE")" != "0:0:644" ]]; then
-    pending_config="$(mktemp "$CONFIG_DIR/.90-matkassen-retention.conf.XXXXXX")"
-    install -o root -g root -m 0644 "$desired_config" "$pending_config"
-    mv -f "$pending_config" "$CONFIG_FILE"
-    pending_config=""
-    config_changed=true
-fi
 
 mkdir -p "$JOURNAL_DIR"
 systemd-tmpfiles --create --prefix "$JOURNAL_DIR"
@@ -69,7 +69,25 @@ if find "$JOURNAL_DIR" -maxdepth 0 -perm -0002 -print -quit | grep -q .; then
     exit 1
 fi
 
-if [[ "$config_changed" == "true" ]]; then
+install -d -o root -g root -m 0755 "$CONFIG_DIR"
+
+config_changed=false
+if [[ ! -f "$CONFIG_FILE" ]] ||
+    ! cmp -s "$desired_config" "$CONFIG_FILE" ||
+    [[ "$(stat -c '%u:%g:%a' "$CONFIG_FILE")" != "0:0:644" ]]; then
+    # Keep this marker until the restarted service is confirmed active. If this
+    # run is interrupted after installing the drop-in, the next run must not
+    # mistake matching file content for a policy already loaded by journald.
+    install -o root -g root -m 0600 /dev/null "$RESTART_REQUIRED_FILE"
+
+    pending_config="$(mktemp "$CONFIG_DIR/.90-matkassen-retention.conf.XXXXXX")"
+    install -o root -g root -m 0644 "$desired_config" "$pending_config"
+    mv -f "$pending_config" "$CONFIG_FILE"
+    pending_config=""
+    config_changed=true
+fi
+
+if [[ "$config_changed" == "true" || -f "$RESTART_REQUIRED_FILE" ]]; then
     echo "Journald retention policy changed; restarting systemd-journald..."
     systemctl restart systemd-journald
 else
@@ -80,6 +98,8 @@ if ! systemctl is-active --quiet systemd-journald; then
     echo "systemd-journald is not active after configuration." >&2
     exit 1
 fi
+
+rm -f "$RESTART_REQUIRED_FILE"
 
 journalctl --flush
 
@@ -123,6 +143,7 @@ assert_effective_value() {
 assert_effective_value "Storage" "persistent"
 assert_effective_value "SystemMaxUse" "2G"
 assert_effective_value "SystemKeepFree" "5G"
+assert_effective_value "MaxRetentionSec" "0"
 assert_effective_value "Compress" "yes"
 
 canary="matkassen-journal-canary-$(date +%s)-$$"

--- a/scripts/configure-journald.sh
+++ b/scripts/configure-journald.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export LC_ALL=C
+
+readonly CONFIG_DIR="/etc/systemd/journald.conf.d"
+readonly CONFIG_FILE="$CONFIG_DIR/90-matkassen-retention.conf"
+readonly JOURNAL_DIR="/var/log/journal"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+    echo "This script must be run as root (for example with sudo)." >&2
+    exit 1
+fi
+
+for command in awk cmp find grep install journalctl mktemp stat systemctl systemd-analyze systemd-cat systemd-tmpfiles; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "Required command is unavailable: $command" >&2
+        exit 1
+    fi
+done
+
+desired_config="$(mktemp)"
+pending_config=""
+
+cleanup() {
+    rm -f "$desired_config"
+    if [[ -n "$pending_config" ]]; then
+        rm -f "$pending_config"
+    fi
+}
+trap cleanup EXIT
+
+printf '%s\n' \
+    "[Journal]" \
+    "Storage=persistent" \
+    "SystemMaxUse=2G" \
+    "SystemKeepFree=5G" \
+    "Compress=yes" >"$desired_config"
+
+install -d -o root -g root -m 0755 "$CONFIG_DIR"
+
+config_changed=false
+if [[ ! -f "$CONFIG_FILE" ]] ||
+    ! cmp -s "$desired_config" "$CONFIG_FILE" ||
+    [[ "$(stat -c '%u:%g:%a' "$CONFIG_FILE")" != "0:0:644" ]]; then
+    pending_config="$(mktemp "$CONFIG_DIR/.90-matkassen-retention.conf.XXXXXX")"
+    install -o root -g root -m 0644 "$desired_config" "$pending_config"
+    mv -f "$pending_config" "$CONFIG_FILE"
+    pending_config=""
+    config_changed=true
+fi
+
+mkdir -p "$JOURNAL_DIR"
+systemd-tmpfiles --create --prefix "$JOURNAL_DIR"
+
+if [[ ! -d "$JOURNAL_DIR" ]]; then
+    echo "Persistent journal directory was not created: $JOURNAL_DIR" >&2
+    exit 1
+fi
+
+if [[ "$(stat -c '%u' "$JOURNAL_DIR")" != "0" ]]; then
+    echo "Persistent journal directory is not owned by root: $JOURNAL_DIR" >&2
+    exit 1
+fi
+
+if find "$JOURNAL_DIR" -maxdepth 0 -perm -0002 -print -quit | grep -q .; then
+    echo "Persistent journal directory must not be world-writable: $JOURNAL_DIR" >&2
+    exit 1
+fi
+
+if [[ "$config_changed" == "true" ]]; then
+    echo "Journald retention policy changed; restarting systemd-journald..."
+    systemctl restart systemd-journald
+else
+    echo "Journald retention policy is already current; restart not required."
+fi
+
+if ! systemctl is-active --quiet systemd-journald; then
+    echo "systemd-journald is not active after configuration." >&2
+    exit 1
+fi
+
+journalctl --flush
+
+effective_config="$(systemd-analyze cat-config systemd/journald.conf)"
+
+effective_journal_value() {
+    local key="$1"
+
+    awk -F= -v expected_key="$key" '
+        /^[[:space:]]*#/ { next }
+        /^[[:space:]]*\[/ {
+            section = $0
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", section)
+            next
+        }
+        section == "[Journal]" {
+            candidate = $1
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", candidate)
+            if (candidate == expected_key) {
+                value = substr($0, index($0, "=") + 1)
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+            }
+        }
+        END { print value }
+    ' <<<"$effective_config"
+}
+
+assert_effective_value() {
+    local key="$1"
+    local expected="$2"
+    local actual
+
+    actual="$(effective_journal_value "$key")"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "Effective journald setting $key is '$actual'; expected '$expected'." >&2
+        echo "A later systemd drop-in may be overriding $CONFIG_FILE." >&2
+        exit 1
+    fi
+}
+
+assert_effective_value "Storage" "persistent"
+assert_effective_value "SystemMaxUse" "2G"
+assert_effective_value "SystemKeepFree" "5G"
+assert_effective_value "Compress" "yes"
+
+canary="matkassen-journal-canary-$(date +%s)-$$"
+printf '%s\n' "$canary" | systemd-cat --identifier=matkassen-journal-canary --priority=info
+journalctl --sync
+
+if ! journalctl \
+    --file="$JOURNAL_DIR/*/*.journal" \
+    --identifier=matkassen-journal-canary \
+    --since="-1 minute" \
+    --quiet \
+    --no-pager \
+    --output=cat |
+    grep -Fqx "$canary"; then
+    echo "Journal canary could not be read back from persistent storage." >&2
+    exit 1
+fi
+
+echo "Persistent journald storage is configured and verified."

--- a/update.sh
+++ b/update.sh
@@ -154,6 +154,9 @@ echo "Validating nginx configuration..."
 sudo nginx -t
 echo "✅ Nginx configuration updated and validated"
 
+echo "Configuring bounded persistent journal storage..."
+sudo "$APP_DIR/scripts/configure-journald.sh"
+
 # Pull and restart the Docker containers
 echo "Pulling latest Docker images from GitHub Container Registry..."
 cd "$APP_DIR"


### PR DESCRIPTION
## Why

Application logs currently disappear when Docker containers are replaced. Before routing those logs into the host journal, the VPS needs persistent, bounded storage that can be applied safely on both fresh and existing hosts.

This PR prepares that host layer only. It deliberately leaves every Docker logging driver unchanged.

## Design

| Decision | Behavior |
| --- | --- |
| Storage | Persistent journal under `/var/log/journal` |
| Capacity | `SystemMaxUse=2G` with `SystemKeepFree=5G` |
| Retention | Size-bounded, with no global time limit because important host security logs have no other retained copy |
| Deployment safety | Fail before container replacement if installation or verification fails |
| Failure recovery | Keep a boot-scoped restart-required marker until journald is confirmed active, so an interrupted run cannot falsely pass on retry |
| Idempotence | Install atomically and avoid restarting journald when the active policy is already current |

The repository-managed helper applies systemd permissions, verifies the merged configuration to catch later overriding drop-ins, flushes volatile entries, and confirms a unique canary can be read from persistent journal files. Both initial and continuous deployment invoke it immediately before Docker replacement. CI includes the helper in its shell-syntax gate.

The repository now keeps a concise architecture decision containing the durable rationale, system boundaries, deployment invariants, acceptance criteria, security model, and rollback behavior. Temporary implementation sequencing and completed-review history remain in GitHub rather than permanent project documentation.

## Dependency and rollout

The privacy prerequisite in #482 has been merged, deployed, and verified in production. After this PR merges, the journal policy must pass its staging and production host checks before the logging-driver PR can merge.