### PR TITLE
Route backup scheduler logs by severity

### DIFF
--- a/Dockerfile.db-backup
+++ b/Dockerfile.db-backup
@@ -47,4 +47,5 @@ RUN chmod +x /usr/local/bin/backup-db.sh && \
 # Switch to non-root user
 USER backupuser
 
-CMD ["supercronic", "/etc/supercronic/crontab"]
+# Keep journald priorities aligned with Supercronic's structured log levels.
+CMD ["supercronic", "-split-logs", "/etc/supercronic/crontab"]


### PR DESCRIPTION
## Why

Supercronic writes every record to stderr by default, even when its structured level is info. Docker maps stderr to the journald error priority without parsing that embedded level, so benign backup-scheduler startup messages pollute error-only operational checks.

## Design

Start Supercronic with its level-based log routing enabled. Debug and info records now use stdout, while warnings and errors remain on stderr, allowing Docker and journald to assign meaningful priorities.

Supercronic continues to wrap job output with schedule and command metadata. A command stderr line is still represented as an informational record with `channel=stderr`, but a non-zero job exit also emits a separate error-level record on stderr. This preserves the error signal and the existing backup failure notification while keeping structured context.

The change is confined to the backup image startup command. It does not alter the backup schedule, backup script, database access, retention, credentials, or application container.