### PR TITLE
build(deps-dev): bump postcss to 8.5.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "eslint-config-next": "15.5.20",
         "happy-dom": "^20.9.0",
         "jsdom": "^29.1.1",
-        "postcss": "^8.5.15",
+        "postcss": "^8.5.23",
         "postcss-preset-mantine": "^1.18.0",
         "postcss-simple-vars": "^7.0.1",
         "prettier": "3.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,7 +176,7 @@ importers:
         version: 8.60.1(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^5.1.2
-        version: 5.1.2(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))
+        version: 5.1.2(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.23))(tsx@4.21.0))
       '@vitest/ui':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -197,13 +197,13 @@ importers:
         version: 29.1.1
       postcss:
         specifier: '>=8.5.10'
-        version: 8.5.15
+        version: 8.5.23
       postcss-preset-mantine:
         specifier: ^1.18.0
-        version: 1.18.0(postcss@8.5.15)
+        version: 1.18.0(postcss@8.5.23)
       postcss-simple-vars:
         specifier: ^7.0.1
-        version: 7.0.1(postcss@8.5.15)
+        version: 7.0.1(postcss@8.5.23)
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -212,10 +212,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.5
-        version: 7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)
+        version: 7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.23))(tsx@4.21.0)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.23))(tsx@4.21.0))
 
 packages:
 
@@ -3176,8 +3176,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3486,8 +3486,8 @@ packages:
     peerDependencies:
       postcss: '>=8.5.10'
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -5682,7 +5682,7 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@5.1.2(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))':
+  '@vitejs/plugin-react@5.1.2(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.23))(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
@@ -5690,7 +5690,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)
+      vite: 7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.23))(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5703,13 +5703,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))':
+  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.23))(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)
+      vite: 7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.23))(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -5738,7 +5738,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.23))(tsx@4.21.0))
 
   '@vitest/utils@4.1.8':
     dependencies:
@@ -7194,7 +7194,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   nanoid@5.1.11: {}
 
@@ -7234,7 +7234,7 @@ snapshots:
       '@next/env': 15.5.21
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001806
-      postcss: 8.5.15
+      postcss: 8.5.23
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
@@ -7482,42 +7482,42 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-js@4.0.1(postcss@8.5.15):
+  postcss-js@4.0.1(postcss@8.5.23):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.15
+      postcss: 8.5.23
 
-  postcss-mixins@12.1.2(postcss@8.5.15):
+  postcss-mixins@12.1.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.15
-      postcss-js: 4.0.1(postcss@8.5.15)
-      postcss-simple-vars: 7.0.1(postcss@8.5.15)
-      sugarss: 5.0.1(postcss@8.5.15)
+      postcss: 8.5.23
+      postcss-js: 4.0.1(postcss@8.5.23)
+      postcss-simple-vars: 7.0.1(postcss@8.5.23)
+      sugarss: 5.0.1(postcss@8.5.23)
       tinyglobby: 0.2.17
 
-  postcss-nested@7.0.2(postcss@8.5.15):
+  postcss-nested@7.0.2(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.1
 
-  postcss-preset-mantine@1.18.0(postcss@8.5.15):
+  postcss-preset-mantine@1.18.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.15
-      postcss-mixins: 12.1.2(postcss@8.5.15)
-      postcss-nested: 7.0.2(postcss@8.5.15)
+      postcss: 8.5.23
+      postcss-mixins: 12.1.2(postcss@8.5.23)
+      postcss-nested: 7.0.2(postcss@8.5.23)
 
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-simple-vars@7.0.1(postcss@8.5.15):
+  postcss-simple-vars@7.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.23
 
-  postcss@8.5.15:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -8009,9 +8009,9 @@ snapshots:
 
   stylis@4.3.6: {}
 
-  sugarss@5.0.1(postcss@8.5.15):
+  sugarss@5.0.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.23
 
   supports-color@7.2.0:
     dependencies:
@@ -8243,25 +8243,25 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0):
+  vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.23))(tsx@4.21.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.23
       rollup: 4.59.0
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.13.3
       fsevents: 2.3.3
       jiti: 1.21.7
-      sugarss: 5.0.1(postcss@8.5.15)
+      sugarss: 5.0.1(postcss@8.5.23)
       tsx: 4.21.0
 
-  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/ui@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.23))(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0))
+      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.23))(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -8278,7 +8278,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.15))(tsx@4.21.0)
+      vite: 7.3.5(@types/node@24.13.3)(jiti@1.21.7)(sugarss@5.0.1(postcss@8.5.23))(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
PostCSS 8.5.23 completes the source-map loading hardening introduced in 8.5.18. The existing Dependabot update in #485 stops at 8.5.18 even though the follow-up security release was already available.

Update directly to 8.5.23 so the application receives the full set of current patch fixes in one change. The lockfile also refreshes PostCSS’s expected `nanoid` 3.x dependency.

Supersedes #485.