### PR TITLE
Reduce backup health-check startup delay

### DIFF
--- a/docker-compose.backup.yml
+++ b/docker-compose.backup.yml
@@ -64,6 +64,8 @@ services:
         healthcheck:
             test: ["CMD", "pgrep", "supercronic"]
             interval: 60s
+            start_period: 10s
+            start_interval: 2s
             timeout: 10s
             retries: 3
         logging:


### PR DESCRIPTION
Production deployment waits roughly 60 seconds for the backup scheduler even though Supercronic starts in under a second. Docker delays the first ordinary health probe by the configured 60-second interval, so the deployment is waiting on probe scheduling rather than service readiness.

Use a short startup period with two-second startup probes while preserving the existing 60-second steady-state interval. A successful startup probe marks the service healthy immediately, removing almost a minute from production deployment without weakening ongoing monitoring or changing the backup process.