### PR TITLE
Remove duplicate release verification

### DIFF
--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -8,35 +8,9 @@ permissions:
     contents: read
 
 jobs:
-    verify-release:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout release commit
-              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-            - name: Setup pnpm
-              uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-            - name: Setup Node.js
-              uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-              with:
-                  node-version: 24
-                  cache: "pnpm"
-
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
-
-            - name: Validate release commit
-              run: pnpm run validate
-
-            - name: Test release commit
-              env:
-                  NODE_ENV: test
-                  TZ: Europe/Stockholm
-              run: pnpm test
-
+    # Pull requests must pass the main branch's required CI checks before merge.
+    # CD starts by publishing immutable images for that protected merge commit.
     publish-images:
-        needs: verify-release
         runs-on: ubuntu-latest
         permissions:
             contents: read


### PR DESCRIPTION
## Why

Pull requests already have to pass the required build, validation, test, Docker and repository checks before they can merge. The main ruleset now also requires each pull request to be tested against the latest main branch.

Running validation and the full test suite again after merge therefore repeats the same assurance and delays image publication by roughly five minutes.

## Approach

Continuous deployment now starts by publishing immutable images for the protected merge commit. Staging and production deployment, migration, container identity, restart-loop and public verification safeguards remain unchanged.

This keeps the responsibility boundary simple: pull-request CI proves the change before merge, while continuous deployment builds, deploys and verifies the resulting release.