### PR TITLE
Warn only for parcel count increases above threshold

### DIFF
--- a/__tests__/components/ParcelManagementForm.test.tsx
+++ b/__tests__/components/ParcelManagementForm.test.tsx
@@ -1,0 +1,230 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import type { FoodParcel, FoodParcels } from "@/app/[locale]/households/enroll/types";
+import { ParcelManagementForm } from "@/components/ParcelManagementForm/ParcelManagementForm";
+
+const { mockRouterPush, mockNotificationsShow } = vi.hoisted(() => ({
+    mockRouterPush: vi.fn(),
+    mockNotificationsShow: vi.fn(),
+}));
+
+vi.mock("@/app/i18n/navigation", () => ({
+    useRouter: () => ({ push: mockRouterPush }),
+}));
+
+vi.mock("@mantine/notifications", () => ({
+    notifications: { show: mockNotificationsShow },
+}));
+
+vi.mock("next-intl", () => ({
+    useTranslations: (namespace: string) => (key: string, params?: Record<string, string>) => {
+        if (namespace === "parcelWarning" && key === "modal.message") {
+            return `Projected count: ${params?.count}; threshold: ${params?.threshold}`;
+        }
+
+        const translations: Record<string, string> = {
+            "parcelWarning.modal.title": "High Parcel Count Warning",
+            "parcelWarning.modal.explanation": "Warning explanation",
+            "parcelWarning.modal.acknowledgmentLabel": "Acknowledge warning",
+            "parcelWarning.modal.confirmButton": "Continue Adding Parcels",
+            "parcelWarning.modal.cancelButton": "Cancel",
+            "parcelManagement.actions.saveParcels": "Save Parcels",
+        };
+
+        return translations[`${namespace}.${key}`] ?? key;
+    },
+}));
+
+vi.mock("@/app/[locale]/households/enroll/components/FoodParcelsForm", () => ({
+    default: ({
+        data,
+        updateData,
+    }: {
+        data: FoodParcels;
+        updateData: (data: FoodParcels) => void;
+    }) => (
+        <div>
+            <span>Form count: {data.parcels.length}</span>
+            <button
+                type="button"
+                onClick={() =>
+                    updateData({
+                        ...data,
+                        parcels: [...data.parcels, createParcel(data.parcels.length + 1)],
+                    })
+                }
+            >
+                Add Parcel
+            </button>
+            <button
+                type="button"
+                onClick={() => updateData({ ...data, parcels: data.parcels.slice(0, -1) })}
+            >
+                Remove Parcel
+            </button>
+        </div>
+    ),
+}));
+
+vi.mock("@/components/ParcelManagementForm/ParcelWarningModal", () => ({
+    ParcelWarningModal: ({
+        opened,
+        onConfirm,
+        projectedParcelCount,
+        threshold,
+    }: {
+        opened: boolean;
+        onConfirm: () => void;
+        projectedParcelCount: number;
+        threshold: number;
+    }) =>
+        opened ? (
+            <div>
+                <h2>High Parcel Count Warning</h2>
+                <p>{`Projected count: ${projectedParcelCount}; threshold: ${threshold}`}</p>
+                <button type="button" onClick={onConfirm}>
+                    Continue Adding Parcels
+                </button>
+            </div>
+        ) : null,
+}));
+
+function createParcel(index: number): FoodParcel {
+    const pickupEarliestTime = new Date(2027, 0, index + 1, 10, 0);
+    return {
+        id: `parcel-${index}`,
+        pickupLocationId: "location-1",
+        pickupDate: pickupEarliestTime,
+        pickupEarliestTime,
+        pickupLatestTime: new Date(2027, 0, index + 1, 11, 0),
+    };
+}
+
+function createInitialData(count: number): FoodParcels {
+    return {
+        pickupLocationId: "location-1",
+        parcels: Array.from({ length: count }, (_, index) => createParcel(index)),
+    };
+}
+
+function renderForm({
+    currentCount,
+    threshold,
+    initialCount = currentCount,
+}: {
+    currentCount: number;
+    threshold: number | null;
+    initialCount?: number;
+}) {
+    const onSubmit = vi.fn(async (_data: FoodParcels) => ({
+        success: true as const,
+        data: undefined,
+    }));
+
+    render(
+        <MantineProvider>
+            <ParcelManagementForm
+                householdName="Test Household"
+                initialData={createInitialData(initialCount)}
+                onSubmit={onSubmit}
+                warningData={{
+                    parcelCount: currentCount,
+                    threshold,
+                }}
+            />
+        </MantineProvider>,
+    );
+
+    return { onSubmit };
+}
+
+describe("ParcelManagementForm threshold warning", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("submits a reduction without warning even when the projected count remains above the threshold", async () => {
+        const { onSubmit } = renderForm({ currentCount: 12, threshold: 10 });
+
+        fireEvent.click(screen.getByRole("button", { name: "Remove Parcel" }));
+        fireEvent.click(screen.getByRole("button", { name: "Save Parcels" }));
+
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+        expect(screen.queryByText("High Parcel Count Warning")).toBeNull();
+    });
+
+    it("warns when the change crosses the threshold", () => {
+        const { onSubmit } = renderForm({ currentCount: 10, threshold: 10 });
+
+        fireEvent.click(screen.getByRole("button", { name: "Add Parcel" }));
+        fireEvent.click(screen.getByRole("button", { name: "Save Parcels" }));
+
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(screen.getByText("High Parcel Count Warning")).not.toBeNull();
+        expect(screen.getByText("Projected count: 11; threshold: 10")).not.toBeNull();
+    });
+
+    it("warns when an already over-threshold household receives another parcel", () => {
+        const { onSubmit } = renderForm({ currentCount: 12, threshold: 10 });
+
+        fireEvent.click(screen.getByRole("button", { name: "Add Parcel" }));
+        fireEvent.click(screen.getByRole("button", { name: "Save Parcels" }));
+
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(screen.getByText("Projected count: 13; threshold: 10")).not.toBeNull();
+    });
+
+    it("submits without warning when the resulting count equals the threshold", async () => {
+        const { onSubmit } = renderForm({ currentCount: 9, threshold: 10 });
+
+        fireEvent.click(screen.getByRole("button", { name: "Add Parcel" }));
+        fireEvent.click(screen.getByRole("button", { name: "Save Parcels" }));
+
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+        expect(screen.queryByText("High Parcel Count Warning")).toBeNull();
+    });
+
+    it("submits an unchanged over-threshold count without warning", async () => {
+        const { onSubmit } = renderForm({ currentCount: 12, threshold: 10 });
+
+        fireEvent.click(screen.getByRole("button", { name: "Save Parcels" }));
+
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+        expect(screen.queryByText("High Parcel Count Warning")).toBeNull();
+    });
+
+    it("does not warn when the threshold setting is disabled", async () => {
+        const { onSubmit } = renderForm({ currentCount: 10, threshold: null });
+
+        fireEvent.click(screen.getByRole("button", { name: "Add Parcel" }));
+        fireEvent.click(screen.getByRole("button", { name: "Save Parcels" }));
+
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+        expect(screen.queryByText("High Parcel Count Warning")).toBeNull();
+    });
+
+    it("uses the form's net change with the current server count", () => {
+        const { onSubmit } = renderForm({ currentCount: 10, initialCount: 9, threshold: 10 });
+
+        fireEvent.click(screen.getByRole("button", { name: "Add Parcel" }));
+        fireEvent.click(screen.getByRole("button", { name: "Save Parcels" }));
+
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(screen.getByText("Projected count: 11; threshold: 10")).not.toBeNull();
+    });
+
+    it("requires a new acknowledgment if the projected count changes", () => {
+        const { onSubmit } = renderForm({ currentCount: 10, threshold: 10 });
+
+        fireEvent.click(screen.getByRole("button", { name: "Add Parcel" }));
+        fireEvent.click(screen.getByRole("button", { name: "Save Parcels" }));
+        fireEvent.click(screen.getByRole("button", { name: "Continue Adding Parcels" }));
+        fireEvent.click(screen.getByRole("button", { name: "Add Parcel" }));
+        fireEvent.click(screen.getByRole("button", { name: "Save Parcels" }));
+
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(screen.getByText("Projected count: 12; threshold: 10")).not.toBeNull();
+    });
+});

--- a/app/[locale]/households/[id]/parcels/ParcelManagementClient.tsx
+++ b/app/[locale]/households/[id]/parcels/ParcelManagementClient.tsx
@@ -9,7 +9,6 @@ interface ParcelManagementClientProps {
     householdName: string;
     initialData?: FoodParcels;
     warningData?: {
-        shouldWarn: boolean;
         parcelCount: number;
         threshold: number | null;
     };

--- a/components/ParcelManagementForm/ParcelManagementForm.tsx
+++ b/components/ParcelManagementForm/ParcelManagementForm.tsx
@@ -18,7 +18,6 @@ interface ParcelManagementFormProps {
     isLoading?: boolean;
     loadError?: string | null;
     warningData?: {
-        shouldWarn: boolean;
         parcelCount: number;
         threshold: number | null;
     };
@@ -47,7 +46,7 @@ export function ParcelManagementForm({
     >([]);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [showWarningModal, setShowWarningModal] = useState(false);
-    const [warningAcknowledged, setWarningAcknowledged] = useState(false);
+    const [acknowledgedParcelCount, setAcknowledgedParcelCount] = useState<number | null>(null);
 
     // Initialize form data with defaults
     const [formData, setFormData] = useState<FoodParcels>(
@@ -56,6 +55,16 @@ export function ParcelManagementForm({
             parcels: [],
         },
     );
+
+    const initialParcelCount = initialData?.parcels.length ?? 0;
+    const projectedParcelCount = warningData
+        ? warningData.parcelCount + formData.parcels.length - initialParcelCount
+        : formData.parcels.length;
+    const requiresWarningAcknowledgment =
+        warningData?.threshold !== null &&
+        warningData?.threshold !== undefined &&
+        projectedParcelCount > warningData.threshold &&
+        projectedParcelCount > warningData.parcelCount;
 
     // Handle form data updates
     const updateFormData = useCallback((data: FoodParcels) => {
@@ -66,9 +75,9 @@ export function ParcelManagementForm({
 
     // Handle warning modal confirmation
     const handleWarningConfirm = useCallback(() => {
-        setWarningAcknowledged(true);
+        setAcknowledgedParcelCount(projectedParcelCount);
         setShowWarningModal(false);
-    }, []);
+    }, [projectedParcelCount]);
 
     // Handle form submission
     const handleSubmit = async () => {
@@ -88,8 +97,8 @@ export function ParcelManagementForm({
             return;
         }
 
-        // Check if we need to show warning modal (only if not already acknowledged this session)
-        if (warningData?.shouldWarn && !warningAcknowledged) {
+        // Only require confirmation when this change increases the count above the threshold.
+        if (requiresWarningAcknowledgment && acknowledgedParcelCount !== projectedParcelCount) {
             setShowWarningModal(true);
             return;
         }
@@ -206,14 +215,13 @@ export function ParcelManagementForm({
     return (
         <Container size="lg" py="md">
             {/* Warning Modal */}
-            {warningData?.shouldWarn && warningData.threshold !== null && (
+            {requiresWarningAcknowledgment && warningData?.threshold !== null && (
                 <ParcelWarningModal
                     opened={showWarningModal}
                     onClose={() => setShowWarningModal(false)}
                     onConfirm={handleWarningConfirm}
-                    parcelCount={warningData.parcelCount}
+                    projectedParcelCount={projectedParcelCount}
                     threshold={warningData.threshold}
-                    householdName={householdName}
                 />
             )}
 

--- a/components/ParcelManagementForm/ParcelWarningModal.tsx
+++ b/components/ParcelManagementForm/ParcelWarningModal.tsx
@@ -9,18 +9,16 @@ interface ParcelWarningModalProps {
     opened: boolean;
     onClose: () => void;
     onConfirm: () => void;
-    parcelCount: number;
+    projectedParcelCount: number;
     threshold: number;
-    householdName: string;
 }
 
 export function ParcelWarningModal({
     opened,
     onClose,
     onConfirm,
-    parcelCount,
+    projectedParcelCount,
     threshold,
-    householdName,
 }: ParcelWarningModalProps) {
     const t = useTranslations("parcelWarning");
     const [acknowledged, setAcknowledged] = useState(false);
@@ -48,8 +46,7 @@ export function ParcelWarningModal({
                 <Alert icon={<IconAlertTriangle />} color="orange" variant="light">
                     <Text size="sm">
                         {t("modal.message", {
-                            householdName,
-                            count: String(parcelCount),
+                            count: String(projectedParcelCount),
                             threshold: String(threshold),
                         })}
                     </Text>

--- a/messages/en.json
+++ b/messages/en.json
@@ -1549,8 +1549,8 @@
     "parcelWarning": {
         "modal": {
             "title": "High Parcel Count Warning",
-            "message": "{householdName} has received {count} food parcels (threshold: {threshold}).",
-            "explanation": "This household has exceeded the parcel limit threshold. Please verify that they have received appropriate support and assistance. You can still add more parcels, but this requires acknowledgment.",
+            "message": "This change means the household will have {count} registered food parcels (warning threshold: {threshold}).",
+            "explanation": "The household will exceed the food parcel warning threshold. Please verify that they have received appropriate support and assistance before saving this change.",
             "acknowledgmentLabel": "I acknowledge this household may need additional review or support",
             "confirmButton": "Continue Adding Parcels",
             "cancelButton": "Cancel"

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -1549,8 +1549,8 @@
     "parcelWarning": {
         "modal": {
             "title": "Varning för högt antal matkassar",
-            "message": "{householdName} har mottagit {count} matkassar (gräns: {threshold}).",
-            "explanation": "Detta hushåll har överskridit varningsgränsen för matkassar. Vänligen verifiera att de har fått lämpligt stöd och hjälp. Du kan fortfarande lägga till fler kassar, men detta kräver bekräftelse.",
+            "message": "Ändringen innebär att hushållet kommer att ha {count} registrerade matkassar (varningsgräns: {threshold}).",
+            "explanation": "Hushållet kommer att överskrida varningsgränsen för matkassar. Kontrollera att de har fått lämpligt stöd och hjälp innan du sparar ändringen.",
             "acknowledgmentLabel": "Jag bekräftar att detta hushåll kan behöva ytterligare genomgång eller stöd",
             "confirmButton": "Fortsätt lägga till matkassar",
             "cancelButton": "Avbryt"


### PR DESCRIPTION
## Why

The parcel warning was based only on the household count when the management page loaded. This made parcel removals confusing because staff had to confirm that they were adding parcels, while a household moving from exactly the threshold to above it received no warning at all.

## Behavior

| Change | Confirmation |
| --- | --- |
| Count decreases but remains above the threshold | No |
| Count stays unchanged above the threshold | No |
| Count increases up to the threshold | No |
| Count crosses the threshold | Yes |
| Count increases while already above the threshold | Yes |

The management flow now calculates the projected post-save count from the current server count and the form net change. An acknowledgment applies to that projected count, so adding more parcels after acknowledging requires a fresh confirmation.

The persistent household-detail warning remains unchanged and non-blocking. The confirmation now describes the actual outcome: “Ändringen innebär att hushållet kommer att ha {count} registrerade matkassar (varningsgräns: {threshold}).”